### PR TITLE
CPLAT-6812 Add optional snapshot arg to componentDidUpdate

### DIFF
--- a/lib/src/component2_suggestors/componentdidupdate_migrator.dart
+++ b/lib/src/component2_suggestors/componentdidupdate_migrator.dart
@@ -26,8 +26,9 @@ class ComponentDidUpdateMigrator extends GeneralizingAstVisitor
     super.visitMethodDeclaration(node);
 
     if (node.name.toString() == 'componentDidUpdate') {
-      var lastArg = node.parameters.childEntities.lastWhere((t) => t.toString() != ')');
-      if(lastArg.toString() != ']') {
+      var lastArg =
+          node.parameters.childEntities.lastWhere((t) => t.toString() != ')');
+      if (lastArg.toString() != ']') {
         yieldPatch(lastArg.end, lastArg.end, ', [snapshot]');
       }
     }

--- a/lib/src/component2_suggestors/componentdidupdate_migrator.dart
+++ b/lib/src/component2_suggestors/componentdidupdate_migrator.dart
@@ -27,7 +27,7 @@ class ComponentDidUpdateMigrator extends GeneralizingAstVisitor
 
     if (node.name.toString() == 'componentDidUpdate') {
       var lastArg =
-          node.parameters.childEntities.lastWhere((t) => t.toString() != ')');
+          node.parameters.childEntities.lastWhere((p) => p.toString() != ')');
 
       if (lastArg.toString() != ']') {
         yieldPatch(lastArg.end, lastArg.end, ', [snapshot]');

--- a/lib/src/component2_suggestors/componentdidupdate_migrator.dart
+++ b/lib/src/component2_suggestors/componentdidupdate_migrator.dart
@@ -19,18 +19,14 @@ import 'package:codemod/codemod.dart';
 class ComponentDidUpdateMigrator extends GeneralizingAstVisitor
     with AstVisitingSuggestorMixin
     implements Suggestor {
-  ComponentDidUpdateMigrator();
 
   @override
   visitMethodDeclaration(MethodDeclaration node) {
     super.visitMethodDeclaration(node);
 
-    if (node.name.toString() == 'componentDidUpdate') {
-      var lastArg =
-          node.parameters.childEntities.lastWhere((p) => p.toString() != ')');
-
-      if (lastArg.toString() != ']') {
-        yieldPatch(lastArg.end, lastArg.end, ', [snapshot]');
+    if (node.name.name == 'componentDidUpdate') {
+      if (node.parameters.parameters.length == 2) {
+        yieldPatch(node.parameters.rightParenthesis.offset, node.parameters.rightParenthesis.offset, ', [snapshot]');
       }
     }
   }

--- a/lib/src/component2_suggestors/componentdidupdate_migrator.dart
+++ b/lib/src/component2_suggestors/componentdidupdate_migrator.dart
@@ -19,14 +19,14 @@ import 'package:codemod/codemod.dart';
 class ComponentDidUpdateMigrator extends GeneralizingAstVisitor
     with AstVisitingSuggestorMixin
     implements Suggestor {
-
   @override
   visitMethodDeclaration(MethodDeclaration node) {
     super.visitMethodDeclaration(node);
 
     if (node.name.name == 'componentDidUpdate') {
       if (node.parameters.parameters.length == 2) {
-        yieldPatch(node.parameters.rightParenthesis.offset, node.parameters.rightParenthesis.offset, ', [snapshot]');
+        yieldPatch(node.parameters.rightParenthesis.offset,
+            node.parameters.rightParenthesis.offset, ', [snapshot]');
       }
     }
   }

--- a/lib/src/component2_suggestors/componentdidupdate_migrator.dart
+++ b/lib/src/component2_suggestors/componentdidupdate_migrator.dart
@@ -1,0 +1,35 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:analyzer/analyzer.dart';
+import 'package:codemod/codemod.dart';
+
+/// Suggestor that adds an optional `snapshot` argument to `componentDidUpdate`.
+class ComponentDidUpdateMigrator extends GeneralizingAstVisitor
+    with AstVisitingSuggestorMixin
+    implements Suggestor {
+  ComponentDidUpdateMigrator();
+
+  @override
+  visitMethodDeclaration(MethodDeclaration node) {
+    super.visitMethodDeclaration(node);
+
+    if (node.name.toString() == 'componentDidUpdate') {
+      var lastArg = node.parameters.childEntities.lastWhere((t) => t.toString() != ')');
+      if(lastArg.toString() != ']') {
+        yieldPatch(lastArg.end, lastArg.end, ', [snapshot]');
+      }
+    }
+  }
+}

--- a/lib/src/component2_suggestors/componentdidupdate_migrator.dart
+++ b/lib/src/component2_suggestors/componentdidupdate_migrator.dart
@@ -28,6 +28,7 @@ class ComponentDidUpdateMigrator extends GeneralizingAstVisitor
     if (node.name.toString() == 'componentDidUpdate') {
       var lastArg =
           node.parameters.childEntities.lastWhere((t) => t.toString() != ')');
+
       if (lastArg.toString() != ']') {
         yieldPatch(lastArg.end, lastArg.end, ', [snapshot]');
       }

--- a/lib/src/component2_suggestors/componentwillmount_migrator.dart
+++ b/lib/src/component2_suggestors/componentwillmount_migrator.dart
@@ -16,7 +16,6 @@ import 'package:analyzer/analyzer.dart';
 import 'package:codemod/codemod.dart';
 
 import '../constants.dart';
-import '../util.dart';
 
 /// Suggestor that renames all props and state classes to have the required `_$`
 /// prefix.

--- a/lib/src/executables/component2_upgrade.dart
+++ b/lib/src/executables/component2_upgrade.dart
@@ -16,6 +16,7 @@ import 'dart:io';
 
 import 'package:codemod/codemod.dart';
 import 'package:over_react_codemod/src/component2_suggestors/class_name_and_annotation_migrator.dart';
+import 'package:over_react_codemod/src/component2_suggestors/componentdidupdate_migrator.dart';
 import 'package:over_react_codemod/src/component2_suggestors/componentwillmount_migrator.dart';
 
 const _changesRequiredOutput = """
@@ -35,6 +36,7 @@ void main(List<String> args) {
     [
       ClassNameAndAnnotationMigrator(),
       ComponentWillMountMigrator(),
+      ComponentDidUpdateMigrator(),
     ],
     args: args,
     defaultYes: true,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,8 +28,10 @@ dev_dependencies:
   dart_dev: ^2.0.1
   dart_style: ^1.2.0
   dependency_validator: ^1.2.3
+  meta: ^1.1.7
   mockito: ^4.0.0
   pedantic: ^1.4.0
+  react: ^4.6.1
   test: ^1.5.1
 
 executables:

--- a/test/component2_suggestors/componentdidupdate_migrator_test.dart
+++ b/test/component2_suggestors/componentdidupdate_migrator_test.dart
@@ -57,5 +57,20 @@ main() {
         ''',
       );
     });
+
+    test('componentDidUpdate does not update if optional third argument exists',
+        () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
+          @Component2()
+          class FooComponent extends UiComponent2 {
+              componentDidUpdate(Map prevProps, Map prevState, [_]) {
+                  // method body
+              }
+          }
+        ''',
+      );
+    });
   });
 }

--- a/test/component2_suggestors/componentdidupdate_migrator_test.dart
+++ b/test/component2_suggestors/componentdidupdate_migrator_test.dart
@@ -1,0 +1,61 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react_codemod/src/component2_suggestors/componentdidupdate_migrator.dart';
+import 'package:test/test.dart';
+
+import '../util.dart';
+
+main() {
+  group('ComponentDidUpdateMigrator', () {
+    final testSuggestor = getSuggestorTester(ComponentDidUpdateMigrator());
+
+    test('empty file', () {
+      testSuggestor(expectedPatchCount: 0, input: '');
+    });
+
+    test('no matches', () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
+          library foo;
+          var a = 'b';
+          class Foo {}
+        ''',
+      );
+    });
+
+    test('componentDidUpdate method updates', () {
+      testSuggestor(
+        expectedPatchCount: 1,
+        input: '''
+          @Component2()
+          class FooComponent extends UiComponent2 {
+              componentDidUpdate(Map prevProps, Map prevState) {
+                  // method body
+              }
+          }
+        ''',
+        expectedOutput: '''
+          @Component2()
+          class FooComponent extends UiComponent2 {
+              componentDidUpdate(Map prevProps, Map prevState, [snapshot]) {
+                // method body
+              }
+          }
+        ''',
+      );
+    });
+  });
+}

--- a/test/util.dart
+++ b/test/util.dart
@@ -26,7 +26,7 @@ final _pathPattern = RegExp(r'\(path ([\w./]+)\)');
 final _dartfmtOutputPattern = RegExp(r'\s*@dartfmt_output');
 final _idempotentPattern = RegExp(r'\s*@idempotent');
 
-final formatter = new DartFormatter();
+final formatter = DartFormatter();
 
 // This testing approach is similar to what dart_style does for their formatting
 // tests since it is pretty much entirely input >> output.
@@ -152,14 +152,14 @@ void _testSuggestor(Map<String, Suggestor> suggestorMap, String testFilePath) {
 /// Returns a version of [testSuggestor] with [suggestor] curried.
 void Function({
   @required String input,
-  @required String expectedOutput,
+  String expectedOutput,
   int expectedPatchCount,
   bool shouldDartfmtOutput,
   bool testIdempotency,
 }) getSuggestorTester(Suggestor suggestor) {
   return ({
     @required String input,
-    @required String expectedOutput,
+    String expectedOutput,
     int expectedPatchCount,
     bool shouldDartfmtOutput = true,
     bool testIdempotency = true,
@@ -177,11 +177,11 @@ void Function({
 void testSuggestor({
   @required Suggestor suggestor,
   @required String input,
-  @required String expectedOutput,
+  String expectedOutput,
   int expectedPatchCount,
   bool shouldDartfmtOutput = true,
   bool testIdempotency = true,
-  String inputUrl: 'input',
+  String inputUrl = 'input',
 }) {
   if (expectedOutput == null) {
     expectedOutput = input;


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
An optional `snapshot` argument needs to be added to `componentDidUpdate` to be compatible with UiComponent2.
## Changes
  <!-- What this PR changes to fix the problem. -->
- Add suggestor that adds an optional `snapshot` argument to `componentDidUpdate`.
- Write tests.
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->
@kealjones-wk @aaronlademann-wf @joebingham-wk @greglittlefield-wf 
### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
      - [ ] CI passes.
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
