### PR TITLE
AF-3985 Fix a bug with the UiFactoryIgnoreCommentRemover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.1
+
+- Fix a bug with removing the `// ignore: undefined_identifier` comment from
+  UI Factories when running `over_react_codemod:dart2_upgrade` without the
+  `--backwards-compat` flag.
+
 ## 1.0.0
 
 - Initial release!

--- a/lib/src/dart2_suggestors/ui_factory_initializer.dart
+++ b/lib/src/dart2_suggestors/ui_factory_initializer.dart
@@ -46,7 +46,6 @@ class UiFactoryInitializer extends RecursiveAstVisitor
     // There can only be one UiFactory per file.
     final factoryNode = node?.variables?.variables?.first;
     if (factoryNode == null) {
-      // throw new
       return;
     }
 

--- a/test/dart2_suggestors/ui_factory_ignore_comment_remover.suggestor_test
+++ b/test/dart2_suggestors/ui_factory_ignore_comment_remover.suggestor_test
@@ -33,7 +33,17 @@ UiFactory Foo = _$Foo;
 @Factory()
 UiFactory Foo =
   // ignore: undefined_identifier
-  $Foo;
+  _$Foo;
 <<<
 @Factory()
-UiFactory Foo = _$Foo;
+UiFactory Foo =
+  _$Foo;
+
+
+>>> ignore comment on line between annotation and factory (patches 1)
+@Factory()
+// ignore: undefined_identifier
+UiFactory<_CustomColorInputProps> _CustomColorInput = _$_CustomColorInput;
+<<<
+@Factory()
+UiFactory<_CustomColorInputProps> _CustomColorInput = _$_CustomColorInput;

--- a/test/util.dart
+++ b/test/util.dart
@@ -98,6 +98,10 @@ void _testSuggestor(Map<String, Suggestor> suggestorMap, String testFilePath) {
       test(description, () {
         final sourceFile = SourceFile.fromString(input, url: path);
         final patches = suggestor.generatePatches(sourceFile);
+        final emptyPatches = patches.where((p) => p.isNoop);
+        expect(emptyPatches, isEmpty,
+            reason: 'Suggested ${emptyPatches.length} empty patch(es).');
+
         if (expectedNumPatches != null &&
             patches.length != expectedNumPatches) {
           fail('Incorrect number of patches generated '


### PR DESCRIPTION
## Description
- No longer emits an empty patch when the ignore comment precedes the entire factory declaration
- testSuggestorsDir() util now also asserts that no empty patches were emitted

## Testing
- [ ] CI passes (test added)

## Code Review
@corwinsheahan-wf @sebastianmalysa-wf @georgelesica-wf @maxwellpeterson-wf 