### PR TITLE
CPLAT-7029 Fix style map codemod edge cases

### DIFF
--- a/lib/src/react16_suggestors/react_style_maps_updater.dart
+++ b/lib/src/react16_suggestors/react_style_maps_updater.dart
@@ -87,6 +87,11 @@ class ReactStyleMapsUpdater extends GeneralizingAstVisitor
           String originalCssPropertyKey = propertyKey.toSource();
           String cleanedCssPropertyKey = cleanString(propertyKey);
 
+          if (_unitlessNumberProperties.contains(cleanedCssPropertyKey) ||
+              _nonLengthValueProperties.contains(cleanedCssPropertyKey)) {
+            return;
+          }
+
           final cssPropertyValue = cssPropertyRow.value;
           String cleanedCssPropertyValue = cleanString(cssPropertyValue);
 
@@ -299,3 +304,90 @@ SyntacticEntity getStyles(Expression cascade) {
 
   return cleanedChildEntities.first;
 }
+
+/// A non-exhaustive set of CSS property names whose values can be numbers
+/// without units.
+const _unitlessNumberProperties = const {
+  'animationIterationCount',
+  'borderImageOutset',
+  'borderImageSlice',
+  'borderImageWidth',
+  'boxFlex',
+  'boxFlexGroup',
+  'boxOrdinalGroup',
+  'columnCount',
+  'columns',
+  'flex',
+  'flexGrow',
+  'flexPositive',
+  'flexShrink',
+  'flexNegative',
+  'flexOrder',
+  'gridRow',
+  'gridRowEnd',
+  'gridRowSpan',
+  'gridRowStart',
+  'gridColumn',
+  'gridColumnEnd',
+  'gridColumnSpan',
+  'gridColumnStart',
+  'fontWeight',
+  'lineClamp',
+  'lineHeight',
+  'opacity',
+  'order',
+  'orphans',
+  'tabSize',
+  'widows',
+  'zIndex',
+  'zoom',
+
+  // SVG-related properties
+  'fillOpacity',
+  'floodOpacity',
+  'stopOpacity',
+  'strokeDasharray',
+  'strokeDashoffset',
+  'strokeMiterlimit',
+  'strokeOpacity',
+  'strokeWidth',
+};
+
+/// A non-exhaustive set of CSS property names whose values never represent
+/// CSS lengths (absolute lengths like px/pt, relative lengths like %/rem).
+const _nonLengthValueProperties = const {
+  'backgroundAttachment',
+  'backgroundColor',
+  'backgroundImage',
+  'borderBottomColor',
+  'borderBottomStyle',
+  'borderColor',
+  'borderLeftColor',
+  'borderLeftStyle',
+  'borderRightColor',
+  'borderRightStyle',
+  'borderStyle',
+  'borderTopColor',
+  'borderTopStyle',
+  'clear',
+  'color',
+  'cursor',
+  'display',
+  'float',
+  'cssFloat',
+  'font',
+  'fontFamily',
+  'fontVariant',
+  'listStyle',
+  'listStyleImage',
+  'listStyleType',
+  'overflow',
+  'pageBreakAfter',
+  'pageBreakBefore',
+  'position',
+  'textAlign',
+  'textDecoration',
+  'textTransform',
+  'verticalAlign',
+  'visibility',
+};

--- a/lib/src/react16_suggestors/react_style_maps_updater.dart
+++ b/lib/src/react16_suggestors/react_style_maps_updater.dart
@@ -38,7 +38,14 @@ class ReactStyleMapsUpdater extends GeneralizingAstVisitor
 
     for (Expression cascade in node.cascadeSections) {
       if (!hasComment(cascade, sourceFile, willBeRemovedCommentSuffix)) {
-        if (cascade is AssignmentExpression && cascade.leftHandSide.toSource().contains('style')) {
+        var isStylePropAssignment = false;
+        if (cascade is AssignmentExpression) {
+          final lhs = cascade.leftHandSide;
+          if (lhs is PropertyAccess && lhs.propertyName.name == 'style') {
+            isStylePropAssignment = true;
+          }
+        }
+        if (isStylePropAssignment) {
           /// A style map, method invocation, or a variable
           final stylesObject = getStyles(cascade);
 

--- a/lib/src/react16_suggestors/react_style_maps_updater.dart
+++ b/lib/src/react16_suggestors/react_style_maps_updater.dart
@@ -29,8 +29,8 @@ import './react16_utilities.dart';
 class ReactStyleMapsUpdater extends GeneralizingAstVisitor
     with AstVisitingSuggestorMixin
     implements Suggestor {
-
-  static final _cssValueSuffixPattern = new RegExp(r'\b(?:rem|em|ex|vh|vw|vmin|vmax|%|px|cm|mm|in|pt|pc|ch)$');
+  static final _cssValueSuffixPattern =
+      new RegExp(r'\b(?:rem|em|ex|vh|vw|vmin|vmax|%|px|cm|mm|in|pt|pc|ch)$');
 
   @override
   visitCascadeExpression(CascadeExpression node) {
@@ -139,21 +139,28 @@ class ReactStyleMapsUpdater extends GeneralizingAstVisitor
                   }
                 }
               } else if (cssPropertyValue is StringInterpolation) {
-                final lastElement = cssPropertyValue.elements.isEmpty ? null : cssPropertyValue.elements.last;
-                if (lastElement is! InterpolationString || !_cssValueSuffixPattern.hasMatch((lastElement as InterpolationString).value)) {
+                final lastElement = cssPropertyValue.elements.isEmpty
+                    ? null
+                    : cssPropertyValue.elements.last;
+                if (lastElement is! InterpolationString ||
+                    !_cssValueSuffixPattern
+                        .hasMatch((lastElement as InterpolationString).value)) {
                   flagAsVariable();
                 }
               } else if (cssPropertyValue is MethodInvocation) {
                 var invocation = cssPropertyValue;
                 // Handle `toRem(1).toString()`
-                if (invocation.methodName.name == 'toString' && invocation.target is MethodInvocation) {
+                if (invocation.methodName.name == 'toString' &&
+                    invocation.target is MethodInvocation) {
                   invocation = invocation.target;
                 }
 
-                if (!const ['toPx', 'toRem'].contains(invocation.methodName.name)) {
+                if (!const ['toPx', 'toRem']
+                    .contains(invocation.methodName.name)) {
                   flagAsVariable();
                 }
-              } else if (cssPropertyValue is DoubleLiteral || cssPropertyValue is IntegerLiteral) {
+              } else if (cssPropertyValue is DoubleLiteral ||
+                  cssPropertyValue is IntegerLiteral) {
                 // do nothing
               } else {
                 flagAsVariable();

--- a/test/react16_suggestors/react_style_maps_updater_test.dart
+++ b/test/react16_suggestors/react_style_maps_updater_test.dart
@@ -308,6 +308,22 @@ main() {
         );
       });
 
+      test('is on an instance creation expression', () {
+        testSuggestor(
+          expectedPatchCount: 0,
+          input: '''
+            main() {
+              new NotAPropsClass()
+                ..style = something
+                ..style = getSomething()
+                ..style = {
+                  'width': '40',
+                };
+            }
+          ''',
+        );
+      });
+
       test('is an expression that has already been updated', () {
         testSuggestor(
           expectedPatchCount: 0,

--- a/test/react16_suggestors/react_style_maps_updater_test.dart
+++ b/test/react16_suggestors/react_style_maps_updater_test.dart
@@ -242,6 +242,43 @@ main() {
         );
       });
 
+      test('is on a unitless or non-number property', () {
+        testSuggestor(
+          expectedPatchCount: 0,
+          input: '''
+            main() {
+              Foo()
+              ..style = {
+                'zIndex': '5',
+                'position': 'absolute',
+              };
+            }
+          ''',
+        );
+      });
+
+      test('is on a custom property', () {
+        testSuggestor(
+          expectedPatchCount: 1,
+          input: '''
+            main() {
+              Foo()
+              ..style = {
+                '--foo': '5',
+              };
+            }
+          ''',
+          expectedOutput: '''
+            main() {
+              Foo()
+              ..style = {
+                '--foo': 5,
+              };
+            }
+          ''',
+        );
+      });
+
       test('is a toRem/toPx call', () {
         testSuggestor(
           expectedPatchCount: 0,

--- a/test/react16_suggestors/react_style_maps_updater_test.dart
+++ b/test/react16_suggestors/react_style_maps_updater_test.dart
@@ -294,10 +294,10 @@ main() {
             main() {
               Foo()
                 ${getCheckboxComment(keysOfModdedValues: [
-                  'width',
-                  'height',
-                  'fontSize'
-                ])}
+            'width',
+            'height',
+            'fontSize'
+          ])}
                 ..style = {
                   'width': '\$width',
                   'height': '\${getHeight()}foo',

--- a/test/react16_suggestors/react_style_maps_updater_test.dart
+++ b/test/react16_suggestors/react_style_maps_updater_test.dart
@@ -588,7 +588,7 @@ main() {
       );
     });
 
-    test('does not run on setProperty', () {
+    test('does not run on DOM style setProperty', () {
       testSuggestor(
         expectedPatchCount: 0,
         input: '''
@@ -596,9 +596,19 @@ main() {
               DivElement()..style.setProperty('width', '400');
             }
           ''',
-        expectedOutput: '''
+      );
+    });
+
+    test('does not run on DOM style property assignments in various forms', () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
             main() {
-              DivElement()..style.setProperty('width', '400');
+              style.width = '400';
+              style..width = '400';
+              DivElement().style.width = '400';
+              DivElement()..style.width = '400';
+              DivElement().style..width = '400';
             }
           ''',
       );

--- a/test/react16_suggestors/react_style_maps_updater_test.dart
+++ b/test/react16_suggestors/react_style_maps_updater_test.dart
@@ -242,6 +242,72 @@ main() {
         );
       });
 
+      test('is a toRem/toPx call', () {
+        testSuggestor(
+          expectedPatchCount: 0,
+          input: '''
+            main() {
+              Foo()
+              ..style = {
+                'width': toRem(width),
+                'height': toPx(height),
+              };
+            }
+          ''',
+        );
+      });
+
+      test('is a toRem/toPx call with a toString at the end', () {
+        testSuggestor(
+          expectedPatchCount: 0,
+          input: '''
+            main() {
+              Foo()
+              ..style = {
+                'fontSize': toRem('12').toString(),
+                'margin': toPx('25').toString(),
+              };
+            }
+          ''',
+        );
+      });
+
+      test('is an interpolated string ending in a known CSS unit', () {
+        testSuggestor(
+          expectedPatchCount: 0,
+          input: r'''
+            main() {
+              Foo()
+                ..style = {
+                  'width': '${width}rem',
+                  'width': '${getHeight()}px',
+                };
+            }
+          ''',
+        );
+      });
+
+      test('is an interpolated string not ending in a known CSS unit', () {
+        testSuggestor(
+          expectedPatchCount: 0,
+          input: '''
+            main() {
+              Foo()
+                ${getCheckboxComment(keysOfModdedValues: [
+                  'width',
+                  'height',
+                  'fontSize'
+                ])}
+                ..style = {
+                  'width': '\$width',
+                  'height': '\${getHeight()}foo',
+                  'fontSize': '\${getFontSize()}notpx',
+                };
+            }
+          ''',
+        );
+      });
+
       test('is an expression that has already been updated', () {
         testSuggestor(
           expectedPatchCount: 0,
@@ -385,7 +451,7 @@ main() {
           expectedOutput: '''
             main() {
               Foo()
-              ${manualVariableCheckComment()}
+              ${manualVariableCheckComment(keysOfModdedValues: ['width'])}
               ..style = {
                 'width': foo.bar,
               };
@@ -538,28 +604,27 @@ main() {
       );
     });
 
-    test('adds a comment for custom props', () {
+    test('works for custom props maps containing styles', () {
       testSuggestor(
         expectedPatchCount: 1,
         input: '''
             main() {
               Foo()
-              ..datePickerProps = {
-                'style': {
+              ..datePickerProps = (domProps()
+                ..style = {
                   'width': '40',
                 }
-              };
+              );
             }
           ''',
         expectedOutput: '''
             main() {
               Foo()
-              ${manualVariableCheckComment()}
-              ..datePickerProps = {
-                'style': {
-                  'width': '40',
+              ..datePickerProps = (domProps()
+                ..style = {
+                  'width': 40,
                 }
-              };
+              );
             }
           ''',
       );


### PR DESCRIPTION
## Motivation
I ran into a couple edge cases when testing the codemod on graph_app that caused extra style map comments to be added.

## Changes
- Don't insert comments for things like `style.width = ...`; the `.width` indicates a DOM API since we don't have typed maps for style maps with `width` getters.
    - This cuts down on a lot of comments in places where they're mutating styles with the DOM API
- Act upon nested style maps, as a side effect of updating cascade filtering logic for the bullet above
- Don't insert comments for interpolated strings that add known CSS units
- Don't insert comments for `toRem`/`toPx` calls
- Don't codemod CSS properties that are unitless (e.g., `zIndex`) or don't represent numbers (e.g., `display`)
- Don't codemod when `style` is cascaded on instantiation expressions with `new`, which are never component factory usages

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @aaronlademann-wf @kealjones-wk @joebingham-wk @sydneyjodon-wk 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
