### PR TITLE
AF-3863 Release over_react_codemod 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial release!

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Over React Codemods
 
+[![Pub](https://img.shields.io/pub/v/over_react_codemod.svg)](https://pub.dartlang.org/packages/over_react_codemod)
+[![Build Status](https://travis-ci.org/Workiva/over_react_codemod.svg?branch=master)](https://travis-ci.org/Workiva/over_react_codemod)
+
 > **Built with [dart_codemod][dart_codemod].**
 
 Codemods to help consumers of [over_react][over_react] automate the migration of

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_codemod
-version: 0.0.0
+version: 1.0.0
 homepage: https://github.com/Workiva/over_react_codemod
 
 description: >


### PR DESCRIPTION

Pull Requests included in release:
* [Add migrater](https://github.com/Workiva/over_react_codemod/pull/1)
* [AF-1928 Add suggestors for PropsMeta changes](https://github.com/Workiva/over_react_codemod/pull/2)
* [AF-2152: add more tests to cover additions made in AF-1928](https://github.com/Workiva/over_react_codemod/pull/4)
* [AF-1917: Make over_react_codemod script idempotent](https://github.com/Workiva/over_react_codemod/pull/5)
* [AF-3102 AF-2797 AF-1943 Update codemod to match final transition boilerplate](https://github.com/Workiva/over_react_codemod/pull/6)
* [AF-3591 Add OSS license texts](https://github.com/Workiva/over_react_codemod/pull/7)
* [AF-3592 Add OSS license header to all source files](https://github.com/Workiva/over_react_codemod/pull/8)
* [AF-3101 Add support for "check" mode (`--check|-c`)](https://github.com/Workiva/over_react_codemod/pull/9)
* [AF-3632 Properly detect private companion props/state classes.](https://github.com/Workiva/over_react_codemod/pull/10)
* [AF-3668 Better compatibility with dartfmt](https://github.com/Workiva/over_react_codemod/pull/11)
* [AF-3838 Replace python implementation with dart using dart_codemod](https://github.com/Workiva/over_react_codemod/pull/12)
* [AF-3864 Prep for the first release](https://github.com/Workiva/over_react_codemod/pull/13)
* [AF-3911 Finish the Dart 2 Upgrade codemod](https://github.com/Workiva/over_react_codemod/pull/14)


Requested by: @evan.weible

Diff Between Last Tag and Proposed Release: N/A
Diff Between Last Tag and New Tag: N/A

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6153708125028352/logs/)