### PR TITLE
CPLAT-4097 Release over_react_codemod 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   - `// ignore: uri_has_not_been_generated` comments that precede a
     `.over_react.g.dart` part directive are removed
 
+- Fix a bug that could result in overlapping patches being suggested, which
+  would cause the `dart2_upgrade` codemod to exit early unsuccessfully.
+
 ## [1.0.2](https://github.com/Workiva/over_react_codemod/compare/1.0.1...1.0.2)
 
 - Provide additional output from the `dart2_upgrade` codemod in the following

--- a/lib/src/executables/dart2_upgrade.dart
+++ b/lib/src/executables/dart2_upgrade.dart
@@ -43,7 +43,7 @@ const _helpFlag = '--help';
 const _helpFlagAbbr = '-h';
 const _changesRequiredOutput = """
 To update your code, switch to Dart 2.1.0 and run the following commands:
-  pub global activate over_react_codemod ^1.0.1
+  pub global activate over_react_codemod ^1.1.0
   pub global run over_react_codemod:dart2_upgrade --backwards-compat
 Then, review and commit the changes.
 """;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_codemod
-version: 1.0.2
+version: 1.1.0
 homepage: https://github.com/Workiva/over_react_codemod
 
 description: >


### PR DESCRIPTION

Pull Requests included in release:
* [CPLAT-4307 Add two comment removing suggestors to dart2_upgrade](https://github.com/Workiva/over_react_codemod/pull/25)
* [CPLAT-4451 Reorder suggestors and improve the UI factory ignore remover](https://github.com/Workiva/over_react_codemod/pull/26)


Requested by: @evan.weible

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react_codemod/compare/1.0.2...Workiva:release_over_react_codemod_1.1.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react_codemod/compare/1.0.2...1.1.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6153708125028352/logs/)