### PR TITLE
Retroactively update changelog for 1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## [1.2.0](https://github.com/Workiva/over_react_codemod/compare/1.1.0...1.2.0)
+
+- Added `react16_upgrade` codemod
+
+  - Fixes compatability issues common in react15 code
+  - Updates your versions upper bound of react and over_react in pubspec.yaml to
+    allow for incoming react16 updates
+
+- Added `component2_upgrade` codemod
+
+  - Migrates components to `UiComponent2` (coming in OverReact 3.1.0)
+
+- Added `react16_dependency_override_update` codemod
+
+  - Adds dependency overrides to pubspec.yaml for testing wip branches of react16
+
+- Added `react16_ci_precheck` codemod
+
+  - Checks the version ranges of over_react and react and if they are in
+    transition will run the codemod and fail if there are unaddressed issues.
+
+
 ## [1.1.0](https://github.com/Workiva/over_react_codemod/compare/1.0.2...1.1.0)
 
 - Two additional changes are now made by the `dart2_upgrade` codemod when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 - Added `react16_upgrade` codemod
 
-  - Fixes compatability issues common in react15 code
-  - Updates your versions upper bound of react and over_react in pubspec.yaml to
+  - Fix compatibility issues common in react15 code
+  - Update version upper bound of react and over_react in pubspec.yaml to
     allow for incoming react16 updates
 
 - Added `component2_upgrade` codemod


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Forgot to update changelog in 1.2.0 release...

## Changes
  <!-- What this PR changes to fix the problem. -->
Add changelog entry for 1.2.0 release

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
