### PR TITLE
CPLAT-6936 Add flag to skip components that codemod can only partially upgrade

### DIFF
--- a/lib/src/component2_suggestors/class_name_and_annotation_migrator.dart
+++ b/lib/src/component2_suggestors/class_name_and_annotation_migrator.dart
@@ -26,6 +26,10 @@ import 'component2_utilities.dart';
 class ClassNameAndAnnotationMigrator extends GeneralizingAstVisitor
     with AstVisitingSuggestorMixin
     implements Suggestor {
+  final bool noPartialUpgrades;
+
+  ClassNameAndAnnotationMigrator({this.noPartialUpgrades = false});
+
   Iterable<String> get migrateAnnotations =>
       overReact16AnnotationNamesToMigrate;
 

--- a/lib/src/component2_suggestors/class_name_and_annotation_migrator.dart
+++ b/lib/src/component2_suggestors/class_name_and_annotation_migrator.dart
@@ -57,7 +57,7 @@ class ClassNameAndAnnotationMigrator extends GeneralizingAstVisitor
   visitClassDeclaration(ClassDeclaration node) {
     super.visitClassDeclaration(node);
 
-    if(noPartialUpgrades && !canBeFullyUpgradedToComponent2(node)) {
+    if (noPartialUpgrades && !canBeFullyUpgradedToComponent2(node)) {
       return;
     }
 

--- a/lib/src/component2_suggestors/class_name_and_annotation_migrator.dart
+++ b/lib/src/component2_suggestors/class_name_and_annotation_migrator.dart
@@ -45,9 +45,25 @@ class ClassNameAndAnnotationMigrator extends GeneralizingAstVisitor
       return;
     }
 
+    CompilationUnit unit = node.thisOrAncestorMatching((ancestor) {
+      return ancestor is CompilationUnit;
+    });
+
+    // Check if the import needs to show Component2.
+    bool shouldUpdateImport = true;
+    if (noPartialUpgrades) {
+      shouldUpdateImport = false;
+      unit.declarations.whereType<ClassDeclaration>().forEach((classNode) {
+        if (canBeFullyUpgradedToComponent2(classNode)) {
+          shouldUpdateImport = true;
+        }
+      });
+    }
+
     // Add Component2 to import show list.
     var showNamesList = (node.combinators.first as ShowCombinator)?.shownNames;
-    if (!showNamesList.any((name) => name.toSource() == 'Component2')) {
+    if (shouldUpdateImport &&
+        !showNamesList.any((name) => name.toSource() == 'Component2')) {
       yieldPatch(
         showNamesList.last.end,
         showNamesList.last.end,

--- a/lib/src/component2_suggestors/class_name_and_annotation_migrator.dart
+++ b/lib/src/component2_suggestors/class_name_and_annotation_migrator.dart
@@ -57,6 +57,10 @@ class ClassNameAndAnnotationMigrator extends GeneralizingAstVisitor
   visitClassDeclaration(ClassDeclaration node) {
     super.visitClassDeclaration(node);
 
+    if(noPartialUpgrades && !canBeFullyUpgradedToComponent2(node)) {
+      return;
+    }
+
     var extendsName = node.extendsClause?.superclass?.name;
     if (extendsName == null) {
       return;

--- a/lib/src/component2_suggestors/component2_utilities.dart
+++ b/lib/src/component2_suggestors/component2_utilities.dart
@@ -87,15 +87,30 @@ bool canBeFullyUpgradedToComponent2(ClassDeclaration classNode) {
 
   // Check that all lifecycle methods contained in the class will be
   // updated by a codemod.
+  final lifecycleMethods = [
+    'componentWillMount',
+    'componentWillReceiveProps',
+    'componentWillUpdate',
+    'getDerivedStateFromError',
+    'getDerivedStateFromProps',
+    'getSnapshotBeforeUpdate',
+    'shouldComponentUpdate',
+    'render',
+    'componentDidMount',
+    'componentDidUpdate',
+    'componentWillUnmount',
+    'componentDidCatch',
+  ];
+
   var lifecycleMethodsWithCodemods = [
     'componentWillMount',
-    'init',
     'render',
     'componentDidUpdate',
   ];
 
   for (var member in classNode.members) {
     if (member is MethodDeclaration &&
+        lifecycleMethods.contains(member.name.name) &&
         !lifecycleMethodsWithCodemods.contains(member.name.name)) {
       return false;
     }

--- a/lib/src/component2_suggestors/component2_utilities.dart
+++ b/lib/src/component2_suggestors/component2_utilities.dart
@@ -85,7 +85,8 @@ bool canBeFullyUpgradedToComponent2(ClassDeclaration classNode) {
     return false;
   }
 
-  // Check that all lifecycle methods will be updated by codemods.
+  // Check that all lifecycle methods contained in the class will be
+  // updated by a codemod.
   var lifecycleMethodsWithCodemods = [
     'componentWillMount',
     'init',

--- a/lib/src/component2_suggestors/componentdidupdate_migrator.dart
+++ b/lib/src/component2_suggestors/componentdidupdate_migrator.dart
@@ -30,7 +30,7 @@ class ComponentDidUpdateMigrator extends GeneralizingAstVisitor
 
     ClassDeclaration containingClass = node.parent;
 
-    if(noPartialUpgrades && !canBeFullyUpgradedToComponent2(containingClass)) {
+    if (noPartialUpgrades && !canBeFullyUpgradedToComponent2(containingClass)) {
       return;
     }
 

--- a/lib/src/component2_suggestors/componentdidupdate_migrator.dart
+++ b/lib/src/component2_suggestors/componentdidupdate_migrator.dart
@@ -20,6 +20,10 @@ import 'package:over_react_codemod/src/component2_suggestors/component2_utilitie
 class ComponentDidUpdateMigrator extends GeneralizingAstVisitor
     with AstVisitingSuggestorMixin
     implements Suggestor {
+  final bool noPartialUpgrades;
+
+  ComponentDidUpdateMigrator({this.noPartialUpgrades = false});
+
   @override
   visitMethodDeclaration(MethodDeclaration node) {
     super.visitMethodDeclaration(node);

--- a/lib/src/component2_suggestors/componentdidupdate_migrator.dart
+++ b/lib/src/component2_suggestors/componentdidupdate_migrator.dart
@@ -30,6 +30,10 @@ class ComponentDidUpdateMigrator extends GeneralizingAstVisitor
 
     ClassDeclaration containingClass = node.parent;
 
+    if(noPartialUpgrades && !canBeFullyUpgradedToComponent2(containingClass)) {
+      return;
+    }
+
     if (extendsComponent2(containingClass)) {
       if (node.name.name == 'componentDidUpdate') {
         if (node.parameters.parameters.length == 2) {

--- a/lib/src/component2_suggestors/componentwillmount_migrator.dart
+++ b/lib/src/component2_suggestors/componentwillmount_migrator.dart
@@ -32,7 +32,7 @@ class ComponentWillMountMigrator extends GeneralizingAstVisitor
 
     ClassDeclaration containingClass = node.parent;
 
-    if(noPartialUpgrades && !canBeFullyUpgradedToComponent2(containingClass)) {
+    if (noPartialUpgrades && !canBeFullyUpgradedToComponent2(containingClass)) {
       return;
     }
 

--- a/lib/src/component2_suggestors/componentwillmount_migrator.dart
+++ b/lib/src/component2_suggestors/componentwillmount_migrator.dart
@@ -32,6 +32,10 @@ class ComponentWillMountMigrator extends GeneralizingAstVisitor
 
     ClassDeclaration containingClass = node.parent;
 
+    if(noPartialUpgrades && !canBeFullyUpgradedToComponent2(containingClass)) {
+      return;
+    }
+
     if (extendsComponent2(containingClass)) {
       // Update method name.
       if (node.name.name == 'componentWillMount') {

--- a/lib/src/component2_suggestors/componentwillmount_migrator.dart
+++ b/lib/src/component2_suggestors/componentwillmount_migrator.dart
@@ -22,6 +22,10 @@ import 'component2_utilities.dart';
 class ComponentWillMountMigrator extends GeneralizingAstVisitor
     with AstVisitingSuggestorMixin
     implements Suggestor {
+  final bool noPartialUpgrades;
+
+  ComponentWillMountMigrator({this.noPartialUpgrades = false});
+
   @override
   visitMethodDeclaration(MethodDeclaration node) {
     super.visitMethodDeclaration(node);

--- a/lib/src/component2_suggestors/copyunconsumeddomprops_migrator.dart
+++ b/lib/src/component2_suggestors/copyunconsumeddomprops_migrator.dart
@@ -33,7 +33,7 @@ class CopyUnconsumedDomPropsMigrator extends GeneralizingAstVisitor
       return ancestor is ClassDeclaration;
     });
 
-    if(noPartialUpgrades && !canBeFullyUpgradedToComponent2(containingClass)) {
+    if (noPartialUpgrades && !canBeFullyUpgradedToComponent2(containingClass)) {
       return;
     }
 

--- a/lib/src/component2_suggestors/copyunconsumeddomprops_migrator.dart
+++ b/lib/src/component2_suggestors/copyunconsumeddomprops_migrator.dart
@@ -33,6 +33,10 @@ class CopyUnconsumedDomPropsMigrator extends GeneralizingAstVisitor
       return ancestor is ClassDeclaration;
     });
 
+    if(noPartialUpgrades && !canBeFullyUpgradedToComponent2(containingClass)) {
+      return;
+    }
+
     if (extendsComponent2(containingClass)) {
       if (node.methodName.name == 'addProps') {
         var firstArg = node.argumentList.arguments.first;

--- a/lib/src/component2_suggestors/copyunconsumeddomprops_migrator.dart
+++ b/lib/src/component2_suggestors/copyunconsumeddomprops_migrator.dart
@@ -21,6 +21,10 @@ import 'component2_utilities.dart';
 class CopyUnconsumedDomPropsMigrator extends GeneralizingAstVisitor
     with AstVisitingSuggestorMixin
     implements Suggestor {
+  final bool noPartialUpgrades;
+
+  CopyUnconsumedDomPropsMigrator({this.noPartialUpgrades = false});
+
   @override
   visitMethodInvocation(MethodInvocation node) {
     super.visitMethodInvocation(node);

--- a/lib/src/component2_suggestors/deprecated_lifecycle_suggestor.dart
+++ b/lib/src/component2_suggestors/deprecated_lifecycle_suggestor.dart
@@ -25,6 +25,10 @@ import 'component2_utilities.dart';
 class DeprecatedLifecycleSuggestor extends GeneralizingAstVisitor
     with AstVisitingSuggestorMixin
     implements Suggestor {
+  final bool noPartialUpgrades;
+
+  DeprecatedLifecycleSuggestor({this.noPartialUpgrades = false});
+
   @override
   visitMethodDeclaration(MethodDeclaration node) {
     super.visitMethodDeclaration(node);

--- a/lib/src/component2_suggestors/deprecated_lifecycle_suggestor.dart
+++ b/lib/src/component2_suggestors/deprecated_lifecycle_suggestor.dart
@@ -35,6 +35,11 @@ class DeprecatedLifecycleSuggestor extends GeneralizingAstVisitor
     super.visitMethodDeclaration(node);
 
     ClassDeclaration containingClass = node.parent;
+
+    if (noPartialUpgrades && !canBeFullyUpgradedToComponent2(containingClass)) {
+      return;
+    }
+
     if (extendsComponent2(containingClass)) {
       var deprecatedLifecycleMethods = [
         'componentWillUpdate',

--- a/lib/src/component2_suggestors/setstate_updater.dart
+++ b/lib/src/component2_suggestors/setstate_updater.dart
@@ -22,6 +22,10 @@ import 'component2_utilities.dart';
 class SetStateUpdater extends GeneralizingAstVisitor
     with AstVisitingSuggestorMixin
     implements Suggestor {
+  final bool noPartialUpgrades;
+
+  SetStateUpdater({this.noPartialUpgrades = false});
+
   @override
   visitMethodInvocation(MethodInvocation node) {
     super.visitMethodInvocation(node);

--- a/lib/src/component2_suggestors/setstate_updater.dart
+++ b/lib/src/component2_suggestors/setstate_updater.dart
@@ -34,7 +34,7 @@ class SetStateUpdater extends GeneralizingAstVisitor
       return ancestor is ClassDeclaration;
     });
 
-    if(noPartialUpgrades && !canBeFullyUpgradedToComponent2(containingClass)) {
+    if (noPartialUpgrades && !canBeFullyUpgradedToComponent2(containingClass)) {
       return;
     }
 

--- a/lib/src/component2_suggestors/setstate_updater.dart
+++ b/lib/src/component2_suggestors/setstate_updater.dart
@@ -34,6 +34,10 @@ class SetStateUpdater extends GeneralizingAstVisitor
       return ancestor is ClassDeclaration;
     });
 
+    if(noPartialUpgrades && !canBeFullyUpgradedToComponent2(containingClass)) {
+      return;
+    }
+
     if (extendsComponent2(containingClass)) {
       if (node.argumentList.arguments.isEmpty) return;
 

--- a/lib/src/executables/component2_upgrade.dart
+++ b/lib/src/executables/component2_upgrade.dart
@@ -21,6 +21,7 @@ import 'package:over_react_codemod/src/component2_suggestors/componentwillmount_
 import 'package:over_react_codemod/src/component2_suggestors/setstate_updater.dart';
 import 'package:over_react_codemod/src/component2_suggestors/copyunconsumeddomprops_migrator.dart';
 
+const _noPartialUpgradesFlag = '--no-partial-upgrades';
 const _changesRequiredOutput = """
 To update your code, switch to Dart 2.1.0 and run the following commands:
   pub global activate over_react_codemod ^1.1.0
@@ -29,6 +30,9 @@ Then, review the the changes, address any FIXMEs, and commit.
 """;
 
 void main(List<String> args) {
+  final noPartialUpgrades = args.contains(_noPartialUpgradesFlag);
+  args.removeWhere((arg) => arg == _noPartialUpgradesFlag);
+
   final query = FileQuery.dir(
     pathFilter: isDartFile,
     recursive: true,
@@ -36,11 +40,11 @@ void main(List<String> args) {
   exitCode = runInteractiveCodemodSequence(
     query,
     [
-      ClassNameAndAnnotationMigrator(),
-      ComponentWillMountMigrator(),
-      SetStateUpdater(),
-      ComponentDidUpdateMigrator(),
-      CopyUnconsumedDomPropsMigrator(),
+      ClassNameAndAnnotationMigrator(noPartialUpgrades: noPartialUpgrades),
+      ComponentWillMountMigrator(noPartialUpgrades: noPartialUpgrades),
+      SetStateUpdater(noPartialUpgrades: noPartialUpgrades),
+      ComponentDidUpdateMigrator(noPartialUpgrades: noPartialUpgrades),
+      CopyUnconsumedDomPropsMigrator(noPartialUpgrades: noPartialUpgrades),
     ],
     args: args,
     defaultYes: true,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ environment:
 dependencies:
   analyzer: '>=0.37.0 <0.39.0'
   args: ^1.5.1
-  codemod: ^0.1.3
+  codemod: ^0.1.5
   meta: ^1.1.6
   path: ^1.6.2
   pub_semver: ^1.4.2
@@ -37,9 +37,3 @@ dev_dependencies:
 executables:
   dart2_upgrade:
   component2_upgrade:
-
-dependency_overrides:
-  codemod:
-    git:
-      url: https://github.com/Workiva/dart_codemod.git
-      ref: master

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
-  analyzer: ^0.33.6+1
+  analyzer: '>=0.37.0 <0.39.0'
   args: ^1.5.1
   codemod: ^0.1.3
   meta: ^1.1.6
@@ -37,3 +37,9 @@ dev_dependencies:
 executables:
   dart2_upgrade:
   component2_upgrade:
+
+dependency_overrides:
+  codemod:
+    git:
+      url: git@github.com:Workiva/dart_codemod.git
+      ref: CPLAT-7009-increase-analyzer-upper-bound

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ authors:
   - Sebastian Malysa <sebastian.malysa@workiva.com>
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.2.0 <3.0.0"
 
 dependencies:
   analyzer: '>=0.37.0 <0.39.0'

--- a/test/component2_suggestors/class_name_and_annotation_migrator_no_partial_upgrades_test.dart
+++ b/test/component2_suggestors/class_name_and_annotation_migrator_no_partial_upgrades_test.dart
@@ -1,0 +1,158 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react_codemod/src/component2_suggestors/class_name_and_annotation_migrator.dart';
+import 'package:test/test.dart';
+
+import '../util.dart';
+
+main() {
+  group('ClassNameAndAnnotationMigrator with --no-partial-upgrades flag', () {
+    final testSuggestor = getSuggestorTester(
+        ClassNameAndAnnotationMigrator(noPartialUpgrades: true));
+
+    test('empty file', () {
+      testSuggestor(expectedPatchCount: 0, input: '');
+    });
+
+    test('no matches', () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
+          library foo;
+          var a = 'b';
+          class Foo {}
+        ''',
+      );
+    });
+
+    test('annotation with non-based extending class updates', () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
+          @Component()
+          class FooComponent extends SomeOtherClass{}
+        ''',
+      );
+    });
+
+    test('annotation and extending class updates', () {
+      testSuggestor(
+        expectedPatchCount: 2,
+        input: '''
+          @Component()
+          class FooComponent extends UiComponent<FooProps>{}
+        ''',
+        expectedOutput: '''
+          @Component2()
+          class FooComponent extends UiComponent2<FooProps>{}
+        ''',
+      );
+    });
+
+    test('extending class only needs updating', () {
+      testSuggestor(
+        expectedPatchCount: 1,
+        input: '''
+          @Component2()
+          class FooComponent extends UiStatefulComponent<FooProps, FooState>{}
+        ''',
+        expectedOutput: '''
+          @Component2()
+          class FooComponent extends UiStatefulComponent2<FooProps, FooState>{}
+        ''',
+      );
+    });
+
+    test('annotation with args and extending class updates', () {
+      testSuggestor(
+        expectedPatchCount: 2,
+        input: '''
+          @Component(isWrapper: true)
+          class FooComponent extends UiComponent<FooProps>{}
+        ''',
+        expectedOutput: '''
+          @Component2(isWrapper: true)
+          class FooComponent extends UiComponent2<FooProps>{}
+        ''',
+      );
+    });
+
+    test('annotation with args and extending stateful class updates', () {
+      testSuggestor(
+        expectedPatchCount: 2,
+        input: '''
+          @Component(isWrapper: true)
+          class FooComponent extends UiStatefulComponent<FooProps, FooState>{}
+        ''',
+        expectedOutput: '''
+          @Component2(isWrapper: true)
+          class FooComponent extends UiStatefulComponent2<FooProps, FooState>{}
+        ''',
+      );
+    });
+
+    test('AbstractComponent class annotation updates', () {
+      testSuggestor(
+        expectedPatchCount: 2,
+        input: '''
+          @AbstractComponent(isWrapper: true)
+          abstract class FooComponent extends UiStatefulComponent<FooProps, FooState>{}
+        ''',
+        expectedOutput: '''
+          @AbstractComponent2(isWrapper: true)
+          abstract class FooComponent extends UiStatefulComponent2<FooProps, FooState>{}
+        ''',
+      );
+    });
+
+    test('extending class imported from react.dart updates', () {
+      testSuggestor(
+        expectedPatchCount: 2,
+        input: '''
+          import 'package:react/react.dart' as react show Component;
+          import 'package:react/react_dom.dart' as react_dom;
+
+          class FooComponent extends react.Component{}
+        ''',
+        expectedOutput: '''
+          import 'package:react/react.dart' as react show Component, Component2;
+          import 'package:react/react_dom.dart' as react_dom;
+
+          class FooComponent extends react.Component2{}
+        ''',
+      );
+    });
+
+    test(
+        'extending class imported from react.dart with different import name updates',
+        () {
+      testSuggestor(
+        expectedPatchCount: 1,
+        input: '''
+          import "package:react/react_dom.dart" as react_dom;
+          import "package:react/react.dart" as foo;
+
+          class FooComponent extends foo.Component{}
+        ''',
+        expectedOutput: '''
+          import "package:react/react_dom.dart" as react_dom;
+          import "package:react/react.dart" as foo;
+
+          class FooComponent extends foo.Component2{}
+        ''',
+      );
+    });
+  });
+}

--- a/test/component2_suggestors/class_name_and_annotation_migrator_test.dart
+++ b/test/component2_suggestors/class_name_and_annotation_migrator_test.dart
@@ -41,11 +41,11 @@ main() {
         expectedPatchCount: 1,
         input: '''
           @Component()
-          class FooComponent extends SomeOtherClass{}
+          class FooComponent extends AbstractComponent {}
         ''',
         expectedOutput: '''
           @Component2()
-          class FooComponent extends SomeOtherClass{}
+          class FooComponent extends AbstractComponent{}
         ''',
       );
     });
@@ -55,11 +55,59 @@ main() {
         expectedPatchCount: 2,
         input: '''
           @Component()
-          class FooComponent extends UiComponent<FooProps>{}
+          class FooComponent extends UiComponent<FooProps> {
+            eventHandler() {
+              // method body
+            }
+            
+            @override
+            componentWillMount() {
+              // method body
+            }
+            
+            @override
+            render() {
+              // method body
+            }
+            
+            @override
+            componentDidUpdate(Map prevProps, Map prevState) {
+              // method body
+            }
+            
+            @override
+            componentWillUnmount() {
+              // method body
+            }
+          }
         ''',
         expectedOutput: '''
           @Component2()
-          class FooComponent extends UiComponent2<FooProps>{}
+          class FooComponent extends UiComponent2<FooProps> {
+            eventHandler() {
+              // method body
+            }
+            
+            @override
+            componentWillMount() {
+              // method body
+            }
+            
+            @override
+            render() {
+              // method body
+            }
+            
+            @override
+            componentDidUpdate(Map prevProps, Map prevState) {
+              // method body
+            }
+            
+            @override
+            componentWillUnmount() {
+              // method body
+            }
+          }
         ''',
       );
     });
@@ -69,11 +117,31 @@ main() {
         expectedPatchCount: 1,
         input: '''
           @Component2()
-          class FooComponent extends UiStatefulComponent<FooProps, FooState>{}
+          class FooComponent extends UiStatefulComponent<FooProps, FooState> {
+            @override
+            shouldComponentUpdate() {
+              // method body
+            }
+            
+            @override
+            render() {
+              // method body
+            }
+          }
         ''',
         expectedOutput: '''
           @Component2()
-          class FooComponent extends UiStatefulComponent2<FooProps, FooState>{}
+          class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+            @override
+            shouldComponentUpdate() {
+              // method body
+            }
+            
+            @override
+            render() {
+              // method body
+            }
+          }
         ''',
       );
     });
@@ -83,39 +151,66 @@ main() {
         expectedPatchCount: 2,
         input: '''
           @Component(isWrapper: true)
-          class FooComponent extends UiComponent<FooProps>{}
+          class FooComponent extends UiComponent<FooProps> {
+            @override
+            componentWillMount() {
+              // method body
+            }
+            
+            @override
+            componentDidMount() {
+              // method body
+            }
+          }
         ''',
         expectedOutput: '''
           @Component2(isWrapper: true)
-          class FooComponent extends UiComponent2<FooProps>{}
+          class FooComponent extends UiComponent2<FooProps> {
+            @override
+            componentWillMount() {
+              // method body
+            }
+            
+            @override
+            componentDidMount() {
+              // method body
+            }
+          }
         ''',
       );
     });
 
-    test('annotation with args and extending stateful class updates', () {
-      testSuggestor(
-        expectedPatchCount: 2,
-        input: '''
-          @Component(isWrapper: true)
-          class FooComponent extends UiStatefulComponent<FooProps, FooState>{}
-        ''',
-        expectedOutput: '''
-          @Component2(isWrapper: true)
-          class FooComponent extends UiStatefulComponent2<FooProps, FooState>{}
-        ''',
-      );
-    });
-
-    test('AbstractComponent class annotation updates', () {
+    test('AbstractComponent annotation and extending stateful class updates',
+        () {
       testSuggestor(
         expectedPatchCount: 2,
         input: '''
           @AbstractComponent(isWrapper: true)
-          abstract class FooComponent extends UiStatefulComponent<FooProps, FooState>{}
+          abstract class AbstractFooComponent extends UiStatefulComponent {
+            @override
+            componentWillMount() {
+              // method body
+            }
+
+            @override
+            shouldComponentUpdate() {
+              // method body
+            }
+          }
         ''',
         expectedOutput: '''
           @AbstractComponent2(isWrapper: true)
-          abstract class FooComponent extends UiStatefulComponent2<FooProps, FooState>{}
+          abstract class AbstractFooComponent extends UiStatefulComponent2 {
+            @override
+            componentWillMount() {
+              // method body
+            }
+
+            @override
+            shouldComponentUpdate() {
+              // method body
+            }
+          }
         ''',
       );
     });
@@ -127,13 +222,33 @@ main() {
           import 'package:react/react.dart' as react show Component;
           import 'package:react/react_dom.dart' as react_dom;
         
-          class FooComponent extends react.Component{}
+          class FooComponent extends react.Component {
+            @override
+            componentDidUpdate(Map prevProps, Map prevState) {
+              // method body
+            }
+            
+            @override
+            componentWillReceiveProps() {
+              // method body
+            }
+          }
         ''',
         expectedOutput: '''
           import 'package:react/react.dart' as react show Component, Component2;
           import 'package:react/react_dom.dart' as react_dom;
 
-          class FooComponent extends react.Component2{}
+          class FooComponent extends react.Component2 {
+            @override
+            componentDidUpdate(Map prevProps, Map prevState) {
+              // method body
+            }
+            
+            @override
+            componentWillReceiveProps() {
+              // method body
+            }
+          }
         ''',
       );
     });
@@ -147,13 +262,42 @@ main() {
           import "package:react/react_dom.dart" as react_dom;
           import "package:react/react.dart" as foo;
         
-          class FooComponent extends foo.Component{}
+          class FooComponent extends foo.Component {}
         ''',
         expectedOutput: '''
           import "package:react/react_dom.dart" as react_dom;
           import "package:react/react.dart" as foo;
 
-          class FooComponent extends foo.Component2{}
+          class FooComponent extends foo.Component2 {}
+        ''',
+      );
+    });
+
+    test('already updated annotation and extending class does not update', () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
+          @Component2
+          class FooComponent extends UiComponent2 {
+            eventHandler() {
+              // method body
+            }
+            
+            @override
+            init() {
+              // method body
+            }
+            
+            @override
+            render() {
+              // method body
+            }
+            
+            @override
+            componentDidUpdate(Map prevProps, Map prevState, [snapshot]) {
+              // method body
+            }
+          }
         ''',
       );
     });

--- a/test/component2_suggestors/component2_utilities_test.dart
+++ b/test/component2_suggestors/component2_utilities_test.dart
@@ -248,6 +248,126 @@ void main() {
         });
       });
     });
+
+    group('canBeFullyUpgradedToComponent2()', () {
+      group('(fully upgradable) when a class extends UiComponent', () {
+        group('and has no lifecycle methods', () {
+          final input = '''
+            @Component
+            class FooComponent extends UiComponent {
+              // class body
+            }
+          ''';
+
+          testUtilityFunction(
+            input: input,
+            expectedValue: true,
+            functionToTest: canBeFullyUpgradedToComponent2,
+          );
+        });
+
+        group('and contains lifecycle methods that are all updated by codemods',
+            () {
+          final input = '''
+            @Component
+            class FooComponent extends UiComponent {
+              @override
+              componentWillMount() {
+                // method body
+              }
+              
+              @override
+              render() {
+                // method body
+              }
+              
+              @override
+              componentDidUpdate() {
+                // method body
+              }
+            }
+          ''';
+
+          testUtilityFunction(
+            input: input,
+            expectedValue: true,
+            functionToTest: canBeFullyUpgradedToComponent2,
+          );
+        });
+
+        group('and contains non-lifecycle methods', () {
+          final input = '''
+            @Component
+            class FooComponent extends UiComponent {
+              eventHander() {
+                // method body
+              }
+              
+              @override
+              render() {
+                // method body
+              }
+            }
+          ''';
+
+          testUtilityFunction(
+            input: input,
+            expectedValue: true,
+            functionToTest: canBeFullyUpgradedToComponent2,
+          );
+        });
+      });
+
+      group('(not fully upgradable) when a class', () {
+        group('extends non-Component/Component2 classes', () {
+          final input = '''
+            @Component
+            class FooComponent extends AbstractFooComponent {
+              // class body
+            }
+          ''';
+
+          testUtilityFunction(
+            input: input,
+            expectedValue: false,
+            functionToTest: canBeFullyUpgradedToComponent2,
+          );
+        });
+
+        group('contains a lifecycle method not updated by a codemod', () {
+          final input = '''
+            @Component
+            class FooComponent extends UiComponent {
+              @override
+              componentWillMount() {
+                // method body
+              }
+              
+              @override
+              render() {
+                // method body
+              }
+              
+              @override
+              componentDidUpdate() {
+                // method body
+              }
+              
+              @override
+              componentWillUnmount() {
+              
+              }
+            }
+          ''';
+
+          testUtilityFunction(
+            input: input,
+            expectedValue: false,
+            functionToTest: canBeFullyUpgradedToComponent2,
+          );
+        });
+      });
+    });
   });
 }
 

--- a/test/component2_suggestors/component2_utilities_test.dart
+++ b/test/component2_suggestors/component2_utilities_test.dart
@@ -90,7 +90,10 @@ void main() {
             }
           ''';
 
-          testExtendsComponent2(input: input, expectedValue: true);
+          testUtilityFunction(
+              input: input,
+              expectedValue: true,
+              functionToTest: extendsComponent2);
         });
 
         group('extends UiStatefulComponent2,', () {
@@ -101,7 +104,11 @@ void main() {
             }
           ''';
 
-          testExtendsComponent2(input: input, expectedValue: true);
+          testUtilityFunction(
+            input: input,
+            expectedValue: true,
+            functionToTest: extendsComponent2,
+          );
         });
 
         group('extends react.Component2,', () {
@@ -113,7 +120,10 @@ void main() {
             }
           ''';
 
-          testExtendsComponent2(input: input, expectedValue: true);
+          testUtilityFunction(
+              input: input,
+              expectedValue: true,
+              functionToTest: extendsComponent2);
         });
 
         group('has the @Component2 annotation,', () {
@@ -124,7 +134,10 @@ void main() {
             }
           ''';
 
-          testExtendsComponent2(input: input, expectedValue: true);
+          testUtilityFunction(
+              input: input,
+              expectedValue: true,
+              functionToTest: extendsComponent2);
         });
 
         group('has the @AbstractComponent2 annotation,', () {
@@ -135,7 +148,11 @@ void main() {
             }
           ''';
 
-          testExtendsComponent2(input: input, expectedValue: true);
+          testUtilityFunction(
+            input: input,
+            expectedValue: true,
+            functionToTest: extendsComponent2,
+          );
         });
       });
 
@@ -148,7 +165,11 @@ void main() {
             }
           ''';
 
-          testExtendsComponent2(input: input, expectedValue: false);
+          testUtilityFunction(
+            input: input,
+            expectedValue: false,
+            functionToTest: extendsComponent2,
+          );
         });
 
         group('extends UiStatefulComponent,', () {
@@ -159,7 +180,11 @@ void main() {
             }
           ''';
 
-          testExtendsComponent2(input: input, expectedValue: false);
+          testUtilityFunction(
+            input: input,
+            expectedValue: false,
+            functionToTest: extendsComponent2,
+          );
         });
 
         group('extends react.Component,', () {
@@ -171,7 +196,11 @@ void main() {
             }
           ''';
 
-          testExtendsComponent2(input: input, expectedValue: false);
+          testUtilityFunction(
+            input: input,
+            expectedValue: false,
+            functionToTest: extendsComponent2,
+          );
         });
 
         group('has the @Component annotation,', () {
@@ -182,7 +211,11 @@ void main() {
             }
           ''';
 
-          testExtendsComponent2(input: input, expectedValue: false);
+          testUtilityFunction(
+            input: input,
+            expectedValue: false,
+            functionToTest: extendsComponent2,
+          );
         });
 
         group('has the @AbstractComponent annotation,', () {
@@ -193,7 +226,11 @@ void main() {
             }
           ''';
 
-          testExtendsComponent2(input: input, expectedValue: false);
+          testUtilityFunction(
+            input: input,
+            expectedValue: false,
+            functionToTest: extendsComponent2,
+          );
         });
 
         group('extends nothing', () {
@@ -203,23 +240,31 @@ void main() {
             }
           ''';
 
-          testExtendsComponent2(input: input, expectedValue: false);
+          testUtilityFunction(
+            input: input,
+            expectedValue: false,
+            functionToTest: extendsComponent2,
+          );
         });
       });
     });
   });
 }
 
-void testExtendsComponent2({String input, bool expectedValue}) {
+void testUtilityFunction({
+  String input,
+  bool expectedValue,
+  bool Function(ClassDeclaration) functionToTest,
+}) {
   test('returns $expectedValue', () {
     CompilationUnit unit = parseCompilationUnit(input);
     expect(unit.declarations.whereType<ClassDeclaration>().length, 1);
 
     unit.declarations.whereType<ClassDeclaration>().forEach((classNode) {
       if (expectedValue) {
-        expect(extendsComponent2(classNode), isTrue);
+        expect(functionToTest(classNode), isTrue);
       } else {
-        expect(extendsComponent2(classNode), isFalse);
+        expect(functionToTest(classNode), isFalse);
       }
     });
   });

--- a/test/component2_suggestors/component2_utilities_test.dart
+++ b/test/component2_suggestors/component2_utilities_test.dart
@@ -385,7 +385,7 @@ void main() {
               
               @override
               componentWillUnmount() {
-              
+                // method body
               }
             }
           ''';

--- a/test/component2_suggestors/component2_utilities_test.dart
+++ b/test/component2_suggestors/component2_utilities_test.dart
@@ -250,8 +250,8 @@ void main() {
     });
 
     group('canBeFullyUpgradedToComponent2()', () {
-      group('(fully upgradable) when a class extends UiComponent', () {
-        group('and has no lifecycle methods', () {
+      group('(fully upgradable) when a class', () {
+        group('extends UiComponent and has no lifecycle methods', () {
           final input = '''
             @Component
             class FooComponent extends UiComponent {
@@ -266,11 +266,12 @@ void main() {
           );
         });
 
-        group('and contains lifecycle methods that are all updated by codemods',
+        group(
+            'extends UiStatefulComponent and contains lifecycle methods that are all updated by codemods',
             () {
           final input = '''
             @Component
-            class FooComponent extends UiComponent {
+            class FooComponent extends UiStatefulComponent {
               @override
               componentWillMount() {
                 // method body
@@ -282,7 +283,7 @@ void main() {
               }
               
               @override
-              componentDidUpdate() {
+              componentDidUpdate(Map prevProps, Map prevState) {
                 // method body
               }
             }
@@ -295,7 +296,7 @@ void main() {
           );
         });
 
-        group('and contains non-lifecycle methods', () {
+        group('extends UiComponent and contains non-lifecycle methods', () {
           final input = '''
             @Component
             class FooComponent extends UiComponent {
@@ -305,6 +306,34 @@ void main() {
               
               @override
               render() {
+                // method body
+              }
+            }
+          ''';
+
+          testUtilityFunction(
+            input: input,
+            expectedValue: true,
+            functionToTest: canBeFullyUpgradedToComponent2,
+          );
+        });
+
+        group('is already upgraded to Component2', () {
+          final input = '''
+            @Component2
+            class FooComponent extends UiComponent2 {
+              @override
+              init() {
+                // method body
+              }
+              
+              @override
+              render() {
+                // method body
+              }
+              
+              @override
+              componentDidUpdate(Map prevProps, Map prevState, [snapshot]) {
                 // method body
               }
             }
@@ -349,7 +378,7 @@ void main() {
               }
               
               @override
-              componentDidUpdate() {
+              componentDidUpdate(Map prevProps, Map prevState) {
                 // method body
               }
               

--- a/test/component2_suggestors/componentdidupdate_migrator_no_partial_upgrades_test.dart
+++ b/test/component2_suggestors/componentdidupdate_migrator_no_partial_upgrades_test.dart
@@ -1,0 +1,91 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react_codemod/src/component2_suggestors/componentdidupdate_migrator.dart';
+import 'package:test/test.dart';
+
+import '../util.dart';
+
+main() {
+  group('ComponentDidUpdateMigrator', () {
+    final testSuggestor =
+        getSuggestorTester(ComponentDidUpdateMigrator(noPartialUpgrades: true));
+
+    test('empty file', () {
+      testSuggestor(expectedPatchCount: 0, input: '');
+    });
+
+    test('no matches', () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
+          library foo;
+          var a = 'b';
+          class Foo {}
+        ''',
+      );
+    });
+
+    test('componentDidUpdate method updates', () {
+      testSuggestor(
+        expectedPatchCount: 1,
+        input: '''
+          @Component2()
+          class FooComponent extends UiComponent2 {
+              componentDidUpdate(Map prevProps, Map prevState) {
+                  // method body
+              }
+          }
+        ''',
+        expectedOutput: '''
+          @Component2()
+          class FooComponent extends UiComponent2 {
+              componentDidUpdate(Map prevProps, Map prevState, [snapshot]) {
+                // method body
+              }
+          }
+        ''',
+      );
+    });
+
+    test('componentDidUpdate does not update if optional third argument exists',
+        () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
+          @Component2()
+          class FooComponent extends UiComponent2 {
+              componentDidUpdate(Map prevProps, Map prevState, [_]) {
+                  // method body
+              }
+          }
+        ''',
+      );
+    });
+
+    test('does not change componentDidUpdate for non-component2 classes', () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
+          @Component()
+          class FooComponent extends UiComponent {
+            componentDidUpdate(Map prevProps, Map prevState) {
+                  // method body
+            }
+          }
+        ''',
+      );
+    });
+  });
+}

--- a/test/component2_suggestors/componentdidupdate_migrator_no_partial_upgrades_test.dart
+++ b/test/component2_suggestors/componentdidupdate_migrator_no_partial_upgrades_test.dart
@@ -38,7 +38,7 @@ main() {
     });
 
     group('componentDidUpdate method', () {
-      test('updates if containing class is fully upgradeable', () {
+      test('updates if containing class is fully upgradable', () {
         testSuggestor(
           expectedPatchCount: 1,
           input: '''

--- a/test/component2_suggestors/componentdidupdate_migrator_test.dart
+++ b/test/component2_suggestors/componentdidupdate_migrator_test.dart
@@ -36,26 +36,50 @@ main() {
       );
     });
 
-    test('componentDidUpdate method updates', () {
-      testSuggestor(
-        expectedPatchCount: 1,
-        input: '''
-          @Component2()
-          class FooComponent extends UiComponent2 {
+    group('componentDidUpdate method updates', () {
+      test('when containing class extends from Component2 class', () {
+        testSuggestor(
+          expectedPatchCount: 1,
+          input: '''
+            @Component2()
+            class FooComponent extends UiComponent2 {
               componentDidUpdate(Map prevProps, Map prevState) {
-                  // method body
+                // method body
               }
-          }
-        ''',
-        expectedOutput: '''
-          @Component2()
-          class FooComponent extends UiComponent2 {
+            }
+          ''',
+          expectedOutput: '''
+            @Component2()
+            class FooComponent extends UiComponent2 {
               componentDidUpdate(Map prevProps, Map prevState, [snapshot]) {
                 // method body
               }
-          }
-        ''',
-      );
+            }
+          ''',
+        );
+      });
+
+      test('when containing class has @Component2 annotation', () {
+        testSuggestor(
+          expectedPatchCount: 1,
+          input: '''
+            @Component2()
+            class FooComponent extends AbstractComponent {
+              componentDidUpdate(Map prevProps, Map prevState) {
+                // method body
+              }
+            }
+          ''',
+          expectedOutput: '''
+            @Component2()
+            class FooComponent extends AbstractComponent {
+              componentDidUpdate(Map prevProps, Map prevState, [snapshot]) {
+                // method body
+              }
+            }
+          ''',
+        );
+      });
     });
 
     test('componentDidUpdate does not update if optional third argument exists',
@@ -65,9 +89,9 @@ main() {
         input: '''
           @Component2()
           class FooComponent extends UiComponent2 {
-              componentDidUpdate(Map prevProps, Map prevState, [_]) {
-                  // method body
-              }
+            componentDidUpdate(Map prevProps, Map prevState, [_]) {
+              // method body
+            }
           }
         ''',
       );
@@ -80,7 +104,7 @@ main() {
           @Component()
           class FooComponent extends UiComponent {
             componentDidUpdate(Map prevProps, Map prevState) {
-                  // method body
+              // method body
             }
           }
         ''',

--- a/test/component2_suggestors/componentdidupdate_migrator_test.dart
+++ b/test/component2_suggestors/componentdidupdate_migrator_test.dart
@@ -46,12 +46,22 @@ main() {
               componentDidUpdate(Map prevProps, Map prevState) {
                 // method body
               }
+              
+              @override
+              componentWillUnmount() {
+                // method body
+              }
             }
           ''',
           expectedOutput: '''
             @Component2()
             class FooComponent extends UiComponent2 {
               componentDidUpdate(Map prevProps, Map prevState, [snapshot]) {
+                // method body
+              }
+              
+              @override
+              componentWillUnmount() {
                 // method body
               }
             }

--- a/test/component2_suggestors/componentwillmount_migrator_no_partial_upgrades_test.dart
+++ b/test/component2_suggestors/componentwillmount_migrator_no_partial_upgrades_test.dart
@@ -1,0 +1,125 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react_codemod/src/component2_suggestors/componentwillmount_migrator.dart';
+import 'package:test/test.dart';
+
+import '../util.dart';
+
+main() {
+  group('ComponentWillMountMigrator', () {
+    final testSuggestor =
+        getSuggestorTester(ComponentWillMountMigrator(noPartialUpgrades: true));
+
+    test('empty file', () {
+      testSuggestor(expectedPatchCount: 0, input: '');
+    });
+
+    test('no matches', () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
+          library foo;
+          var a = 'b';
+          class Foo {}
+        ''',
+      );
+    });
+
+    test('componentWillMount method updates', () {
+      testSuggestor(
+        expectedPatchCount: 1,
+        input: '''
+          @Component2()
+          class FooComponent extends UiComponent2 {
+              componentWillMount(){
+                  // method body
+              }
+          }
+        ''',
+        expectedOutput: '''
+          @Component2()
+          class FooComponent extends UiComponent2 {
+              init(){
+                  // method body
+              }
+          }
+        ''',
+      );
+    });
+
+    test('componentWillMount method with return type updates', () {
+      testSuggestor(
+        expectedPatchCount: 1,
+        input: '''
+          import 'package:react/react.dart' as react;
+
+          @Component2()
+          class FooComponent extends react.Component2 {
+              void componentWillMount(){
+                  // method body
+              }
+          }
+        ''',
+        expectedOutput: '''
+          import 'package:react/react.dart' as react;
+
+          @Component2()
+          class FooComponent extends react.Component2 {
+              void init(){
+                  // method body
+              }
+          }
+        ''',
+      );
+    });
+
+    test('remove super calls to componentWillMount', () {
+      testSuggestor(
+        expectedPatchCount: 2,
+        input: '''
+          @Component2()
+          class FooComponent extends UiComponent2 {
+              void componentWillMount(){
+                  super.componentWillMount();
+                  // method body
+              }
+          }
+        ''',
+        expectedOutput: '''
+          @Component2()
+          class FooComponent extends UiComponent2 {
+              void init(){
+                  // method body
+              }
+          }
+        ''',
+      );
+    });
+
+    test('does not change componentWillMount for non-component2 classes', () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
+          @Component()
+          class FooComponent extends UiComponent {
+              void componentWillMount(){
+                  // method body
+              }
+          }
+        ''',
+      );
+    });
+  });
+}

--- a/test/component2_suggestors/componentwillmount_migrator_no_partial_upgrades_test.dart
+++ b/test/component2_suggestors/componentwillmount_migrator_no_partial_upgrades_test.dart
@@ -49,7 +49,7 @@ main() {
               }
             }
           ''',
-            expectedOutput: '''
+          expectedOutput: '''
             @Component2()
             class FooComponent extends UiComponent2 {
               init(){
@@ -135,7 +135,7 @@ main() {
               }
             }
           ''',
-            expectedOutput: '''
+          expectedOutput: '''
             @Component2()
             class FooComponent extends UiComponent2 {
               void init(){

--- a/test/component2_suggestors/componentwillmount_migrator_test.dart
+++ b/test/component2_suggestors/componentwillmount_migrator_test.dart
@@ -42,17 +42,27 @@ main() {
         input: '''
           @Component2()
           class FooComponent extends UiComponent2 {
-              componentWillMount(){
-                  // method body
-              }
+            componentWillMount(){
+              // method body
+            }
+            
+            @override
+            componentWillUnmount() {
+              // method body
+            }
           }
         ''',
         expectedOutput: '''
           @Component2()
           class FooComponent extends UiComponent2 {
-              init(){
-                  // method body
-              }
+            init(){
+              // method body
+            }
+            
+            @override
+            componentWillUnmount() {
+              // method body
+            }
           }
         ''',
       );
@@ -66,9 +76,9 @@ main() {
           
           @Component2()
           class FooComponent extends react.Component2 {
-              void componentWillMount(){
-                  // method body
-              }
+            void componentWillMount(){
+              // method body
+            }
           }
         ''',
         expectedOutput: '''
@@ -76,9 +86,9 @@ main() {
           
           @Component2()
           class FooComponent extends react.Component2 {
-              void init(){
-                  // method body
-              }
+            void init(){
+              // method body
+            }
           }
         ''',
       );
@@ -90,18 +100,28 @@ main() {
         input: '''
           @Component2()
           class FooComponent extends UiComponent2 {
-              void componentWillMount(){
-                  super.componentWillMount();
-                  // method body
-              }
+            void componentWillMount(){
+              super.componentWillMount();
+              // method body
+            }
+            
+            @override
+            componentWillUnmount() {
+              // method body
+            }
           }
         ''',
         expectedOutput: '''
           @Component2()
           class FooComponent extends UiComponent2 {
-              void init(){
-                  // method body
-              }
+            void init(){
+              // method body
+            }
+            
+            @override
+            componentWillUnmount() {
+              // method body
+            }
           }
         ''',
       );
@@ -113,9 +133,9 @@ main() {
         input: '''
           @Component()
           class FooComponent extends UiComponent {
-              void componentWillMount(){
-                  // method body
-              }
+            void componentWillMount(){
+              // method body
+            }
           }
         ''',
       );

--- a/test/component2_suggestors/copyunconsumeddomprops_migrator_no_partial_upgrades_test.dart
+++ b/test/component2_suggestors/copyunconsumeddomprops_migrator_no_partial_upgrades_test.dart
@@ -1,0 +1,117 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react_codemod/src/component2_suggestors/copyunconsumeddomprops_migrator.dart';
+import 'package:test/test.dart';
+
+import '../util.dart';
+
+main() {
+  group('CopyUnconsumedDomPropsMigrator', () {
+    final testSuggestor = getSuggestorTester(
+        CopyUnconsumedDomPropsMigrator(noPartialUpgrades: true));
+
+    test('empty file', () {
+      testSuggestor(expectedPatchCount: 0, input: '');
+    });
+
+    test('no matches', () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
+          library foo;
+          var a = 'b';
+          class Foo {}
+        ''',
+      );
+    });
+
+    test('copyUnconsumedDomProps updates', () {
+      testSuggestor(
+        expectedPatchCount: 2,
+        input: '''
+          @Component2()
+          class FooComponent extends UiComponent2<FooProps> {
+            @override
+            render() {
+              return (Dom.span()
+                ..addProps(copyUnconsumedDomProps())
+              )(props.children);
+            }
+          }
+        ''',
+        expectedOutput: '''
+          @Component2()
+          class FooComponent extends UiComponent2<FooProps> {
+            @override
+            render() {
+              return (Dom.span()
+                ..modifyProps(addUnconsumedDomProps)
+              )(props.children);
+            }
+          }
+        ''',
+      );
+    });
+
+    test('copyUnconsumedProps updates', () {
+      testSuggestor(
+        expectedPatchCount: 2,
+        input: '''
+          import 'package:react/react.dart' as react;
+
+          @Component2()
+          class FooComponent extends react.Component2 {
+            @override
+            render() {
+              return (Dom.span()
+                ..addProps(copyUnconsumedProps())
+              )(props.children);
+            }
+          }
+        ''',
+        expectedOutput: '''
+          import 'package:react/react.dart' as react;
+
+          @Component2()
+          class FooComponent extends react.Component2 {
+            @override
+            render() {
+              return (Dom.span()
+                ..modifyProps(addUnconsumedProps)
+              )(props.children);
+            }
+          }
+        ''',
+      );
+    });
+
+    test('does not change copyUnconsumedProps for non-component2 classes', () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
+          @Component()
+          class FooComponent extends UiComponent {
+            @override
+            render() {
+              return (Dom.span()
+                ..addProps(copyUnconsumedDomProps())
+              )(props.children);
+            }
+          }
+        ''',
+      );
+    });
+  });
+}

--- a/test/component2_suggestors/copyunconsumeddomprops_migrator_test.dart
+++ b/test/component2_suggestors/copyunconsumeddomprops_migrator_test.dart
@@ -48,6 +48,11 @@ main() {
                 ..addProps(copyUnconsumedDomProps())
               )(props.children);
             }
+            
+            @override
+            componentWillUnmount() {
+              // method body
+            }
           }
         ''',
         expectedOutput: '''
@@ -58,6 +63,11 @@ main() {
               return (Dom.span()
                 ..modifyProps(addUnconsumedDomProps)
               )(props.children);
+            }
+            
+            @override
+            componentWillUnmount() {
+              // method body
             }
           }
         ''',
@@ -78,6 +88,11 @@ main() {
                 ..addProps(copyUnconsumedProps())
               )(props.children);
             }
+            
+            @override
+            componentWillUnmount() {
+              // method body
+            }
           }
         ''',
         expectedOutput: '''
@@ -90,6 +105,11 @@ main() {
               return (Dom.span()
                 ..modifyProps(addUnconsumedProps)
               )(props.children);
+            }
+            
+            @override
+            componentWillUnmount() {
+              // method body
             }
           }
         ''',

--- a/test/component2_suggestors/deprecated_lifecycle_suggestor_no_partial_upgrades_test.dart
+++ b/test/component2_suggestors/deprecated_lifecycle_suggestor_no_partial_upgrades_test.dart
@@ -37,79 +37,74 @@ main() {
       );
     });
 
-    test('does not add a FIXME comment for componentWillUpdate with override',
-        () {
-      testSuggestor(
-        expectedPatchCount: 0,
-        input: '''
-          @Component2()
-          class FooComponent extends UiComponent2 {
+    group('does not add a FIXME comment', () {
+      test('for componentWillUpdate with override', () {
+        testSuggestor(
+          expectedPatchCount: 0,
+          input: '''
+            @Component2()
+            class FooComponent extends UiComponent2 {
               @override
               componentWillUpdate(){}
-          }
-        ''',
-      );
-    });
+            }
+          ''',
+        );
+      });
 
-    test(
-        'does not add a FIXME comment for componentWillUpdate without override',
-        () {
-      testSuggestor(
-        expectedPatchCount: 0,
-        input: '''
-          @Component2()
-          class FooComponent extends UiComponent2 {
+      test('componentWillUpdate without override', () {
+        testSuggestor(
+          expectedPatchCount: 0,
+          input: '''
+            @Component2()
+            class FooComponent extends UiComponent2 {
               componentWillUpdate(){}
-          }
-        ''',
-      );
-    });
+            }
+          ''',
+        );
+      });
 
-    test(
-        'does not add a FIXME comment for componentWillReceiveProps with override',
-        () {
-      testSuggestor(
-        expectedPatchCount: 0,
-        input: '''
-          @Component2()
-          class FooComponent extends UiComponent2 {
+      test('componentWillReceiveProps with override', () {
+        testSuggestor(
+          expectedPatchCount: 0,
+          input: '''
+            @Component2()
+            class FooComponent extends UiComponent2 {
               @override
               componentWillReceiveProps(){}
-          }
-        ''',
-      );
-    });
+            }
+          ''',
+        );
+      });
 
-    test(
-        'does not add a FIXME comment for componentWillReceiveProps without override',
-        () {
-      testSuggestor(
-        expectedPatchCount: 0,
-        input: '''
-          @Component2()
-          class FooComponent extends UiComponent2 {
+      test('componentWillReceiveProps without override', () {
+        testSuggestor(
+          expectedPatchCount: 0,
+          input: '''
+            @Component2()
+            class FooComponent extends UiComponent2 {
               componentWillReceiveProps(){}
-          }
-        ''',
-      );
-    });
+            }
+          ''',
+        );
+      });
 
-    test(
-        'does not add two FIXME comments when both componentWillUpdate and '
-        'componentWillReceiveProps is present', () {
-      testSuggestor(
-        expectedPatchCount: 0,
-        input: '''
-          @Component2()
-          class FooComponent extends UiComponent2 {
+      test(
+          'when both componentWillUpdate and componentWillReceiveProps is present',
+          () {
+        testSuggestor(
+          expectedPatchCount: 0,
+          input: '''
+            @Component2()
+            class FooComponent extends UiComponent2 {
               @override
               componentWillUpdate(){}
-
+              
               @override
               componentWillReceiveProps(){}
-          }
-        ''',
-      );
+            }
+          ''',
+        );
+      });
     });
   });
 }

--- a/test/component2_suggestors/deprecated_lifecycle_suggestor_no_partial_upgrades_test.dart
+++ b/test/component2_suggestors/deprecated_lifecycle_suggestor_no_partial_upgrades_test.dart
@@ -1,0 +1,115 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react_codemod/src/component2_suggestors/deprecated_lifecycle_suggestor.dart';
+import 'package:test/test.dart';
+
+import '../util.dart';
+
+main() {
+  group('DeprecatedLifecycleSuggestor with --no-partial-upgrades flag', () {
+    final testSuggestor = getSuggestorTester(
+        DeprecatedLifecycleSuggestor(noPartialUpgrades: true));
+
+    test('empty file', () {
+      testSuggestor(expectedPatchCount: 0, input: '');
+    });
+
+    test('no matches', () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
+          library foo;
+          var a = 'b';
+          class Foo {}
+        ''',
+      );
+    });
+
+    test('does not add a FIXME comment for componentWillUpdate with override',
+        () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
+          @Component2()
+          class FooComponent extends UiComponent2 {
+              @override
+              componentWillUpdate(){}
+          }
+        ''',
+      );
+    });
+
+    test(
+        'does not add a FIXME comment for componentWillUpdate without override',
+        () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
+          @Component2()
+          class FooComponent extends UiComponent2 {
+              componentWillUpdate(){}
+          }
+        ''',
+      );
+    });
+
+    test(
+        'does not add a FIXME comment for componentWillReceiveProps with override',
+        () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
+          @Component2()
+          class FooComponent extends UiComponent2 {
+              @override
+              componentWillReceiveProps(){}
+          }
+        ''',
+      );
+    });
+
+    test(
+        'does not add a FIXME comment for componentWillReceiveProps without override',
+        () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
+          @Component2()
+          class FooComponent extends UiComponent2 {
+              componentWillReceiveProps(){}
+          }
+        ''',
+      );
+    });
+
+    test(
+        'does not add two FIXME comments when both componentWillUpdate and '
+        'componentWillReceiveProps is present', () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
+          @Component2()
+          class FooComponent extends UiComponent2 {
+              @override
+              componentWillUpdate(){}
+
+              @override
+              componentWillReceiveProps(){}
+          }
+        ''',
+      );
+    });
+  });
+}

--- a/test/component2_suggestors/deprecated_lifecycle_suggestor_test.dart
+++ b/test/component2_suggestors/deprecated_lifecycle_suggestor_test.dart
@@ -43,16 +43,16 @@ main() {
         input: '''
           @Component2()
           class FooComponent extends UiComponent2 {
-              @override
-              componentWillUpdate(){}
+            @override
+            componentWillUpdate(){}
           }
         ''',
         expectedOutput: '''
           @Component2()
           class FooComponent extends UiComponent2 {
-              ${getDeperecationMessage('componentWillUpdate')}
-              @override
-              componentWillUpdate(){}
+            ${getDeperecationMessage('componentWillUpdate')}
+            @override
+            componentWillUpdate(){}
           }
         ''',
       );
@@ -64,14 +64,14 @@ main() {
         input: '''
           @Component2()
           class FooComponent extends UiComponent2 {
-              componentWillUpdate(){}
+            componentWillUpdate(){}
           }
         ''',
         expectedOutput: '''
           @Component2()
           class FooComponent extends UiComponent2 {
-              ${getDeperecationMessage('componentWillUpdate')}
-              componentWillUpdate(){}
+            ${getDeperecationMessage('componentWillUpdate')}
+            componentWillUpdate(){}
           }
         ''',
       );
@@ -84,16 +84,16 @@ main() {
         input: '''
           @Component2()
           class FooComponent extends UiComponent2 {
-              @override
-              componentWillReceiveProps(){}
+            @override
+            componentWillReceiveProps(){}
           }
         ''',
         expectedOutput: '''
           @Component2()
           class FooComponent extends UiComponent2 {
-              ${getDeperecationMessage('componentWillReceiveProps')}
-              @override
-              componentWillReceiveProps(){}
+            ${getDeperecationMessage('componentWillReceiveProps')}
+            @override
+            componentWillReceiveProps(){}
           }
         ''',
       );
@@ -106,14 +106,14 @@ main() {
         input: '''
           @Component2()
           class FooComponent extends UiComponent2 {
-              componentWillReceiveProps(){}
+            componentWillReceiveProps(){}
           }
         ''',
         expectedOutput: '''
           @Component2()
           class FooComponent extends UiComponent2 {
-              ${getDeperecationMessage('componentWillReceiveProps')}
-              componentWillReceiveProps(){}
+            ${getDeperecationMessage('componentWillReceiveProps')}
+            componentWillReceiveProps(){}
           }
         ''',
       );
@@ -127,23 +127,23 @@ main() {
         input: '''
           @Component2()
           class FooComponent extends UiComponent2 {
-              @override
-              componentWillUpdate(){}
-              
-              @override
-              componentWillReceiveProps(){}
+            @override
+            componentWillUpdate(){}
+            
+            @override
+            componentWillReceiveProps(){}
           }
         ''',
         expectedOutput: '''
           @Component2()
           class FooComponent extends UiComponent2 {
-              ${getDeperecationMessage('componentWillUpdate')}
-              @override
-              componentWillUpdate(){}
-          
-              ${getDeperecationMessage('componentWillReceiveProps')}
-              @override
-              componentWillReceiveProps(){}
+            ${getDeperecationMessage('componentWillUpdate')}
+            @override
+            componentWillUpdate(){}
+        
+            ${getDeperecationMessage('componentWillReceiveProps')}
+            @override
+            componentWillReceiveProps(){}
           }
         ''',
       );

--- a/test/component2_suggestors/setState_updater_no_partial_upgrades_test.dart
+++ b/test/component2_suggestors/setState_updater_no_partial_upgrades_test.dart
@@ -1,0 +1,101 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react_codemod/src/component2_suggestors/setstate_updater.dart';
+import 'package:test/test.dart';
+
+import '../util.dart';
+
+main() {
+  group('SetStateUpdater', () {
+    final testSuggestor =
+        getSuggestorTester(SetStateUpdater(noPartialUpgrades: true));
+
+    group('updates correctly when there', () {
+      test('is an empty file', () {
+        testSuggestor(expectedPatchCount: 0, input: '');
+      });
+
+      test('are no matches', () {
+        testSuggestor(
+          expectedPatchCount: 0,
+          input: '''
+          library foo;
+          var a = 'b';
+          class Foo {}
+        ''',
+        );
+      });
+
+      group('is a function expression', () {
+        test('', () {
+          testSuggestor(
+            expectedPatchCount: 0,
+            input: '''
+              @Component2()
+              class FooComponent extends UiComponent2 {
+                @override
+                componentWillReceiveProps(Map newProps) {
+                  super.componentWillReceiveProps(newProps);
+
+                  setState((prevState, props) {
+                    // return ...;
+                  });
+                }
+              }
+            ''',
+          );
+        });
+
+        test('using arrow notation', () {
+          testSuggestor(
+            expectedPatchCount: 0,
+            input: '''
+              @Component2()
+              class FooComponent extends UiComponent2 {
+                @override
+                componentWillReceiveProps(Map newProps) {
+                  super.componentWillReceiveProps(newProps);
+
+                  setState((prevState, props) => newState());
+                }
+              }
+            ''',
+          );
+        });
+      });
+    });
+
+    group('does not update', () {
+      test('for non-component2 classes', () {
+        testSuggestor(
+          expectedPatchCount: 0,
+          input: '''
+            @Component()
+            class FooComponent extends UiComponent {
+              @override
+              componentWillReceiveProps(Map newProps) {
+                super.componentWillReceiveProps(newProps);
+
+                setState((prevState, props) {
+                  // return ...;
+                });
+              }
+            }
+          ''',
+        );
+      });
+    });
+  });
+}

--- a/test/component2_suggestors/setState_updater_no_partial_upgrades_test.dart
+++ b/test/component2_suggestors/setState_updater_no_partial_upgrades_test.dart
@@ -45,7 +45,7 @@ main() {
             input: '''
               @Component2()
               class FooComponent extends UiComponent2 {
-                helperFunction() {
+                someMethod() {
                   setState((prevState, props) {
                     // return ...;
                   });
@@ -55,7 +55,7 @@ main() {
             expectedOutput: '''
               @Component2()
               class FooComponent extends UiComponent2 {
-                helperFunction() {
+                someMethod() {
                   setStateWithUpdater((prevState, props) {
                     // return ...;
                   });
@@ -72,7 +72,7 @@ main() {
               input: '''
                 @Component2()
                 class FooComponent extends AbstractComponent {
-                  helperFunction() {
+                  someMethod() {
                     setState((prevState, props) {
                       // return ...;
                     });
@@ -109,7 +109,7 @@ main() {
               input: '''
                 @Component2()
                 class FooComponent extends UiComponent2 {
-                  helperFunction() {
+                  someMethod() {
                     setState((prevState, props) => newState());
                   }
                 }
@@ -117,7 +117,7 @@ main() {
               expectedOutput: '''
                 @Component2()
                 class FooComponent extends UiComponent2 {
-                  helperFunction() {
+                  someMethod() {
                     setStateWithUpdater((prevState, props) => newState());
                   }
                 }
@@ -132,7 +132,7 @@ main() {
                 input: '''
                   @Component2()
                   class FooComponent extends AbstractComponent {
-                    helperFunction() {
+                    someMethod() {
                       setState((prevState, props) => newState());
                     }
                   }

--- a/test/component2_suggestors/setState_updater_test.dart
+++ b/test/component2_suggestors/setState_updater_test.dart
@@ -30,10 +30,10 @@ main() {
         testSuggestor(
           expectedPatchCount: 0,
           input: '''
-          library foo;
-          var a = 'b';
-          class Foo {}
-        ''',
+            library foo;
+            var a = 'b';
+            class Foo {}
+          ''',
         );
       });
 
@@ -75,22 +75,16 @@ main() {
             expectedPatchCount: 1,
             input: '''
               @Component2()
-              class FooComponent extends UiComponent2 {
-                @override
-                componentWillReceiveProps(Map newProps) {
-                  super.componentWillReceiveProps(newProps);
-                  
+              class FooComponent extends AbstractComponent {
+                helperFunction() {
                   setState((prevState, props) => newState());
                 }
               }
             ''',
             expectedOutput: '''
               @Component2()
-              class FooComponent extends UiComponent2 {
-                @override
-                componentWillReceiveProps(Map newProps) {
-                  super.componentWillReceiveProps(newProps);
-                  
+              class FooComponent extends AbstractComponent {
+                helperFunction() {
                   setStateWithUpdater((prevState, props) => newState());
                 }
               }

--- a/test/component2_suggestors/setState_updater_test.dart
+++ b/test/component2_suggestors/setState_updater_test.dart
@@ -76,7 +76,7 @@ main() {
             input: '''
               @Component2()
               class FooComponent extends AbstractComponent {
-                helperFunction() {
+                someMethod() {
                   setState((prevState, props) => newState());
                 }
               }
@@ -84,7 +84,7 @@ main() {
             expectedOutput: '''
               @Component2()
               class FooComponent extends AbstractComponent {
-                helperFunction() {
+                someMethod() {
                   setStateWithUpdater((prevState, props) => newState());
                 }
               }


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
For an easier incremental upgrade process, we should an option to have our codemod only upgrade components that can be completely upgraded (e.g., don't include deprecated lifecycle methods that we don't have codemods for).

That way, we can run and commit these partial upgrades separately, which will make rolling them back easier if it's determined that manually upgrading will require a bit more effort.
## Changes
  <!-- What this PR changes to fix the problem. -->
- Add a flag `--no-partial-upgrades` to Component2 codemod executable that will prevent partial component upgrades from occurring
  - Pass in as a parameter to suggestors telling them not to perform any actions on those components
- Create a utility function that determines whether a component can be fully upgraded, that can be shared across multiple suggestors. __Criteria:__
  - In order for a component to be fully upgradable, the component must:
    - extend directly from `UiComponent`/`UiStatefulComponent`/`react.Component`
    - contain only the lifecycle methods that the codemod updates:
      - `componentWillMount` (updated to `init`)
      - `render`
      - `componentDidUpdate`
- Write test coverage for each suggestor using the flag
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
      - [ ] CI passes
      - [ ] Run the Component2 codemod on web_skin_dart with the `--no-partial-upgrades` flag and verify that the codemod only updates components that can be fully upgraded based on the above criteria.
        - `pub global run over_react_codemod:component2_upgrade --no-partial-upgrades`
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
