### PR TITLE
AF-3632 Properly detect private companion props/state classes.

### DIFF
--- a/over_react_codemod/updaters.py
+++ b/over_react_codemod/updaters.py
@@ -35,12 +35,15 @@ def add_public_props_or_state_class_boilerplate(lines, matches, prev_lines, next
         options = [
             'abstract class %s ' % class_name,
             'abstract class %s<' % class_name,
+            'abstract class _%s ' % class_name,
+            'abstract class _%s<' % class_name,
             'class %s ' % class_name,
             'class %s<' % class_name,
+            'class _%s ' % class_name,
+            'class _%s<' % class_name,
         ]
         for option in options:
             if line.startswith(option):
-                # if re.match(r'(abstract\s+)?class\s+' + class_name + r'[\s<]', line):
                 # Accompanying class already added.
                 return None
 

--- a/tests/suggestors/test_props_and_state_classes.py
+++ b/tests/suggestors/test_props_and_state_classes.py
@@ -270,6 +270,19 @@ class _$FooProps extends UiProps {
 
 class FooProps extends _$FooProps with _$FooPropsAccessorsMixin {}''')
         self.assert_no_patches_suggested()
+    
+    def test_private_already_added(self):
+        self.suggest('''library foo;
+
+@Props()
+class _$FooProps extends UiProps {
+    String prop1;
+
+    bool prop2;
+}
+
+class _FooProps extends _$FooProps with _$FooPropsAccessorsMixin {}''')
+        self.assert_no_patches_suggested()
 
 
 class TestPropsAndStateClassesRenameSuggestor(CodemodPatchTestCase):


### PR DESCRIPTION
## Problem
For private props/state classes, the accompanying class suggestor was not properly detecting that it had already been added and as a result was not idempotent.

## Solution
Check for the `_`-prefixed variants when deciding if the work has already been done.

## Testing
- [ ] CI passes, test added

## Code Review
@corwinsheahan-wf @sebastianmalysa-wf 