### PR TITLE
CPLAT-7175 Update componentWillMount Suggestor

### DIFF
--- a/lib/src/component2_suggestors/component2_constants.dart
+++ b/lib/src/component2_suggestors/component2_constants.dart
@@ -35,3 +35,6 @@ String getDeperecationMessage(String methodName) {
   ///
   $revertInstructions''';
 }
+
+String componentWillMountMessage = '''
+  /// FIXME: Method has been renamed from `componentWillMount` to `componentDidMount`. Please check if super call should be added or updated.''';

--- a/lib/src/component2_suggestors/component2_constants.dart
+++ b/lib/src/component2_suggestors/component2_constants.dart
@@ -36,27 +36,16 @@ String getDeperecationMessage(String methodName) {
   $revertInstructions''';
 }
 
-final componentWillMountMessage = '''
+const componentWillMountMessage = '''
   /// FIXME: Method has been updated from `componentWillMount` to `componentDidMount`. Please check if super call should be added, updated, or removed.''';
 
-final deprecatedLifecycleMethods = [
+const deprecatedLifecycleMethods = [
   'componentWillMount',
   'componentWillReceiveProps',
   'componentWillUpdate',
 ];
 
-final lifecycleMethodsWithCodemods = [
+const lifecycleMethodsWithCodemods = [
   'componentWillMount',
   'componentDidUpdate',
-];
-
-final componentClassNames = [
-  'UiComponent',
-  'UiComponent2',
-  'UiStatefulComponent',
-  'UiStatefulComponent2',
-  'FluxUiComponent',
-  'FluxUiComponent2',
-  'FluxUiStatefulComponent',
-  'FluxUiStatefulComponent2',
 ];

--- a/lib/src/component2_suggestors/component2_constants.dart
+++ b/lib/src/component2_suggestors/component2_constants.dart
@@ -36,22 +36,21 @@ String getDeperecationMessage(String methodName) {
   $revertInstructions''';
 }
 
-String componentWillMountMessage = '''
-  /// FIXME: Method has been renamed from `componentWillMount` to `componentDidMount`. Please check if super call should be added or updated.''';
+final componentWillMountMessage = '''
+  /// FIXME: Method has been updated from `componentWillMount` to `componentDidMount`. Please check if super call should be added, updated, or removed.''';
 
 final deprecatedLifecycleMethods = [
   'componentWillMount',
-  'componentDidUpdate',
   'componentWillReceiveProps',
   'componentWillUpdate',
 ];
 
-var lifecycleMethodsWithCodemods = [
+final lifecycleMethodsWithCodemods = [
   'componentWillMount',
   'componentDidUpdate',
 ];
 
-var componentClassNames = [
+final componentClassNames = [
   'UiComponent',
   'UiComponent2',
   'UiStatefulComponent',

--- a/lib/src/component2_suggestors/component2_constants.dart
+++ b/lib/src/component2_suggestors/component2_constants.dart
@@ -38,3 +38,26 @@ String getDeperecationMessage(String methodName) {
 
 String componentWillMountMessage = '''
   /// FIXME: Method has been renamed from `componentWillMount` to `componentDidMount`. Please check if super call should be added or updated.''';
+
+final deprecatedLifecycleMethods = [
+  'componentWillMount',
+  'componentDidUpdate',
+  'componentWillReceiveProps',
+  'componentWillUpdate',
+];
+
+var lifecycleMethodsWithCodemods = [
+  'componentWillMount',
+  'componentDidUpdate',
+];
+
+var componentClassNames = [
+  'UiComponent',
+  'UiComponent2',
+  'UiStatefulComponent',
+  'UiStatefulComponent2',
+  'FluxUiComponent',
+  'FluxUiComponent2',
+  'FluxUiStatefulComponent',
+  'FluxUiStatefulComponent2',
+];

--- a/lib/src/component2_suggestors/component2_utilities.dart
+++ b/lib/src/component2_suggestors/component2_utilities.dart
@@ -110,7 +110,6 @@ bool fullyUpgradableToComponent2(ClassDeclaration classNode) {
 /// * Generic parameters on component class
 /// * `@AbstractProps` in the same file
 bool canBeExtendedFrom(ClassDeclaration classNode) {
-  var a = classNode.typeParameters;
   if (classNode != null &&
       (classNode.abstractKeyword != null ||
           classNode.typeParameters != null ||

--- a/lib/src/component2_suggestors/component2_utilities.dart
+++ b/lib/src/component2_suggestors/component2_utilities.dart
@@ -110,6 +110,7 @@ bool fullyUpgradableToComponent2(ClassDeclaration classNode) {
 /// * Generic parameters on component class
 /// * `@AbstractProps` in the same file
 bool canBeExtendedFrom(ClassDeclaration classNode) {
+  var a = classNode.typeParameters;
   if (classNode != null &&
       (classNode.abstractKeyword != null ||
           classNode.typeParameters != null ||

--- a/lib/src/component2_suggestors/component2_utilities.dart
+++ b/lib/src/component2_suggestors/component2_utilities.dart
@@ -15,6 +15,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 
 import '../constants.dart';
+import 'component2_constants.dart';
 
 /// Returns the import namespace of the import referencing [uri].
 String getImportNamespace(AstNode node, String uri) {
@@ -70,17 +71,6 @@ bool fullyUpgradableToComponent2(ClassDeclaration classNode) {
   String reactImportName =
       getImportNamespace(classNode, 'package:react/react.dart');
 
-  var componentClassNames = [
-    'UiComponent',
-    'UiComponent2',
-    'UiStatefulComponent',
-    'UiStatefulComponent2',
-    'FluxUiComponent',
-    'FluxUiComponent2',
-    'FluxUiStatefulComponent',
-    'FluxUiStatefulComponent2',
-  ];
-
   if (reactImportName != null) {
     componentClassNames.add('$reactImportName.Component');
     componentClassNames.add('$reactImportName.Component2');
@@ -90,32 +80,11 @@ bool fullyUpgradableToComponent2(ClassDeclaration classNode) {
     return false;
   }
 
-  // Check that all lifecycle methods contained in the class will be
+  // Check that all deprecated lifecycle methods contained in the class will be
   // updated by a codemod.
-  final lifecycleMethods = [
-    'componentWillMount',
-    'componentWillReceiveProps',
-    'componentWillUpdate',
-    'getDerivedStateFromError',
-    'getDerivedStateFromProps',
-    'getSnapshotBeforeUpdate',
-    'shouldComponentUpdate',
-    'render',
-    'componentDidMount',
-    'componentDidUpdate',
-    'componentWillUnmount',
-    'componentDidCatch',
-  ];
-
-  var lifecycleMethodsWithCodemods = [
-    'componentWillMount',
-    'render',
-    'componentDidUpdate',
-  ];
-
   for (var member in classNode.members) {
     if (member is MethodDeclaration &&
-        lifecycleMethods.contains(member.name.name) &&
+        deprecatedLifecycleMethods.contains(member.name.name) &&
         !lifecycleMethodsWithCodemods.contains(member.name.name)) {
       return false;
     }

--- a/lib/src/component2_suggestors/component2_utilities.dart
+++ b/lib/src/component2_suggestors/component2_utilities.dart
@@ -80,6 +80,17 @@ bool fullyUpgradableToComponent2(ClassDeclaration classNode) {
   String reactImportName =
       getImportNamespace(classNode, 'package:react/react.dart');
 
+  var componentClassNames = [
+    'UiComponent',
+    'UiComponent2',
+    'UiStatefulComponent',
+    'UiStatefulComponent2',
+    'FluxUiComponent',
+    'FluxUiComponent2',
+    'FluxUiStatefulComponent',
+    'FluxUiStatefulComponent2',
+  ];
+
   if (reactImportName != null) {
     componentClassNames.add('$reactImportName.Component');
     componentClassNames.add('$reactImportName.Component2');

--- a/lib/src/component2_suggestors/componentwillmount_migrator.dart
+++ b/lib/src/component2_suggestors/componentwillmount_migrator.dart
@@ -85,19 +85,11 @@ class ComponentWillMountMigrator extends GeneralizingAstVisitor
         });
 
         if (annotationsToAdd.isNotEmpty) {
-          if (componentDidMountMethodDecl.metadata.isEmpty) {
-            yieldPatch(
-              componentDidMountMethodDecl.offset,
-              componentDidMountMethodDecl.offset,
-              annotationsToAdd,
-            );
-          } else {
-            yieldPatch(
-              componentDidMountMethodDecl.metadata.endToken.end,
-              componentDidMountMethodDecl.metadata.endToken.end,
-              annotationsToAdd,
-            );
-          }
+          yieldPatch(
+            componentDidMountMethodDecl.offset,
+            componentDidMountMethodDecl.offset,
+            annotationsToAdd,
+          );
         }
 
         // Remove `componentWillMount` method.

--- a/lib/src/component2_suggestors/componentwillmount_migrator.dart
+++ b/lib/src/component2_suggestors/componentwillmount_migrator.dart
@@ -80,12 +80,12 @@ class ComponentWillMountMigrator extends GeneralizingAstVisitor
             hasSuperCall ? '' : 'super.componentDidMount();\n',
           );
 
-          // Move body of `componentWillMount` to end of `componentDidMount`.
+          // Move `componentWillMount` body to beginning of `componentDidMount`.
           final componentDidMountBody =
               (componentDidMountMethodDecl.body as BlockFunctionBody).block;
           yieldPatch(
-            componentDidMountBody.rightBracket.offset,
-            componentDidMountBody.rightBracket.offset,
+            componentDidMountBody.leftBracket.end,
+            componentDidMountBody.leftBracket.end,
             methodBody,
           );
         }

--- a/test/component2_suggestors/class_name_and_annotation_migrator_test.dart
+++ b/test/component2_suggestors/class_name_and_annotation_migrator_test.dart
@@ -63,7 +63,7 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
   });
 
   group('annotation and extending class', () {
-    test('updates when all lifecycle methods have codemods', () {
+    test('updates when all deprecated lifecycle methods have codemods', () {
       testSuggestor(
         expectedPatchCount: 2,
         input: '''
@@ -79,6 +79,9 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
             
             @override
             componentDidUpdate(Map prevProps, Map prevState) {}
+            
+            @override
+            componentWillUnmount() {}
           }
         ''',
         expectedOutput: '''
@@ -94,6 +97,9 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
 
             @override
             componentDidUpdate(Map prevProps, Map prevState) {}
+            
+            @override
+            componentWillUnmount() {}
           }
         ''',
       );
@@ -143,7 +149,7 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
 
     test(
         '${allowPartialUpgrades ? 'updates' : 'does not update'} when one or '
-        'more lifecycle method has no codemod', () {
+        'more deprecated lifecycle method has no codemod', () {
       testSuggestor(
         expectedPatchCount: allowPartialUpgrades ? 2 : 0,
         input: '''
@@ -161,7 +167,7 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
             componentDidUpdate(Map prevProps, Map prevState) {}
 
             @override
-            componentWillUnmount() {}
+            componentWillReceiveProps() {}
           }
         ''',
         expectedOutput: '''
@@ -179,7 +185,7 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
             componentDidUpdate(Map prevProps, Map prevState) {}
             
             @override
-            componentWillUnmount() {}
+            componentWillReceiveProps() {}
           }
         ''',
       );
@@ -187,7 +193,7 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
   });
 
   group('extending class only needs updating', () {
-    test('updates when all lifecycle methods have codemods', () {
+    test('updates when all deprecated lifecycle methods have codemods', () {
       testSuggestor(
         expectedPatchCount: 1,
         input: '''
@@ -209,7 +215,7 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
 
     test(
         '${allowPartialUpgrades ? 'updates' : 'does not update'} when one or '
-        'more lifecycle method has no codemod', () {
+        'more deprecated lifecycle method has no codemod', () {
       testSuggestor(
         expectedPatchCount: allowPartialUpgrades ? 1 : 0,
         input: '''
@@ -220,6 +226,9 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
             
             @override
             void render() {}
+            
+            @override
+            componentWillReceiveProps() {}
           }
         ''',
         expectedOutput: '''
@@ -230,6 +239,9 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
             
             @override
             void render() {}
+            
+            @override
+            componentWillReceiveProps() {}
           }
         ''',
       );
@@ -237,7 +249,7 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
   });
 
   group('annotation with args and extending class', () {
-    test('updates when all lifecycle methods have codemods', () {
+    test('updates when all deprecated lifecycle methods have codemods', () {
       testSuggestor(
         expectedPatchCount: 2,
         input: '''
@@ -247,6 +259,9 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
 
             @override
             render() {}
+            
+            @override
+            componentDidMount() {}
           }
         ''',
         expectedOutput: '''
@@ -256,6 +271,9 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
 
             @override
             render() {}
+            
+            @override
+            componentDidMount() {}
           }
         ''',
       );
@@ -263,7 +281,7 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
 
     test(
         '${allowPartialUpgrades ? 'updates' : 'does not update'} when one or '
-        'more lifecycle method has no codemod', () {
+        'more deprecated lifecycle method has no codemod', () {
       testSuggestor(
         expectedPatchCount: allowPartialUpgrades ? 2 : 0,
         input: '''
@@ -273,7 +291,7 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
             componentWillMount() {}
             
             @override
-            componentDidMount() {}
+            componentWillUpdate() {}
           }
         ''',
         expectedOutput: '''
@@ -283,7 +301,7 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
             componentWillMount() {}
             
             @override
-            componentDidMount() {}
+            componentWillUpdate() {}
           }
         ''',
       );
@@ -299,6 +317,9 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
           class FooComponent extends SomeOtherClass<FooProps> {
             @override
             render() {}
+            
+            @override
+            shouldComponentUpdate() {}
           }
         ''',
         expectedOutput: '''
@@ -306,6 +327,9 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
           class FooComponent extends SomeOtherClass<FooProps> {
             @override
             render() {}
+            
+            @override
+            shouldComponentUpdate() {}
           }
         ''',
       );
@@ -313,7 +337,7 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
   });
 
   group('AbstractComponent annotation and extending stateful class', () {
-    test('updates when all lifecycle methods have codemods', () {
+    test('updates when all deprecated lifecycle methods have codemods', () {
       testSuggestor(
         expectedPatchCount: 2,
         input: '''
@@ -335,7 +359,7 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
 
     test(
         '${allowPartialUpgrades ? 'updates' : 'does not update'} when one or '
-        'more lifecycle method has no codemod', () {
+        'more deprecated lifecycle method has no codemod', () {
       testSuggestor(
         expectedPatchCount: allowPartialUpgrades ? 2 : 0,
         input: '''
@@ -345,7 +369,7 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
             componentWillMount() {}
 
             @override
-            shouldComponentUpdate() {}
+            componentWillUpdate() {}
           }
         ''',
         expectedOutput: '''
@@ -355,7 +379,7 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
             componentWillMount() {}
 
             @override
-            shouldComponentUpdate() {}
+            componentWillUpdate() {}
           }
         ''',
       );
@@ -379,7 +403,7 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
   });
 
   group('extending class imported from react.dart', () {
-    test('updates when all lifecycle methods have codemods', () {
+    test('updates when all deprecated lifecycle methods have codemods', () {
       testSuggestor(
         expectedPatchCount: 2,
         input: '''
@@ -405,7 +429,7 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
 
     test(
         '${allowPartialUpgrades ? 'updates' : 'does not update'} when one or '
-        'more lifecycle method has no codemod', () {
+        'more deprecated lifecycle method has no codemod', () {
       testSuggestor(
         expectedPatchCount: allowPartialUpgrades ? 2 : 0,
         input: '''
@@ -454,7 +478,7 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
     });
 
     test(
-        'with different import name updates when all lifecycle methods have codemods',
+        'with different import name updates when all deprecated lifecycle methods have codemods',
         () {
       testSuggestor(
         expectedPatchCount: 1,
@@ -462,13 +486,19 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
           import "package:react/react_dom.dart" as react_dom;
           import "package:react/react.dart" as foo;
         
-          class FooComponent extends foo.Component {}
+          class FooComponent extends foo.Component {
+            @override
+            componentWillMount() {}
+          }
         ''',
         expectedOutput: '''
           import "package:react/react_dom.dart" as react_dom;
           import "package:react/react.dart" as foo;
 
-          class FooComponent extends foo.Component2 {}
+          class FooComponent extends foo.Component2 {
+            @override
+            componentWillMount() {}
+          }
         ''',
       );
     });
@@ -490,13 +520,16 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
           class FooComponent extends react.Component {
             @override
             componentDidUpdate(Map prevProps, Map prevState) {}
+            
+            @override
+            shouldComponentUpdate() {}
           }
           
           class FooComponent extends react.Component {}
           
           class FooComponent extends react.Component {
             @override
-            shouldComponentUpdate() {}
+            componentWillUpdate() {}
             
             @override
             render() {}
@@ -514,13 +547,16 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
           class FooComponent extends react.Component2 {
             @override
             componentDidUpdate(Map prevProps, Map prevState) {}
+            
+            @override
+            shouldComponentUpdate() {}
           }
           
           class FooComponent extends react.Component2 {}
           
           class FooComponent extends react.Component${allowPartialUpgrades ? '2' : ''} {
             @override
-            shouldComponentUpdate() {}
+            componentWillUpdate() {}
             
             @override
             render() {}
@@ -544,7 +580,7 @@ void classNameAndAnnotationTests({bool allowPartialUpgrades}) {
             
             class FooComponent extends react.Component {
               @override
-              shouldComponentUpdate() {}
+              componentWillUpdate() {}
               
               @override
               render() {}

--- a/test/component2_suggestors/class_name_and_annotation_migrator_test.dart
+++ b/test/component2_suggestors/class_name_and_annotation_migrator_test.dart
@@ -518,7 +518,7 @@ void classNameAndAnnotationTests({
     group('with @AbstractComponent() annotation and abstract keyword', () {
       test(
           '${shouldUpgradeAbstractComponents ? 'updates' : 'does not update'} '
-          'when all lifecycle methods have codemods', () {
+          'when all deprecated lifecycle methods have codemods', () {
         testSuggestor(
           expectedPatchCount: shouldUpgradeAbstractComponents ? 3 : 0,
           input: '''
@@ -541,7 +541,7 @@ void classNameAndAnnotationTests({
 
       test(
           '${allowPartialUpgrades && shouldUpgradeAbstractComponents ? 'updates' : 'does not update'} when one or '
-          'more lifecycle method has no codemod', () {
+          'more deprecated lifecycle method has no codemod', () {
         testSuggestor(
           expectedPatchCount:
               allowPartialUpgrades && shouldUpgradeAbstractComponents ? 3 : 0,
@@ -552,7 +552,7 @@ void classNameAndAnnotationTests({
               componentWillMount() {}
   
               @override
-              shouldComponentUpdate() {}
+              componentWillReceiveProps() {}
             }
           ''',
           expectedOutput: '''
@@ -563,7 +563,7 @@ void classNameAndAnnotationTests({
               componentWillMount() {}
   
               @override
-              shouldComponentUpdate() {}
+              componentWillReceiveProps() {}
             }
           ''',
         );
@@ -591,7 +591,7 @@ void classNameAndAnnotationTests({
     group('with generic parameters', () {
       test(
           '${shouldUpgradeAbstractComponents ? 'updates' : 'does not update'} '
-          'when all lifecycle methods have codemods', () {
+          'when all deprecated lifecycle methods have codemods', () {
         testSuggestor(
           expectedPatchCount: shouldUpgradeAbstractComponents ? 3 : 0,
           input: '''
@@ -614,7 +614,7 @@ void classNameAndAnnotationTests({
 
       test(
           '${allowPartialUpgrades && shouldUpgradeAbstractComponents ? 'updates' : 'does not update'}'
-          ' when one or more lifecycle method has no codemod', () {
+          ' when one or more deprecated lifecycle method has no codemod', () {
         testSuggestor(
           expectedPatchCount:
               allowPartialUpgrades && shouldUpgradeAbstractComponents ? 3 : 0,
@@ -622,7 +622,7 @@ void classNameAndAnnotationTests({
             @Component
             class FooComponent<BarProps, BarState> extends FluxUiComponent<FooProps> {
               @override
-              componentWillMount() {}
+              componentWillReceiveProps() {}
   
               @override
               shouldComponentUpdate() {}
@@ -633,7 +633,7 @@ void classNameAndAnnotationTests({
             @Component${allowPartialUpgrades && shouldUpgradeAbstractComponents ? '2' : ''}
             class FooComponent<BarProps, BarState> extends FluxUiComponent${allowPartialUpgrades && shouldUpgradeAbstractComponents ? '2' : ''}<FooProps> {
               @override
-              componentWillMount() {}
+              componentWillReceiveProps() {}
   
               @override
               shouldComponentUpdate() {}
@@ -664,7 +664,7 @@ void classNameAndAnnotationTests({
     group('with @AbstractProps in the same file', () {
       test(
           '${shouldUpgradeAbstractComponents ? 'updates' : 'does not update'} '
-          'when all lifecycle methods have codemods', () {
+          'when all deprecated lifecycle methods have codemods', () {
         testSuggestor(
           expectedPatchCount: shouldUpgradeAbstractComponents ? 3 : 0,
           input: '''
@@ -693,7 +693,7 @@ void classNameAndAnnotationTests({
 
       test(
           '${allowPartialUpgrades && shouldUpgradeAbstractComponents ? 'updates' : 'does not update'} when one or '
-          'more lifecycle method has no codemod', () {
+          'more deprecated lifecycle method has no codemod', () {
         testSuggestor(
           expectedPatchCount:
               allowPartialUpgrades && shouldUpgradeAbstractComponents ? 3 : 0,
@@ -707,7 +707,7 @@ void classNameAndAnnotationTests({
               componentWillMount() {}
   
               @override
-              shouldComponentUpdate() {}
+              componentWillUpdate() {}
             }
           ''',
           expectedOutput: '''
@@ -721,7 +721,7 @@ void classNameAndAnnotationTests({
               componentWillMount() {}
   
               @override
-              shouldComponentUpdate() {}
+              componentWillUpdate() {}
             }
           ''',
         );

--- a/test/component2_suggestors/component2_utilities_test.dart
+++ b/test/component2_suggestors/component2_utilities_test.dart
@@ -298,7 +298,7 @@ void main() {
         });
 
         group(
-            'extends a base class and contains lifecycle methods that are all updated by codemods',
+            'extends a base class and contains deprecated lifecycle methods that are all updated by codemods',
             () {
           final input = '''
             @Component
@@ -311,6 +311,9 @@ void main() {
               
               @override
               componentDidUpdate(Map prevProps, Map prevState) {}
+              
+              @override
+              shouldComponentUpdate() {}
             }
           ''';
 
@@ -392,7 +395,7 @@ void main() {
               componentDidUpdate(Map prevProps, Map prevState) {}
               
               @override
-              componentWillUnmount() {}
+              componentWillUpdate() {}
             }
           ''';
 

--- a/test/component2_suggestors/componentdidupdate_migrator_test.dart
+++ b/test/component2_suggestors/componentdidupdate_migrator_test.dart
@@ -197,7 +197,7 @@ void componentDidUpdateTests({
           );
         });
 
-        test('-- has lifecycle methods without codemods', () {
+        test('-- has deprecated lifecycle methods without codemods', () {
           testSuggestor(
             expectedPatchCount:
                 allowPartialUpgrades && shouldUpgradeAbstractComponents ? 1 : 0,
@@ -209,7 +209,7 @@ void componentDidUpdateTests({
                 }
                 
                 @override
-                componentWillUnmount() {}
+                componentWillUpdate() {}
               }
             ''',
             expectedOutput: '''
@@ -220,7 +220,7 @@ void componentDidUpdateTests({
                 }
                 
                 @override
-                componentWillUnmount() {}
+                componentWillUpdate() {}
               }
             ''',
           );

--- a/test/component2_suggestors/componentdidupdate_migrator_test.dart
+++ b/test/component2_suggestors/componentdidupdate_migrator_test.dart
@@ -94,7 +94,7 @@ void componentDidUpdateTests({bool allowPartialUpgrades}) {
         );
       });
 
-      test('-- has lifecycle methods without codemods', () {
+      test('-- has deprecated lifecycle methods without codemods', () {
         testSuggestor(
           expectedPatchCount: allowPartialUpgrades ? 1 : 0,
           input: '''
@@ -105,7 +105,7 @@ void componentDidUpdateTests({bool allowPartialUpgrades}) {
               }
               
               @override
-              componentWillUnmount() {}
+              componentWillReceiveProps() {}
             }
           ''',
           expectedOutput: '''
@@ -116,7 +116,7 @@ void componentDidUpdateTests({bool allowPartialUpgrades}) {
               }
               
               @override
-              componentWillUnmount() {}
+              componentWillReceiveProps() {}
             }
           ''',
         );

--- a/test/component2_suggestors/componentwillmount_migrator_test.dart
+++ b/test/component2_suggestors/componentwillmount_migrator_test.dart
@@ -238,6 +238,35 @@ componentWillMountTests({bool allowPartialUpgrades}) {
                 }
               }
             ''',
+            expectedOutput: allowPartialUpgrades
+                ? '''
+              @Component2()
+              class FooComponent extends SomeOtherClass {
+                @override
+                componentDidMount() {
+                  var c = 3;
+                  var d = 4;
+                  var a = 1;
+                  var b = 2;
+                }
+              }
+            '''
+                : '''
+              @Component2()
+              class FooComponent extends SomeOtherClass {
+                @override
+                componentWillMount() {
+                  var a = 1;
+                  var b = 2;
+                }
+                
+                @override
+                componentDidMount() {
+                  var c = 3;
+                  var d = 4;
+                }
+              }
+            ''',
           );
         });
 
@@ -247,6 +276,41 @@ componentWillMountTests({bool allowPartialUpgrades}) {
             input: '''
               @Component2()
               class FooComponent extends UiComponent2 {
+                @override
+                componentWillMount() {
+                  var a = 1;
+                  var b = 2;
+                }
+                
+                @override
+                componentDidMount() {
+                  var c = 3;
+                  var d = 4;
+                }
+                
+                @override
+                componentWillUnmount() {}
+              }
+            ''',
+            expectedOutput: allowPartialUpgrades
+                ? '''
+              @Component2()
+              class FooComponent extends UiComponent2 {
+                @override
+                componentDidMount() {
+                  var c = 3;
+                  var d = 4;
+                  var a = 1;
+                  var b = 2;
+                }
+                
+                @override
+                componentWillUnmount() {}
+              }
+            '''
+                : '''
+              @Component2()
+              class FooComponent extends SomeOtherClass {
                 @override
                 componentWillMount() {
                   var a = 1;

--- a/test/component2_suggestors/componentwillmount_migrator_test.dart
+++ b/test/component2_suggestors/componentwillmount_migrator_test.dart
@@ -65,7 +65,8 @@ componentWillMountTests({
   });
 
   group('when componentDidMount does not exist in containing class', () {
-    group('componentWillMount method', () {
+    group('componentWillMount method', ()
+    {
       test('updates if containing class is fully upgradable', () {
         testSuggestor(
           expectedPatchCount: 2,
@@ -91,7 +92,7 @@ componentWillMountTests({
 
       group(
           '${allowPartialUpgrades ? 'updates' : 'does not update'} if '
-          'containing class is not fully upgradable', () {
+              'containing class is not fully upgradable', () {
         test('-- extends from non-Component class', () {
           testSuggestor(
             expectedPatchCount: allowPartialUpgrades ? 2 : 0,
@@ -106,7 +107,9 @@ componentWillMountTests({
             expectedOutput: '''
               @Component2()
               class FooComponent extends SomeOtherClass {
-                ${allowPartialUpgrades ? '$componentWillMountMessage\ncomponentDidMount' : 'componentWillMount'}(){
+                ${allowPartialUpgrades
+                ? '$componentWillMountMessage\ncomponentDidMount'
+                : 'componentWillMount'}(){
                   // method body
                 }
               }
@@ -114,10 +117,10 @@ componentWillMountTests({
           );
         });
 
-      test('-- has deprecated lifecycle methods without codemods', () {
-        testSuggestor(
-          expectedPatchCount: allowPartialUpgrades ? 2 : 0,
-          input: '''
+        test('-- has deprecated lifecycle methods without codemods', () {
+          testSuggestor(
+            expectedPatchCount: allowPartialUpgrades ? 2 : 0,
+            input: '''
             @Component2()
             class FooComponent extends UiComponent2 {
               componentWillMount(){
@@ -128,10 +131,12 @@ componentWillMountTests({
               componentWillReceiveProps() {}
             }
           ''',
-          expectedOutput: '''
+            expectedOutput: '''
             @Component2()
             class FooComponent extends UiComponent2 {
-              ${allowPartialUpgrades ? '$componentWillMountMessage\ncomponentDidMount' : 'componentWillMount'}(){
+              ${allowPartialUpgrades
+                ? '$componentWillMountMessage\ncomponentDidMount'
+                : 'componentWillMount'}(){
                 // method body
               }
               
@@ -139,103 +144,14 @@ componentWillMountTests({
               componentWillReceiveProps() {}
             }
           ''',
-        );
+          );
+        });
       });
-    });
 
-    group('in an abstract class', () {
-      test(
-          'that is fully upgradable ${shouldUpgradeAbstractComponents ? 'updates' : 'does not update'}',
-          () {
+      test('componentWillMount method with return type', () {
         testSuggestor(
-          expectedPatchCount: shouldUpgradeAbstractComponents ? 1 : 0,
+          expectedPatchCount: 2,
           input: '''
-            @AbstractProps()
-            class AbstractFooProps extends UiProps {}
-            
-            @AbstractComponent2()
-            class FooComponent extends UiComponent2 {
-              componentWillMount(){
-                // method body
-              }
-            }
-          ''',
-          expectedOutput: '''
-            @AbstractProps()
-            class AbstractFooProps extends UiProps {}
-            
-            @AbstractComponent2()
-            class FooComponent extends UiComponent2 {
-              ${shouldUpgradeAbstractComponents ? '$componentWillMountMessage\ncomponentDidMount' : 'componentWillMount'}(){
-                // method body
-              }
-            }
-          ''',
-        );
-      });
-
-      group(
-          'that is not fully upgradable ${allowPartialUpgrades && shouldUpgradeAbstractComponents ? 'updates' : 'does not update'}',
-          () {
-        test('-- extends from non-Component class', () {
-          testSuggestor(
-            expectedPatchCount:
-                allowPartialUpgrades && shouldUpgradeAbstractComponents ? 1 : 0,
-            input: '''
-              @Component2
-              class FooComponent<BarProps> extends SomeOtherClass<FooProps> {
-                componentWillMount(){
-                  // method body
-                }
-              }
-            ''',
-            expectedOutput: '''
-              @Component2
-              class FooComponent<BarProps> extends SomeOtherClass<FooProps> {
-                ${allowPartialUpgrades && shouldUpgradeAbstractComponents ? '$componentWillMountMessage\ncomponentDidMount' : 'componentWillMount'}(){
-                  // method body
-                }
-              }
-            ''',
-          );
-        });
-
-        test('-- has lifecycle methods without codemods', () {
-          testSuggestor(
-            expectedPatchCount:
-                allowPartialUpgrades && shouldUpgradeAbstractComponents ? 1 : 0,
-            input: '''
-              @AbstractComponent2()
-              abstract class FooComponent extends UiComponent2 {
-                componentWillMount(){
-                  // method body
-                }
-                
-                @override
-                componentWillUnmount() {}
-              }
-            ''',
-            expectedOutput: '''
-              @AbstractComponent2()
-              abstract class FooComponent extends UiComponent2 {
-                ${allowPartialUpgrades && shouldUpgradeAbstractComponents ? '$componentWillMountMessage\ncomponentDidMount' : 'componentWillMount'}(){
-                  // method body
-                }
-                
-                @override
-                componentWillUnmount() {}
-              }
-            ''',
-          );
-        });
-      });
-    });
-  });
-
-    test('componentWillMount method with return type', () {
-      testSuggestor(
-        expectedPatchCount: 2,
-        input: '''
           import 'package:react/react.dart' as react;
   
           @Component2()
@@ -245,7 +161,7 @@ componentWillMountTests({
             }
           }
         ''',
-        expectedOutput: '''
+          expectedOutput: '''
           import 'package:react/react.dart' as react;
   
           @Component2()
@@ -256,13 +172,13 @@ componentWillMountTests({
             }
           }
         ''',
-      );
-    });
+        );
+      });
 
-    test('update super calls', () {
-      testSuggestor(
-        expectedPatchCount: 3,
-        input: '''
+      test('update super calls', () {
+        testSuggestor(
+          expectedPatchCount: 3,
+          input: '''
           @Component2()
           class FooComponent extends FluxUiComponent2 {
             void componentWillMount(){
@@ -271,7 +187,7 @@ componentWillMountTests({
             }
           }
         ''',
-        expectedOutput: '''
+          expectedOutput: '''
           @Component2()
           class FooComponent extends FluxUiComponent2 {
             $componentWillMountMessage
@@ -281,7 +197,8 @@ componentWillMountTests({
             }
           }
         ''',
-      );
+        );
+      });
     });
   });
 
@@ -578,6 +495,111 @@ componentWillMountTests({
                 
                 var a = 1;
               }
+            }
+          ''',
+        );
+      });
+    });
+  });
+
+  group('componentWillMount method in an abstract class', () {
+    test('that is fully upgradable ${shouldUpgradeAbstractComponents ? 'updates' : 'does not update'}', () {
+      testSuggestor(
+        expectedPatchCount: allowPartialUpgrades && shouldUpgradeAbstractComponents ? 2 : 0,
+        input: '''
+          @AbstractComponent2()
+          abstract class FooComponent extends SomeOtherClass {
+            @override
+            componentWillMount() {
+              var a = 1;
+              var b = 2;
+            }
+            
+            @override
+            componentDidMount() {
+              var c = 3;
+              var d = 4;
+            }
+          }
+        ''',
+        expectedOutput: allowPartialUpgrades && shouldUpgradeAbstractComponents ? '''
+          @AbstractComponent2()
+          abstract class FooComponent extends SomeOtherClass {
+            @override
+            componentDidMount() {
+              var c = 3;
+              var d = 4;
+              
+              var a = 1;
+              var b = 2;
+            }
+          }
+        ''' : '''
+          @AbstractComponent2()
+          abstract class FooComponent extends SomeOtherClass {
+            @override
+            componentWillMount() {
+              var a = 1;
+              var b = 2;
+            }
+            
+            @override
+            componentDidMount() {
+              var c = 3;
+              var d = 4;
+            }
+          }
+        ''',
+      );
+    });
+
+    group('that is not fully upgradable ${allowPartialUpgrades && shouldUpgradeAbstractComponents ? 'updates' : 'does not update'}', () {
+      test('-- extends from non-Component class', () {
+        testSuggestor(
+          expectedPatchCount:
+          allowPartialUpgrades && shouldUpgradeAbstractComponents ? 2 : 0,
+          input: '''
+          @Component2
+          class FooComponent<BarProps> extends SomeOtherClass<FooProps> {
+            componentWillMount(){
+              // method body
+            }
+          }
+        ''',
+          expectedOutput: '''
+          @Component2
+          class FooComponent<BarProps> extends SomeOtherClass<FooProps> {
+            ${allowPartialUpgrades && shouldUpgradeAbstractComponents ? '$componentWillMountMessage\ncomponentDidMount' : 'componentWillMount'}(){
+              // method body
+            }
+          }
+        ''',
+        );
+      });
+
+      test('-- has lifecycle methods without codemods', () {
+        testSuggestor(
+          expectedPatchCount: allowPartialUpgrades && shouldUpgradeAbstractComponents ? 2 : 0,
+          input: '''
+            @AbstractComponent2()
+            abstract class FooComponent extends UiComponent2 {
+              componentWillMount(){
+                // method body
+              }
+              
+              @override
+              componentWillReceiveProps() {}
+            }
+          ''',
+            expectedOutput: '''
+            @AbstractComponent2()
+            abstract class FooComponent extends UiComponent2 {
+              ${allowPartialUpgrades && shouldUpgradeAbstractComponents ? '$componentWillMountMessage\ncomponentDidMount' : 'componentWillMount'}(){
+                // method body
+              }
+              
+              @override
+              componentWillReceiveProps() {}
             }
           ''',
         );

--- a/test/component2_suggestors/componentwillmount_migrator_test.dart
+++ b/test/component2_suggestors/componentwillmount_migrator_test.dart
@@ -47,285 +47,14 @@ componentWillMountTests({bool allowPartialUpgrades}) {
     );
   });
 
-  group('componentWillMount method', () {
-    test('updates if containing class is fully upgradable', () {
-      testSuggestor(
-        expectedPatchCount: 1,
-        input: '''
-          @Component2()
-          class FooComponent extends UiComponent2 {
-            componentWillMount(){
-              // method body
-            }
-          }
-        ''',
-        expectedOutput: '''
-          @Component2()
-          class FooComponent extends UiComponent2 {
-            init(){
-              // method body
-            }
-          }
-        ''',
-      );
-    });
-
-    group(
-        '${allowPartialUpgrades ? 'updates' : 'does not update'} if '
-        'containing class is not fully upgradable', () {
-      test('-- extends from non-Component class', () {
-        testSuggestor(
-          expectedPatchCount: allowPartialUpgrades ? 1 : 0,
-          input: '''
-            @Component2()
-            class FooComponent extends SomeOtherClass {
-              componentWillMount(){
-                // method body
-              }
-            }
-          ''',
-          expectedOutput: '''
-            @Component2()
-            class FooComponent extends SomeOtherClass {
-              ${allowPartialUpgrades ? 'init' : 'componentWillMount'}(){
-                // method body
-              }
-            }
-          ''',
-        );
-      });
-
-      test('-- has lifecycle methods without codemods', () {
-        testSuggestor(
-          expectedPatchCount: allowPartialUpgrades ? 1 : 0,
-          input: '''
-            @Component2()
-            class FooComponent extends UiComponent2 {
-              componentWillMount(){
-                // method body
-              }
-              
-              @override
-              componentWillUnmount() {}
-            }
-          ''',
-          expectedOutput: '''
-            @Component2()
-            class FooComponent extends UiComponent2 {
-              ${allowPartialUpgrades ? 'init' : 'componentWillMount'}(){
-                // method body
-              }
-              
-              @override
-              componentWillUnmount() {}
-            }
-          ''',
-        );
-      });
-    });
-  });
-
-  test('componentWillMount method with return type updates', () {
-    testSuggestor(
-      expectedPatchCount: 1,
-      input: '''
-        import 'package:react/react.dart' as react;
-
-        @Component2()
-        class FooComponent extends react.Component2 {
-          void componentWillMount(){
-            // method body
-          }
-        }
-      ''',
-      expectedOutput: '''
-        import 'package:react/react.dart' as react;
-
-        @Component2()
-        class FooComponent extends react.Component2 {
-          void init(){
-            // method body
-          }
-        }
-      ''',
-    );
-  });
-
-  group('super calls to componentWillMount', () {
-    group('are removed if containing class is fully upgradable', () {
-      test('and extends UiComponent2', () {
-        testSuggestor(
-          expectedPatchCount: 2,
-          input: '''
-            @Component2()
-            class FooComponent extends FluxUiComponent2 {
-              void componentWillMount(){
-                super.componentWillMount();
-                // method body
-              }
-            }
-          ''',
-          expectedOutput: '''
-            @Component2()
-            class FooComponent extends FluxUiComponent2 {
-              void init(){
-                // method body
-              }
-            }
-          ''',
-        );
-      });
-
-      test('and extends UiStatefulComponent2', () {
-        testSuggestor(
-          expectedPatchCount: 2,
-          input: '''
-            @Component2()
-            class FooComponent extends UiStatefulComponent2 {
-              void componentWillMount(){
-                super.componentWillMount();
-                // method body
-              }
-            }
-          ''',
-          expectedOutput: '''
-            @Component2()
-            class FooComponent extends UiStatefulComponent2 {
-              void init(){
-                // method body
-              }
-            }
-          ''',
-        );
-      });
-
-      test('and extends react.Component2', () {
-        testSuggestor(
-          expectedPatchCount: 2,
-          input: '''
-            import 'package:react/react.dart' as react;
-            
-            @Component2()
-            class FooComponent extends react.Component2 {
-              void componentWillMount(){
-                super.componentWillMount();
-                // method body
-              }
-            }
-          ''',
-          expectedOutput: '''
-            import 'package:react/react.dart' as react;
-            
-            @Component2()
-            class FooComponent extends react.Component2 {
-              void init(){
-                // method body
-              }
-            }
-          ''',
-        );
-      });
-    });
-
-    test(
-        'does not remove super calls to componentWillMount for non-base extending classes',
-        () {
-      testSuggestor(
-        expectedPatchCount: allowPartialUpgrades ? 1 : 0,
-        input: '''
-          @Component2()
-          class FooComponent extends SomeOtherClass {
-            void componentWillMount(){
-              super.componentWillMount();
-              // method body
-            }
-          }
-        ''',
-        expectedOutput: '''
-          @Component2()
-          class FooComponent extends SomeOtherClass {
-            void ${allowPartialUpgrades ? 'init' : 'componentWillMount'}(){
-              super.componentWillMount();
-              // method body
-            }
-          }
-        ''',
-      );
-    });
-
-    test(
-        'are ${allowPartialUpgrades ? '' : 'not '}removed if containing class'
-        ' has lifecycle methods without codemods', () {
-      testSuggestor(
-        expectedPatchCount: allowPartialUpgrades ? 2 : 0,
-        input: '''
-          @Component2()
-          class FooComponent extends UiComponent2 {
-            void componentWillMount(){
-              super.componentWillMount();
-              // method body
-            }
-            
-            @override
-            componentWillUnmount() {}
-          }
-        ''',
-        expectedOutput: '''
-          @Component2()
-          class FooComponent extends UiComponent2 {
-            void ${allowPartialUpgrades ? 'init' : 'componentWillMount'}(){
-              ${allowPartialUpgrades ? '' : 'super.componentWillMount();'}
-              // method body
-            }
-            
-            @override
-            componentWillUnmount() {}
-          }
-        ''',
-      );
-    });
-  });
-
-  test('does not change componentWillMount for non-component2 classes', () {
-    testSuggestor(
-      expectedPatchCount: 0,
-      input: '''
-        @Component()
-        class FooComponent extends UiComponent {
-          void componentWillMount(){
-            // method body
-          }
-        }
-      ''',
-    );
-  });
-
-  group('ComponentWillMountMigrator', () {
-    final testSuggestor = getSuggestorTester(ComponentWillMountMigrator());
-
-    test('empty file', () {
-      testSuggestor(expectedPatchCount: 0, input: '');
-    });
-
-    test('no matches', () {
-      testSuggestor(
-        expectedPatchCount: 0,
-        input: '''
-          library foo;
-          var a = 'b';
-          class Foo {}
-        ''',
-      );
-    });
-
-    group('when componentDidMount does not exist in containing class', () {
-      test('componentWillMount method updates', () {
+  group('when componentDidMount does not exist in containing class', () {
+    group('componentWillMount method', () {
+      test('updates if containing class is fully upgradable', () {
         testSuggestor(
           expectedPatchCount: 2,
           input: '''
             @Component2()
             class FooComponent extends UiComponent2 {
-              @override
               componentWillMount(){
                 // method body
               }
@@ -335,7 +64,6 @@ componentWillMountTests({bool allowPartialUpgrades}) {
             @Component2()
             class FooComponent extends UiComponent2 {
               $componentWillMountMessage
-              @override
               componentDidMount(){
                 // method body
               }
@@ -344,75 +72,117 @@ componentWillMountTests({bool allowPartialUpgrades}) {
         );
       });
 
-      test('componentWillMount method with return type updates', () {
-        testSuggestor(
-          expectedPatchCount: 2,
-          input: '''
-            import 'package:react/react.dart' as react;
-            
-            @Component2()
-            class FooComponent extends react.Component2 {
-              void componentWillMount(){
-                // method body
+      group(
+          '${allowPartialUpgrades ? 'updates' : 'does not update'} if '
+          'containing class is not fully upgradable', () {
+        test('-- extends from non-Component class', () {
+          testSuggestor(
+            expectedPatchCount: allowPartialUpgrades ? 2 : 0,
+            input: '''
+              @Component2()
+              class FooComponent extends SomeOtherClass {
+                componentWillMount(){
+                  // method body
+                }
               }
-            }
-          ''',
-          expectedOutput: '''
-            import 'package:react/react.dart' as react;
-            
-            @Component2()
-            class FooComponent extends react.Component2 {
-              $componentWillMountMessage
-              void componentDidMount(){
-                // method body
+            ''',
+            expectedOutput: '''
+              @Component2()
+              class FooComponent extends SomeOtherClass {
+                ${allowPartialUpgrades ? '$componentWillMountMessage\ncomponentDidMount' : 'componentWillMount'}(){
+                  // method body
+                }
               }
-            }
-          ''',
-        );
-      });
+            ''',
+          );
+        });
 
-      test('update super calls to componentDidMount', () {
-        testSuggestor(
-          expectedPatchCount: 3,
-          input: '''
-            @Component2()
-            class FooComponent extends FluxUiComponent2 {
-              void componentWillMount(){
-                super.componentWillMount();
-                // method body
+        test('-- has lifecycle methods without codemods', () {
+          testSuggestor(
+            expectedPatchCount: allowPartialUpgrades ? 2 : 0,
+            input: '''
+              @Component2()
+              class FooComponent extends UiComponent2 {
+                componentWillMount(){
+                  // method body
+                }
+                
+                @override
+                componentWillUnmount() {}
               }
-            }
-          ''',
-          expectedOutput: '''
-            @Component2()
-            class FooComponent extends FluxUiComponent2 {
-              $componentWillMountMessage
-              void componentDidMount(){
-                super.componentDidMount();
-                // method body
+            ''',
+            expectedOutput: '''
+              @Component2()
+              class FooComponent extends UiComponent2 {
+                ${allowPartialUpgrades ? '$componentWillMountMessage\ncomponentDidMount' : 'componentWillMount'}(){
+                  // method body
+                }
+                
+                @override
+                componentWillUnmount() {}
               }
-            }
-          ''',
-        );
-      });
-
-      test('does not change componentWillMount for non-component2 classes', () {
-        testSuggestor(
-          expectedPatchCount: 0,
-          input: '''
-            @Component()
-            class FooComponent extends UiComponent {
-              void componentWillMount(){
-                // method body
-              }
-            }
-          ''',
-        );
+            ''',
+          );
+        });
       });
     });
 
-    group('when componentDidMount exists in containing class', () {
-      test('componentWillMount method updates', () {
+    test('componentWillMount method with return type updates', () {
+      testSuggestor(
+        expectedPatchCount: 2,
+        input: '''
+          import 'package:react/react.dart' as react;
+  
+          @Component2()
+          class FooComponent extends react.Component2 {
+            void componentWillMount(){
+              // method body
+            }
+          }
+        ''',
+        expectedOutput: '''
+          import 'package:react/react.dart' as react;
+  
+          @Component2()
+          class FooComponent extends react.Component2 {
+            $componentWillMountMessage
+            void componentDidMount(){
+              // method body
+            }
+          }
+        ''',
+      );
+    });
+
+    test('update super calls from componentDidMount to componentDidMount', () {
+      testSuggestor(
+        expectedPatchCount: 3,
+        input: '''
+          @Component2()
+          class FooComponent extends FluxUiComponent2 {
+            void componentWillMount(){
+              super.componentWillMount();
+              // method body
+            }
+          }
+        ''',
+        expectedOutput: '''
+          @Component2()
+          class FooComponent extends FluxUiComponent2 {
+            $componentWillMountMessage
+            void componentDidMount(){
+              super.componentDidMount();
+              // method body
+            }
+          }
+        ''',
+      );
+    });
+  });
+
+  group('when componentDidMount exists in containing class', () {
+    group('componentWillMount method', () {
+      test('updates if containing class is fully upgradable', () {
         testSuggestor(
           expectedPatchCount: 2,
           input: '''
@@ -446,67 +216,83 @@ componentWillMountTests({bool allowPartialUpgrades}) {
         );
       });
 
-      test('componentWillMount method with return type updates', () {
-        testSuggestor(
-          expectedPatchCount: 2,
-          input: '''
-            import 'package:react/react.dart' as react;
-            
-            @Component2()
-            class FooComponent extends react.Component2 {
-              void componentWillMount() {
-                var a = 1;
-                var b = 2;
+      group(
+          '${allowPartialUpgrades ? 'updates' : 'does not update'} if '
+          'containing class is not fully upgradable', () {
+        test('-- extends from non-Component class', () {
+          testSuggestor(
+            expectedPatchCount: allowPartialUpgrades ? 2 : 0,
+            input: '''
+              @Component2()
+              class FooComponent extends SomeOtherClass {
+                @override
+                componentWillMount() {
+                  var a = 1;
+                  var b = 2;
+                }
+                
+                @override
+                componentDidMount() {
+                  var c = 3;
+                  var d = 4;
+                }
               }
-              
-              void componentDidMount() {
-                var c = 3;
-                var d = 4;
+            ''',
+          );
+        });
+
+        test('-- has lifecycle methods without codemods', () {
+          testSuggestor(
+            expectedPatchCount: allowPartialUpgrades ? 2 : 0,
+            input: '''
+              @Component2()
+              class FooComponent extends UiComponent2 {
+                @override
+                componentWillMount() {
+                  var a = 1;
+                  var b = 2;
+                }
+                
+                @override
+                componentDidMount() {
+                  var c = 3;
+                  var d = 4;
+                }
+                
+                @override
+                componentWillUnmount() {}
               }
-            }
-          ''',
-          expectedOutput: '''
-            import 'package:react/react.dart' as react;
-            
-            @Component2()
-            class FooComponent extends react.Component2 {
-              void componentDidMount() {
-                var c = 3;
-                var d = 4;
-                var a = 1;
-                var b = 2;
-              }
-            }
-          ''',
-        );
+            ''',
+          );
+        });
       });
 
       test('update super call to componentWillMount if not already existing',
-              () {
-            testSuggestor(
-              expectedPatchCount: 2,
-              input: '''
+          () {
+        testSuggestor(
+          expectedPatchCount: 2,
+          input: '''
             @Component2()
             class FooComponent extends FluxUiComponent2 {
               @override
-              componentDidMount() {
+              void componentDidMount() {
                 var c = 3;
                 var d = 4;
               }
               
               @override
-              componentWillMount() {
+              void componentWillMount() {
                 super.componentWillMount();
                 var a = 1;
                 var b = 2;
               }
             }
           ''',
-              expectedOutput: '''
+          expectedOutput: '''
             @Component2()
             class FooComponent extends FluxUiComponent2 {
               @override
-              componentDidMount() {
+              void componentDidMount() {
                 var c = 3;
                 var d = 4;
                 super.componentDidMount();
@@ -515,8 +301,8 @@ componentWillMountTests({bool allowPartialUpgrades}) {
               }
             }
           ''',
-            );
-          });
+        );
+      });
 
       test('remove super call if it already exists in componentDidMount', () {
         testSuggestor(
@@ -619,30 +405,30 @@ componentWillMountTests({bool allowPartialUpgrades}) {
           ''',
         );
       });
-
-      test('does not change componentWillMount for non-component2 classes', () {
-        testSuggestor(
-          expectedPatchCount: 0,
-          input: '''
-          @Component()
-            class FooComponent extends FluxUiComponent {
-              @override
-              componentDidMount() {
-                super.componentDidMount();
-                var c = 3;
-                var d = 4;
-              }
-              
-              @override
-              componentWillMount() {
-                super.componentWillMount();
-                var a = 1;
-                var b = 2;
-              }
-            }
-        ''',
-        );
-      });
     });
+  });
+
+  test('does not change componentWillMount for non-component2 classes', () {
+    testSuggestor(
+      expectedPatchCount: 0,
+      input: '''
+        @Component()
+          class FooComponent extends FluxUiComponent {
+            @override
+            componentDidMount() {
+              super.componentDidMount();
+              var c = 3;
+              var d = 4;
+            }
+            
+            @override
+            componentWillMount() {
+              super.componentWillMount();
+              var a = 1;
+              var b = 2;
+            }
+          }
+      ''',
+    );
   });
 }

--- a/test/component2_suggestors/componentwillmount_migrator_test.dart
+++ b/test/component2_suggestors/componentwillmount_migrator_test.dart
@@ -154,7 +154,7 @@ componentWillMountTests({bool allowPartialUpgrades}) {
       );
     });
 
-    test('update super calls from componentDidMount to componentDidMount', () {
+    test('update super calls', () {
       testSuggestor(
         expectedPatchCount: 3,
         input: '''

--- a/test/component2_suggestors/componentwillmount_migrator_test.dart
+++ b/test/component2_suggestors/componentwillmount_migrator_test.dart
@@ -65,8 +65,7 @@ componentWillMountTests({
   });
 
   group('when componentDidMount does not exist in containing class', () {
-    group('componentWillMount method', ()
-    {
+    group('componentWillMount method', () {
       test('updates if containing class is fully upgradable', () {
         testSuggestor(
           expectedPatchCount: 2,
@@ -92,7 +91,7 @@ componentWillMountTests({
 
       group(
           '${allowPartialUpgrades ? 'updates' : 'does not update'} if '
-              'containing class is not fully upgradable', () {
+          'containing class is not fully upgradable', () {
         test('-- extends from non-Component class', () {
           testSuggestor(
             expectedPatchCount: allowPartialUpgrades ? 2 : 0,
@@ -107,9 +106,7 @@ componentWillMountTests({
             expectedOutput: '''
               @Component2()
               class FooComponent extends SomeOtherClass {
-                ${allowPartialUpgrades
-                ? '$componentWillMountMessage\ncomponentDidMount'
-                : 'componentWillMount'}(){
+                ${allowPartialUpgrades ? '$componentWillMountMessage\ncomponentDidMount' : 'componentWillMount'}(){
                   // method body
                 }
               }
@@ -134,9 +131,7 @@ componentWillMountTests({
             expectedOutput: '''
             @Component2()
             class FooComponent extends UiComponent2 {
-              ${allowPartialUpgrades
-                ? '$componentWillMountMessage\ncomponentDidMount'
-                : 'componentWillMount'}(){
+              ${allowPartialUpgrades ? '$componentWillMountMessage\ncomponentDidMount' : 'componentWillMount'}(){
                 // method body
               }
               
@@ -503,9 +498,12 @@ componentWillMountTests({
   });
 
   group('componentWillMount method in an abstract class', () {
-    test('that is fully upgradable ${shouldUpgradeAbstractComponents ? 'updates' : 'does not update'}', () {
+    test(
+        'that is fully upgradable ${shouldUpgradeAbstractComponents ? 'updates' : 'does not update'}',
+        () {
       testSuggestor(
-        expectedPatchCount: allowPartialUpgrades && shouldUpgradeAbstractComponents ? 2 : 0,
+        expectedPatchCount:
+            allowPartialUpgrades && shouldUpgradeAbstractComponents ? 2 : 0,
         input: '''
           @AbstractComponent2()
           abstract class FooComponent extends SomeOtherClass {
@@ -522,7 +520,8 @@ componentWillMountTests({
             }
           }
         ''',
-        expectedOutput: allowPartialUpgrades && shouldUpgradeAbstractComponents ? '''
+        expectedOutput: allowPartialUpgrades && shouldUpgradeAbstractComponents
+            ? '''
           @AbstractComponent2()
           abstract class FooComponent extends SomeOtherClass {
             @override
@@ -534,7 +533,8 @@ componentWillMountTests({
               var b = 2;
             }
           }
-        ''' : '''
+        '''
+            : '''
           @AbstractComponent2()
           abstract class FooComponent extends SomeOtherClass {
             @override
@@ -553,11 +553,13 @@ componentWillMountTests({
       );
     });
 
-    group('that is not fully upgradable ${allowPartialUpgrades && shouldUpgradeAbstractComponents ? 'updates' : 'does not update'}', () {
+    group(
+        'that is not fully upgradable ${allowPartialUpgrades && shouldUpgradeAbstractComponents ? 'updates' : 'does not update'}',
+        () {
       test('-- extends from non-Component class', () {
         testSuggestor(
           expectedPatchCount:
-          allowPartialUpgrades && shouldUpgradeAbstractComponents ? 2 : 0,
+              allowPartialUpgrades && shouldUpgradeAbstractComponents ? 2 : 0,
           input: '''
           @Component2
           class FooComponent<BarProps> extends SomeOtherClass<FooProps> {
@@ -579,7 +581,8 @@ componentWillMountTests({
 
       test('-- has lifecycle methods without codemods', () {
         testSuggestor(
-          expectedPatchCount: allowPartialUpgrades && shouldUpgradeAbstractComponents ? 2 : 0,
+          expectedPatchCount:
+              allowPartialUpgrades && shouldUpgradeAbstractComponents ? 2 : 0,
           input: '''
             @AbstractComponent2()
             abstract class FooComponent extends UiComponent2 {
@@ -591,7 +594,7 @@ componentWillMountTests({
               componentWillReceiveProps() {}
             }
           ''',
-            expectedOutput: '''
+          expectedOutput: '''
             @AbstractComponent2()
             abstract class FooComponent extends UiComponent2 {
               ${allowPartialUpgrades && shouldUpgradeAbstractComponents ? '$componentWillMountMessage\ncomponentDidMount' : 'componentWillMount'}(){

--- a/test/component2_suggestors/componentwillmount_migrator_test.dart
+++ b/test/component2_suggestors/componentwillmount_migrator_test.dart
@@ -223,11 +223,11 @@ componentWillMountTests({
             class FooComponent extends UiComponent2 {
               @override
               componentDidMount() {
-                var c = 3;
-                var d = 4;
-                
                 var a = 1;
                 var b = 2;
+                
+                var c = 3;
+                var d = 4;
               }
             }
           ''',
@@ -262,11 +262,11 @@ componentWillMountTests({
               class FooComponent extends SomeOtherClass {
                 @override
                 componentDidMount() {
-                  var c = 3;
-                  var d = 4;
-                  
                   var a = 1;
                   var b = 2;
+                  
+                  var c = 3;
+                  var d = 4;
                 }
               }
             '''
@@ -317,11 +317,11 @@ componentWillMountTests({
               class FooComponent extends UiComponent2 {
                 @override
                 componentDidMount() {
-                  var c = 3;
-                  var d = 4;
-                  
                   var a = 1;
                   var b = 2;
+                  
+                  var c = 3;
+                  var d = 4;
                 }
                 
                 @override
@@ -378,12 +378,12 @@ componentWillMountTests({
               $componentWillMountMessage
               @override
               void componentDidMount() {
-                var c = 3;
-                var d = 4;
-                
                 super.componentDidMount();
                 var a = 1;
                 var b = 2;
+                
+                var c = 3;
+                var d = 4;
               }
             }
           ''',
@@ -418,12 +418,12 @@ componentWillMountTests({
               @override
               @mustCallSuper
               componentDidMount() {
+                var a = 1;
+                var b = 2;
+                
                 super.componentDidMount();
                 var c = 3;
                 var d = 4;
-                
-                var a = 1;
-                var b = 2;
               }
             }
           ''',
@@ -454,9 +454,9 @@ componentWillMountTests({
               @mustCallSuper
               @override
               componentDidMount() {
-                // `componentDidMount` method body
-                
                 // `componentWillMount` method body
+                
+                // `componentDidMount` method body
               }
             }
           ''',
@@ -486,9 +486,9 @@ componentWillMountTests({
               @override
               @mustCallSuper
               componentDidMount() {
-                var c = 3;
-                
                 var a = 1;
+                
+                var c = 3;
               }
             }
           ''',
@@ -526,11 +526,11 @@ componentWillMountTests({
           abstract class FooComponent extends SomeOtherClass {
             @override
             componentDidMount() {
-              var c = 3;
-              var d = 4;
-              
               var a = 1;
               var b = 2;
+              
+              var c = 3;
+              var d = 4;
             }
           }
         '''

--- a/test/component2_suggestors/componentwillmount_migrator_test.dart
+++ b/test/component2_suggestors/componentwillmount_migrator_test.dart
@@ -72,7 +72,7 @@ main() {
             @Component2()
             class FooComponent extends react.Component2 {
               void componentWillMount(){
-                  // method body
+                // method body
               }
             }
           ''',
@@ -83,7 +83,7 @@ main() {
             class FooComponent extends react.Component2 {
               $componentWillMountMessage
               void componentDidMount(){
-                  // method body
+                // method body
               }
             }
           ''',
@@ -173,13 +173,11 @@ main() {
             
             @Component2()
             class FooComponent extends react.Component2 {
-              @override
               void componentWillMount() {
                 var a = 1;
                 var b = 2;
               }
               
-              @override
               void componentDidMount() {
                 var c = 3;
                 var d = 4;
@@ -191,7 +189,6 @@ main() {
             
             @Component2()
             class FooComponent extends react.Component2 {
-              @override
               void componentDidMount() {
                 var c = 3;
                 var d = 4;
@@ -247,6 +244,7 @@ main() {
             @Component2()
             class FooComponent extends FluxUiComponent2 {
               @override
+              @mustCallSuper
               componentDidMount() {
                 super.componentDidMount();
                 var c = 3;
@@ -265,6 +263,7 @@ main() {
             @Component2()
             class FooComponent extends FluxUiComponent2 {
               @override
+              @mustCallSuper
               componentDidMount() {
                 super.componentDidMount();
                 var c = 3;
@@ -277,16 +276,89 @@ main() {
         );
       });
 
+      test('copy any annotations not already present to componentDidMount', () {
+        testSuggestor(
+          expectedPatchCount: 3,
+          input: '''
+            @Component2()
+            class FooComponent extends FluxUiComponent2 {
+              @override
+              componentDidMount() {
+                var c = 3;
+              }
+              
+              @override
+              @mustCallSuper
+              componentWillMount() {
+                var a = 1;
+              }
+            }
+          ''',
+          expectedOutput: '''
+            @Component2()
+            class FooComponent extends FluxUiComponent2 {
+              @override
+              @mustCallSuper
+              componentDidMount() {
+                var c = 3;
+                var a = 1;
+              }
+            }
+          ''',
+        );
+      });
+
+      test('copy any annotations to annotationless componentDidMount', () {
+        testSuggestor(
+          expectedPatchCount: 3,
+          input: '''
+            @Component2()
+            class FooComponent extends FluxUiComponent2 {
+              componentDidMount() {
+                var c = 3;
+              }
+              
+              @override
+              @mustCallSuper
+              componentWillMount() {
+                var a = 1;
+              }
+            }
+          ''',
+          expectedOutput: '''
+            @Component2()
+            class FooComponent extends FluxUiComponent2 {
+              @override
+              @mustCallSuper
+              componentDidMount() {
+                var c = 3;
+                var a = 1;
+              }
+            }
+          ''',
+        );
+      });
+
       test('does not change componentWillMount for non-component2 classes', () {
         testSuggestor(
           expectedPatchCount: 0,
           input: '''
           @Component()
-          class FooComponent extends UiComponent {
-              void componentWillMount(){
-                  // method body
+            class FooComponent extends FluxUiComponent {
+              @override
+              componentDidMount() {
+                super.componentDidMount();
+                var c = 3;
+                var d = 4;
               }
-          }
+              
+              @override
+              componentWillMount() {
+                super.componentWillMount();
+                var a = 1;
+                var b = 2;
+              }
+            }
         ''',
         );
       });

--- a/test/component2_suggestors/componentwillmount_migrator_test.dart
+++ b/test/component2_suggestors/componentwillmount_migrator_test.dart
@@ -97,7 +97,7 @@ componentWillMountTests({bool allowPartialUpgrades}) {
           );
         });
 
-        test('-- has lifecycle methods without codemods', () {
+        test('-- has deprecated lifecycle methods without codemods', () {
           testSuggestor(
             expectedPatchCount: allowPartialUpgrades ? 2 : 0,
             input: '''
@@ -108,7 +108,7 @@ componentWillMountTests({bool allowPartialUpgrades}) {
                 }
                 
                 @override
-                componentWillUnmount() {}
+                componentWillReceiveProps() {}
               }
             ''',
             expectedOutput: '''
@@ -119,7 +119,7 @@ componentWillMountTests({bool allowPartialUpgrades}) {
                 }
                 
                 @override
-                componentWillUnmount() {}
+                componentWillReceiveProps() {}
               }
             ''',
           );
@@ -270,7 +270,7 @@ componentWillMountTests({bool allowPartialUpgrades}) {
           );
         });
 
-        test('-- has lifecycle methods without codemods', () {
+        test('-- has deprecated lifecycle methods without codemods', () {
           testSuggestor(
             expectedPatchCount: allowPartialUpgrades ? 2 : 0,
             input: '''
@@ -289,7 +289,7 @@ componentWillMountTests({bool allowPartialUpgrades}) {
                 }
                 
                 @override
-                componentWillUnmount() {}
+                componentWillUpdate() {}
               }
             ''',
             expectedOutput: allowPartialUpgrades
@@ -305,12 +305,12 @@ componentWillMountTests({bool allowPartialUpgrades}) {
                 }
                 
                 @override
-                componentWillUnmount() {}
+                componentWillUpdate() {}
               }
             '''
                 : '''
               @Component2()
-              class FooComponent extends SomeOtherClass {
+              class FooComponent extends UiComponent2 {
                 @override
                 componentWillMount() {
                   var a = 1;
@@ -324,7 +324,7 @@ componentWillMountTests({bool allowPartialUpgrades}) {
                 }
                 
                 @override
-                componentWillUnmount() {}
+                componentWillUpdate() {}
               }
             ''',
           );

--- a/test/component2_suggestors/componentwillmount_migrator_test.dart
+++ b/test/component2_suggestors/componentwillmount_migrator_test.dart
@@ -428,8 +428,8 @@ componentWillMountTests({bool allowPartialUpgrades}) {
           expectedOutput: '''
             @Component2()
             class FooComponent extends FluxUiComponent2 {
-              @override
               @mustCallSuper
+              @override
               componentDidMount() {
                 var c = 3;
                 var a = 1;

--- a/test/component2_suggestors/componentwillmount_migrator_test.dart
+++ b/test/component2_suggestors/componentwillmount_migrator_test.dart
@@ -127,7 +127,7 @@ componentWillMountTests({bool allowPartialUpgrades}) {
       });
     });
 
-    test('componentWillMount method with return type updates', () {
+    test('componentWillMount method with return type', () {
       testSuggestor(
         expectedPatchCount: 2,
         input: '''
@@ -208,6 +208,7 @@ componentWillMountTests({bool allowPartialUpgrades}) {
               componentDidMount() {
                 var c = 3;
                 var d = 4;
+                
                 var a = 1;
                 var b = 2;
               }
@@ -246,6 +247,7 @@ componentWillMountTests({bool allowPartialUpgrades}) {
                 componentDidMount() {
                   var c = 3;
                   var d = 4;
+                  
                   var a = 1;
                   var b = 2;
                 }
@@ -300,6 +302,7 @@ componentWillMountTests({bool allowPartialUpgrades}) {
                 componentDidMount() {
                   var c = 3;
                   var d = 4;
+                  
                   var a = 1;
                   var b = 2;
                 }
@@ -334,7 +337,7 @@ componentWillMountTests({bool allowPartialUpgrades}) {
       test('update super call to componentWillMount if not already existing',
           () {
         testSuggestor(
-          expectedPatchCount: 2,
+          expectedPatchCount: 3,
           input: '''
             @Component2()
             class FooComponent extends FluxUiComponent2 {
@@ -355,10 +358,12 @@ componentWillMountTests({bool allowPartialUpgrades}) {
           expectedOutput: '''
             @Component2()
             class FooComponent extends FluxUiComponent2 {
+              $componentWillMountMessage
               @override
               void componentDidMount() {
                 var c = 3;
                 var d = 4;
+                
                 super.componentDidMount();
                 var a = 1;
                 var b = 2;
@@ -399,6 +404,7 @@ componentWillMountTests({bool allowPartialUpgrades}) {
                 super.componentDidMount();
                 var c = 3;
                 var d = 4;
+                
                 var a = 1;
                 var b = 2;
               }
@@ -415,13 +421,13 @@ componentWillMountTests({bool allowPartialUpgrades}) {
             class FooComponent extends FluxUiComponent2 {
               @override
               componentDidMount() {
-                var c = 3;
+                // `componentDidMount` method body
               }
               
               @override
               @mustCallSuper
               componentWillMount() {
-                var a = 1;
+                // `componentWillMount` method body
               }
             }
           ''',
@@ -431,8 +437,9 @@ componentWillMountTests({bool allowPartialUpgrades}) {
               @mustCallSuper
               @override
               componentDidMount() {
-                var c = 3;
-                var a = 1;
+                // `componentDidMount` method body
+                
+                // `componentWillMount` method body
               }
             }
           ''',
@@ -463,6 +470,7 @@ componentWillMountTests({bool allowPartialUpgrades}) {
               @mustCallSuper
               componentDidMount() {
                 var c = 3;
+                
                 var a = 1;
               }
             }

--- a/test/component2_suggestors/copyunconsumeddomprops_migrator_test.dart
+++ b/test/component2_suggestors/copyunconsumeddomprops_migrator_test.dart
@@ -222,7 +222,7 @@ copyUnconsumedDomPropsTests({
           );
         });
 
-        test('-- has lifecycle methods without codemods', () {
+        test('-- has deprecated lifecycle methods without codemods', () {
           testSuggestor(
             expectedPatchCount:
                 allowPartialUpgrades && shouldUpgradeAbstractComponents ? 2 : 0,
@@ -240,7 +240,7 @@ copyUnconsumedDomPropsTests({
                 }
                 
                 @override
-                componentWillUnmount() {}
+                componentWillUpdate() {}
               }
             ''',
             expectedOutput: '''
@@ -257,7 +257,7 @@ copyUnconsumedDomPropsTests({
                 }
                 
                 @override
-                componentWillUnmount() {}
+                componentWillUpdate() {}
               }
             ''',
           );

--- a/test/component2_suggestors/copyunconsumeddomprops_migrator_test.dart
+++ b/test/component2_suggestors/copyunconsumeddomprops_migrator_test.dart
@@ -106,7 +106,7 @@ copyUnconsumedDomPropsTests({bool allowPartialUpgrades}) {
         );
       });
 
-      test('-- has lifecycle methods without codemods', () {
+      test('-- has deprecated lifecycle methods without codemods', () {
         testSuggestor(
           expectedPatchCount: allowPartialUpgrades ? 2 : 0,
           input: '''
@@ -120,7 +120,7 @@ copyUnconsumedDomPropsTests({bool allowPartialUpgrades}) {
               }
               
               @override
-              componentWillUnmount() {}
+              componentWillUpdate() {}
             }
           ''',
           expectedOutput: '''
@@ -134,7 +134,7 @@ copyUnconsumedDomPropsTests({bool allowPartialUpgrades}) {
               }
               
               @override
-              componentWillUnmount() {}
+              componentWillUpdate() {}
             }
           ''',
         );
@@ -204,7 +204,7 @@ copyUnconsumedDomPropsTests({bool allowPartialUpgrades}) {
         );
       });
 
-      test('-- has lifecycle methods without codemods', () {
+      test('-- has deprecated lifecycle methods without codemods', () {
         testSuggestor(
           expectedPatchCount: allowPartialUpgrades ? 2 : 0,
           input: '''
@@ -220,7 +220,7 @@ copyUnconsumedDomPropsTests({bool allowPartialUpgrades}) {
               }
               
               @override
-              componentWillUnmount() {}
+              componentWillReceiveProps() {}
             }
           ''',
           expectedOutput: '''
@@ -236,7 +236,7 @@ copyUnconsumedDomPropsTests({bool allowPartialUpgrades}) {
               }
               
               @override
-              componentWillUnmount() {}
+              componentWillReceiveProps() {}
             }
           ''',
         );

--- a/test/component2_suggestors/setState_updater_test.dart
+++ b/test/component2_suggestors/setState_updater_test.dart
@@ -101,7 +101,7 @@ setStateTests({bool allowPartialUpgrades}) {
           );
         });
 
-        test('-- has lifecycle methods without codemods', () {
+        test('-- has deprecated lifecycle methods without codemods', () {
           testSuggestor(
             expectedPatchCount: allowPartialUpgrades ? 1 : 0,
             input: '''
@@ -180,7 +180,7 @@ setStateTests({bool allowPartialUpgrades}) {
             );
           });
 
-          test('-- has lifecycle methods without codemods', () {
+          test('-- has deprecated lifecycle methods without codemods', () {
             testSuggestor(
               expectedPatchCount: allowPartialUpgrades ? 1 : 0,
               input: '''

--- a/test/component2_suggestors/setState_updater_test.dart
+++ b/test/component2_suggestors/setState_updater_test.dart
@@ -207,7 +207,7 @@ setStateTests({
             );
           });
 
-          test('-- has lifecycle methods without codemods', () {
+          test('-- has deprecated lifecycle methods without codemods', () {
             testSuggestor(
               expectedPatchCount:
                   allowPartialUpgrades && shouldUpgradeAbstractComponents


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Part of [CPLAT-5212](https://jira.atl.workiva.net/browse/CPLAT-5212) was to add a suggestor that takes `componentWillMount` and transitions it to `init`. 

We need to modify that to go from `componentWillMount` to `componentDidMount`.
## Changes
  <!-- What this PR changes to fix the problem. -->
- Update the `componentWillMount` suggestor with the following changes:
   - If there is also a `componentDidMount` in that component
      - Move the body of `componentWillMount` to the beginning of componentDidMount
      - Copy any annotations not already present to `componentDidMount` (e.g., `@mustCallSuper`)
      - Remove componentWillMount.
      - If the `componentWillMount` had a super-call, change it to `componentDidMount`
          - UNLESS there's already a super-call in the existing `componentDidMount`
   - If there is **not** a `componentDidMount` in that component
      - Rename `componentWillMount` to `componentDidMount`.
      - Add a fixme comment instructing consumers to check if there should be a super-call.
- Add test coverage.
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->
@kealjones-wk @greglittlefield-wf @aaronlademann-wf @joebingham-wk 
### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
      - [ ] CI passes
      - [ ] Run the Component2 codemod on web_skin_dart and verify that the codemod updates `componentWillMount` based on the above criteria.
        - `pub global run over_react_codemod:component2_upgrade`
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
