### PR TITLE
CPLAT-4307 Add two comment removing suggestors to dart2_upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [1.1.0](https://github.com/Workiva/over_react_codemod/compare/1.0.2...1.1.0)
+
+- Two additional changes are now made by the `dart2_upgrade` codemod when
+  running without the `--backwards-compat` flag:
+
+  - `// orcm_ignore` comments are removed
+  - `// ignore: uri_has_not_been_generated` comments that precede a
+    `.over_react.g.dart` part directive are removed
+
 ## [1.0.2](https://github.com/Workiva/over_react_codemod/compare/1.0.1...1.0.2)
 
 - Provide additional output from the `dart2_upgrade` codemod in the following

--- a/lib/src/dart2_suggestors/generated_part_directive_adder.dart
+++ b/lib/src/dart2_suggestors/generated_part_directive_adder.dart
@@ -23,12 +23,12 @@ import 'needs_over_react_library_collector.dart';
 /// Suggestor that uses the set of libraries that need the over_react generated
 /// part directive (collected via [NeedsOverReactLibraryCollector]) and adds the
 /// directive to every library that needs it and does not already have it.
-class OverReactGeneratedPartDirectiveAdder extends SimpleAstVisitor
+class GeneratedPartDirectiveAdder extends SimpleAstVisitor
     with AstVisitingSuggestorMixin
     implements Suggestor {
   final NeedsOverReactLibraryCollector _libraryCollector;
 
-  OverReactGeneratedPartDirectiveAdder(this._libraryCollector);
+  GeneratedPartDirectiveAdder(this._libraryCollector);
 
   @override
   visitCompilationUnit(CompilationUnit node) {

--- a/lib/src/dart2_suggestors/generated_part_directive_ignore_remover.dart
+++ b/lib/src/dart2_suggestors/generated_part_directive_ignore_remover.dart
@@ -1,0 +1,40 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:analyzer/analyzer.dart';
+import 'package:codemod/codemod.dart';
+
+import '../constants.dart';
+
+/// Suggestor that removes the `// ignore: ...` comment attached to each
+/// over_react generated part directive.
+class GeneratedPartDirectiveIgnoreRemover extends RecursiveAstVisitor
+    with AstVisitingSuggestorMixin
+    implements Suggestor {
+  final _ignoreComment = RegExp(r'[\n]?[ ]*//[ ]*ignore:.*');
+
+  @override
+  visitPartDirective(PartDirective node) {
+    if (!node.uri.stringValue.endsWith(overReactGeneratedExtension)) {
+      return;
+    }
+
+    final prevLineEnd = node.offset - 1;
+    final prevLineStart = sourceFile.getOffset(sourceFile.getLine(prevLineEnd));
+    final prevLine = sourceFile.getText(prevLineStart, prevLineEnd);
+    if (_ignoreComment.hasMatch(prevLine)) {
+      yieldPatch(prevLineStart, prevLineEnd + 1, '');
+    }
+  }
+}

--- a/lib/src/dart2_suggestors/needs_over_react_library_collector.dart
+++ b/lib/src/dart2_suggestors/needs_over_react_library_collector.dart
@@ -17,13 +17,13 @@ import 'package:codemod/codemod.dart';
 import 'package:path/path.dart' as p;
 
 import '../util.dart';
-import 'over_react_generated_part_directive_adder.dart';
+import 'generated_part_directive_adder.dart';
 
 /// Suggestor that collects the set of libraries that need an over_react
 /// generated part file.
 ///
 /// This suggestor is intended to be used in conjunction with the
-/// [OverReactGeneratedPartDirectiveAdder]; this collector should run first
+/// [GeneratedPartDirectiveAdder]; this collector should run first
 /// across the entire set of Dart files in a project and then the directive
 /// adder should run second (using [runInteractiveCodemodSequence]).
 class NeedsOverReactLibraryCollector extends RecursiveAstVisitor

--- a/lib/src/dart2_suggestors/orcm_ignore_remover.dart
+++ b/lib/src/dart2_suggestors/orcm_ignore_remover.dart
@@ -1,0 +1,35 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:codemod/codemod.dart';
+import 'package:source_span/source_span.dart';
+
+/// Suggestor that removes every instance of a `// orcm_ignore` comment.
+class OrcmIgnoreRemover implements Suggestor {
+  final _orcmIgnore = RegExp(r'[\n]?[ ]*//[ ]*orcm_ignore[ ]*');
+
+  @override
+  Iterable<Patch> generatePatches(SourceFile sourceFile) sync* {
+    for (final match in _orcmIgnore.allMatches(sourceFile.getText(0))) {
+      yield Patch(
+        sourceFile,
+        sourceFile.span(match.start, match.end),
+        '',
+      );
+    }
+  }
+
+  @override
+  bool shouldSkip(_) => false;
+}

--- a/lib/src/executables/dart2_upgrade.dart
+++ b/lib/src/executables/dart2_upgrade.dart
@@ -22,7 +22,9 @@ import '../dart2_suggestors/component_default_props_migrator.dart';
 import '../dart2_suggestors/dollar_prop_keys_migrator.dart';
 import '../dart2_suggestors/dollar_props_migrator.dart';
 import '../dart2_suggestors/needs_over_react_library_collector.dart';
-import '../dart2_suggestors/over_react_generated_part_directive_adder.dart';
+import '../dart2_suggestors/orcm_ignore_remover.dart';
+import '../dart2_suggestors/generated_part_directive_adder.dart';
+import '../dart2_suggestors/generated_part_directive_ignore_remover.dart';
 import '../dart2_suggestors/props_and_state_classes_renamer.dart';
 import '../dart2_suggestors/props_and_state_companion_class_adder.dart';
 import '../dart2_suggestors/props_and_state_companion_class_remover.dart';
@@ -98,11 +100,13 @@ void main(List<String> args) {
           UiFactoryIgnoreCommentRemover(),
           PropsAndStateMixinMetaRemover(),
           PropsAndStateMixinUsageConsolidator(),
+          GeneratedPartDirectiveIgnoreRemover(),
+          OrcmIgnoreRemover(),
         ]);
 
   final phaseThreeSuggestors = <Suggestor>[
     Ignoreable(
-      OverReactGeneratedPartDirectiveAdder(
+      GeneratedPartDirectiveAdder(
         needsOverReactLibraryCollector,
       ),
     ),

--- a/test/dart2_suggestors/generated_part_directive_adder.suggestor_test
+++ b/test/dart2_suggestors/generated_part_directive_adder.suggestor_test
@@ -1,4 +1,4 @@
-OverReactGeneratedPartDirectiveAdder
+GeneratedPartDirectiveAdder
 # This test requires a small amount of setup, as the suggestor depends on the
 # NeedsOverReactLibraryCollector to determine which library names and paths
 # need the over_react generated part directive.

--- a/test/dart2_suggestors/generated_part_directive_ignore_remover.suggestor_test
+++ b/test/dart2_suggestors/generated_part_directive_ignore_remover.suggestor_test
@@ -1,0 +1,26 @@
+GeneratedPartDirectiveIgnoreRemover
+>>> empty file (patches 0)
+<<<
+
+
+>>> no matches (patches 0)
+library foo;
+var a = 'b';
+class Random {}
+<<<
+library foo;
+var a = 'b';
+class Random {}
+
+
+>>> removes comment (patches 1)
+library foo;
+
+import 'bar.dart';
+// ignore: uri_has_not_been_generated
+part 'foo.over_react.g.dart';
+<<<
+library foo;
+
+import 'bar.dart';
+part 'foo.over_react.g.dart';

--- a/test/dart2_suggestors/orcm_ignore_remover.suggestor_test
+++ b/test/dart2_suggestors/orcm_ignore_remover.suggestor_test
@@ -1,0 +1,61 @@
+OrcmIgnoreRemover
+>>> empty file (patches 0)
+<<<
+
+
+>>> no matches (patches 0)
+library foo;
+var a = 'b';
+class Random {}
+<<<
+library foo;
+var a = 'b';
+class Random {}
+
+
+>>> previous line (patches 1)
+library foo;
+
+// orcm_ignore
+var foo;
+<<<
+library foo;
+
+var foo;
+
+
+>>> same line (patches 1)
+library foo;
+
+var foo; // orcm_ignore
+<<<
+library foo;
+
+var foo;
+
+
+>>> whitespace (patches 1)
+library foo;
+
+  // orcm_ignore  
+var foo;
+<<<
+library foo;
+
+var foo;
+
+
+>>> multiple removals (patches 2)
+library foo;
+
+// orcm_ignore
+var foo;
+
+// orcm_ignore
+var bar;
+<<<
+library foo;
+
+var foo;
+
+var bar;

--- a/test/suggestors_test.dart
+++ b/test/suggestors_test.dart
@@ -21,7 +21,9 @@ import 'package:over_react_codemod/src/dart2_suggestors/component_default_props_
 import 'package:over_react_codemod/src/dart2_suggestors/dollar_prop_keys_migrator.dart';
 import 'package:over_react_codemod/src/dart2_suggestors/dollar_props_migrator.dart';
 import 'package:over_react_codemod/src/dart2_suggestors/needs_over_react_library_collector.dart';
-import 'package:over_react_codemod/src/dart2_suggestors/over_react_generated_part_directive_adder.dart';
+import 'package:over_react_codemod/src/dart2_suggestors/generated_part_directive_adder.dart';
+import 'package:over_react_codemod/src/dart2_suggestors/generated_part_directive_ignore_remover.dart';
+import 'package:over_react_codemod/src/dart2_suggestors/orcm_ignore_remover.dart';
 import 'package:over_react_codemod/src/dart2_suggestors/props_and_state_classes_renamer.dart';
 import 'package:over_react_codemod/src/dart2_suggestors/props_and_state_companion_class_adder.dart';
 import 'package:over_react_codemod/src/dart2_suggestors/props_and_state_companion_class_remover.dart';
@@ -46,8 +48,8 @@ void main() {
     final mockCollector = MockCollector();
     when(mockCollector.byName).thenReturn(['match']);
     when(mockCollector.byPath).thenReturn([p.canonicalize('match.dart')]);
-    final overReactGeneratedPartDirectiveAdder =
-        Ignoreable(OverReactGeneratedPartDirectiveAdder(mockCollector));
+    final generatedPartDirectiveAdder =
+        Ignoreable(GeneratedPartDirectiveAdder(mockCollector));
 
     final suggestorMap = {
       'ComponentDefaultPropsMigrator': Ignoreable(
@@ -59,8 +61,10 @@ void main() {
       'DollarPropsMigrator': Ignoreable(
         DollarPropsMigrator(),
       ),
-      'OverReactGeneratedPartDirectiveAdder':
-          overReactGeneratedPartDirectiveAdder,
+      'GeneratedPartDirectiveAdder': generatedPartDirectiveAdder,
+      'GeneratedPartDirectiveIgnoreRemover':
+          GeneratedPartDirectiveIgnoreRemover(),
+      'OrcmIgnoreRemover': OrcmIgnoreRemover(),
       'PropsAndStateClassesRenamer': Ignoreable(
         PropsAndStateClassesRenamer(renameMixins: true),
       ),


### PR DESCRIPTION
## Description

Two more suggestors for the `dart2_upgrade` codemod when not retaining backwards-compatibility:

- Removing any `// orcm_ignore` comments. These are only necessary to prevent the codemod from failing when running in the `--fail-on-changes` mode for instances that were being flagged as false positives.
- Removing the `// ignore: uri_has_not_been_generated` comment that precedes all `.over_react.g.dart` part directives.

## Testing
- [ ] CI passes (tests added)
- [ ] Smoke test the `dart2_upgrade` codemod with and without the `--backwards-compat` flag

## Code Review
@corwinsheahan-wf @sebastianmalysa-wf @smaifullerton-wk @seanburke-wf @maxwellpeterson-wf