### PR TITLE
CPLAT-4451 Reorder suggestors and improve the UI factory ignore remover

### DIFF
--- a/lib/src/dart2_suggestors/ui_factory_ignore_comment_remover.dart
+++ b/lib/src/dart2_suggestors/ui_factory_ignore_comment_remover.dart
@@ -74,13 +74,13 @@ class UiFactoryIgnoreCommentRemover extends RecursiveAstVisitor
     if (_ignoreLines.contains(initializerLineNum)) {
       final currentFactory = sourceFile
           .span(
-            node.offset,
+            node.metadata.beginToken.offset,
             node.end,
           )
           .text;
       final updatedFactory = currentFactory.replaceFirst(ignorePattern, '');
       yieldPatch(
-        node.offset,
+        node.metadata.beginToken.offset,
         node.end,
         updatedFactory,
       );

--- a/test/dart2_suggestors/ui_factory_ignore_comment_remover.suggestor_test
+++ b/test/dart2_suggestors/ui_factory_ignore_comment_remover.suggestor_test
@@ -47,3 +47,20 @@ UiFactory<_CustomColorInputProps> _CustomColorInput = _$_CustomColorInput;
 <<<
 @Factory()
 UiFactory<_CustomColorInputProps> _CustomColorInput = _$_CustomColorInput;
+
+
+>>> factory with doc comment (patches 1)
+/// Doc comment.
+/// Line 2.
+/// Line 3.
+@Factory()
+UiFactory Foo =
+  // ignore: undefined_identifier
+  _$Foo;
+<<<
+/// Doc comment.
+/// Line 2.
+/// Line 3.
+@Factory()
+UiFactory Foo =
+  _$Foo;


### PR DESCRIPTION
## Description

@maxwellpeterson-wf reported a bug with the codemod where it is possible for certain suggestors to suggest overlapping patches, which is disallowed by the codemod runner. To avoid this, we can simply break up the suggestor list into a few more "phases" that run sequentially. In particular, the cleanup suggestors that remove the backwards-compat-only stuff can be run in their own aggregate suggestor after the other suggestors.

Also included an improvement to the UI factory ignore comment remover that rewrites less (meaning that if you have a factory with a really large doc comment on it, the suggestor won't include that in the diff).

## Testing
- [ ] CI passes
- [ ] Smoke test the `dart2_upgrade` codemod with and without `--backwards-compat` on a few large over_react consumers
