### PR TITLE
CPLAT-7372: Fix errors caused by trying to parse versions from dependency overrides

### DIFF
--- a/lib/src/dart2_suggestors/pubspec_over_react_upgrader.dart
+++ b/lib/src/dart2_suggestors/pubspec_over_react_upgrader.dart
@@ -93,7 +93,7 @@ class PubspecOverReactUpgrader implements Suggestor {
               '  over_react: $newValue');
         }
       } catch (e) {
-        // We can skip these they are versions we dont want to mess with in this codemod
+        // We can skip these. They are versions we don't want to mess with in this codemod.
         if (e.toString().contains('git:') || e.toString().contains('path:'))
           return;
         rethrow;

--- a/lib/src/react16_suggestors/pubspec_react_upgrader.dart
+++ b/lib/src/react16_suggestors/pubspec_react_upgrader.dart
@@ -64,7 +64,7 @@ class PubspecReactUpdater implements Suggestor {
               '  react: $newValue');
         }
       } catch (e) {
-        // We can skip these they are versions we dont want to mess with in this codemod
+        // We can skip these. They are versions we don't want to mess with in this codemod.
         if (e.toString().contains('git:') || e.toString().contains('path:'))
           return;
         rethrow;

--- a/test/dart2_suggestors/pubspec_over_react_upgrader_test.dart
+++ b/test/dart2_suggestors/pubspec_over_react_upgrader_test.dart
@@ -79,6 +79,43 @@ main() {
               '',
         );
       });
+
+      group('does not attempt to update dependency_overrides', () {
+        test('git', () {
+          defaultTestSuggestor(
+              expectedPatchCount: 0,
+              shouldDartfmtOutput: false,
+              validateContents: validatePubspecYaml,
+              input: ''
+                  'dependency_overrides:\n'
+                  '  over_react:\n'
+                  '    git:\n'
+                  '      url: git@github.com:cleandart/react-dart.git\n'
+                  '      ref: 5.0.0-wip\n',
+              expectedOutput: ''
+                  'dependency_overrides:\n'
+                  '  over_react:\n'
+                  '    git:\n'
+                  '      url: git@github.com:cleandart/react-dart.git\n'
+                  '      ref: 5.0.0-wip\n');
+        });
+
+        test('path', () {
+          defaultTestSuggestor(
+            expectedPatchCount: 0,
+            shouldDartfmtOutput: false,
+            validateContents: validatePubspecYaml,
+            input: ''
+                'dependency_overrides:\n'
+                '  over_react:\n'
+                '    path: ../\n',
+            expectedOutput: ''
+                'dependency_overrides:\n'
+                '  over_react:\n'
+                '    path: ../\n',
+          );
+        });
+      });
     });
 
     group('with shouldAlwaysUpdate true', () {
@@ -93,6 +130,43 @@ main() {
         dependency: dependency,
         midVersionRange: midRangeMark,
       );
+
+      group('does not attempt to update dependency_overrides', () {
+        test('git', () {
+          defaultTestSuggestor(
+              expectedPatchCount: 0,
+              shouldDartfmtOutput: false,
+              validateContents: validatePubspecYaml,
+              input: ''
+                  'dependency_overrides:\n'
+                  '  over_react:\n'
+                  '    git:\n'
+                  '      url: git@github.com:cleandart/react-dart.git\n'
+                  '      ref: 5.0.0-wip\n',
+              expectedOutput: ''
+                  'dependency_overrides:\n'
+                  '  over_react:\n'
+                  '    git:\n'
+                  '      url: git@github.com:cleandart/react-dart.git\n'
+                  '      ref: 5.0.0-wip\n');
+        });
+
+        test('path', () {
+          defaultTestSuggestor(
+            expectedPatchCount: 0,
+            shouldDartfmtOutput: false,
+            validateContents: validatePubspecYaml,
+            input: ''
+                'dependency_overrides:\n'
+                '  over_react:\n'
+                '    path: ../\n',
+            expectedOutput: ''
+                'dependency_overrides:\n'
+                '  over_react:\n'
+                '    path: ../\n',
+          );
+        });
+      });
     });
   });
 }

--- a/test/dart2_suggestors/pubspec_over_react_upgrader_test.dart
+++ b/test/dart2_suggestors/pubspec_over_react_upgrader_test.dart
@@ -83,15 +83,15 @@ main() {
       group('does not attempt to update dependency_overrides', () {
         test('git', () {
           defaultTestSuggestor(
-              expectedPatchCount: 0,
-              shouldDartfmtOutput: false,
-              validateContents: validatePubspecYaml,
-              input: ''
-                  'dependency_overrides:\n'
-                  '  over_react:\n'
-                  '    git:\n'
-                  '      url: git@github.com:cleandart/react-dart.git\n'
-                  '      ref: 5.0.0-wip\n',
+            expectedPatchCount: 0,
+            shouldDartfmtOutput: false,
+            validateContents: validatePubspecYaml,
+            input: ''
+                'dependency_overrides:\n'
+                '  over_react:\n'
+                '    git:\n'
+                '      url: git@github.com:cleandart/react-dart.git\n'
+                '      ref: 5.0.0-wip\n',
           );
         });
 

--- a/test/dart2_suggestors/pubspec_over_react_upgrader_test.dart
+++ b/test/dart2_suggestors/pubspec_over_react_upgrader_test.dart
@@ -92,12 +92,7 @@ main() {
                   '    git:\n'
                   '      url: git@github.com:cleandart/react-dart.git\n'
                   '      ref: 5.0.0-wip\n',
-              expectedOutput: ''
-                  'dependency_overrides:\n'
-                  '  over_react:\n'
-                  '    git:\n'
-                  '      url: git@github.com:cleandart/react-dart.git\n'
-                  '      ref: 5.0.0-wip\n');
+          );
         });
 
         test('path', () {
@@ -106,10 +101,6 @@ main() {
             shouldDartfmtOutput: false,
             validateContents: validatePubspecYaml,
             input: ''
-                'dependency_overrides:\n'
-                '  over_react:\n'
-                '    path: ../\n',
-            expectedOutput: ''
                 'dependency_overrides:\n'
                 '  over_react:\n'
                 '    path: ../\n',

--- a/test/react16_suggestors/pubspec_react_updater_test.dart
+++ b/test/react16_suggestors/pubspec_react_updater_test.dart
@@ -106,12 +106,7 @@ main() {
                 '    git:\n'
                 '      url: git@github.com:cleandart/react-dart.git\n'
                 '      ref: 5.0.0-wip\n',
-            expectedOutput: ''
-                'dependency_overrides:\n'
-                '  react:\n'
-                '    git:\n'
-                '      url: git@github.com:cleandart/react-dart.git\n'
-                '      ref: 5.0.0-wip\n');
+        );
       });
 
       test('path', () {
@@ -120,10 +115,6 @@ main() {
           shouldDartfmtOutput: false,
           validateContents: validatePubspecYaml,
           input: ''
-              'dependency_overrides:\n'
-              '  react:\n'
-              '    path: ../\n',
-          expectedOutput: ''
               'dependency_overrides:\n'
               '  react:\n'
               '    path: ../\n',

--- a/test/react16_suggestors/pubspec_react_updater_test.dart
+++ b/test/react16_suggestors/pubspec_react_updater_test.dart
@@ -97,15 +97,15 @@ main() {
     group('does not attempt to update dependency_overrides', () {
       test('git', () {
         testSuggestor(
-            expectedPatchCount: 0,
-            shouldDartfmtOutput: false,
-            validateContents: validatePubspecYaml,
-            input: ''
-                'dependency_overrides:\n'
-                '  react:\n'
-                '    git:\n'
-                '      url: git@github.com:cleandart/react-dart.git\n'
-                '      ref: 5.0.0-wip\n',
+          expectedPatchCount: 0,
+          shouldDartfmtOutput: false,
+          validateContents: validatePubspecYaml,
+          input: ''
+              'dependency_overrides:\n'
+              '  react:\n'
+              '    git:\n'
+              '      url: git@github.com:cleandart/react-dart.git\n'
+              '      ref: 5.0.0-wip\n',
         );
       });
 

--- a/test/react16_suggestors/pubspec_react_updater_test.dart
+++ b/test/react16_suggestors/pubspec_react_updater_test.dart
@@ -93,6 +93,43 @@ main() {
             '',
       );
     });
+
+    group('does not attempt to update dependency_overrides', () {
+      test('git', () {
+        testSuggestor(
+            expectedPatchCount: 0,
+            shouldDartfmtOutput: false,
+            validateContents: validatePubspecYaml,
+            input: ''
+                'dependency_overrides:\n'
+                '  react:\n'
+                '    git:\n'
+                '      url: git@github.com:cleandart/react-dart.git\n'
+                '      ref: 5.0.0-wip\n',
+            expectedOutput: ''
+                'dependency_overrides:\n'
+                '  react:\n'
+                '    git:\n'
+                '      url: git@github.com:cleandart/react-dart.git\n'
+                '      ref: 5.0.0-wip\n');
+      });
+
+      test('path', () {
+        testSuggestor(
+          expectedPatchCount: 0,
+          shouldDartfmtOutput: false,
+          validateContents: validatePubspecYaml,
+          input: ''
+              'dependency_overrides:\n'
+              '  react:\n'
+              '    path: ../\n',
+          expectedOutput: ''
+              'dependency_overrides:\n'
+              '  react:\n'
+              '    path: ../\n',
+        );
+      });
+    });
   });
 }
 


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
An unexpected issue was found when testing the codemod. If you run the react16_upgrade when it would try and parse the version of a dependency found in `dependency_overrides`, (aka the version value was like "git:" and/or "path: ../".

## Changes
  <!-- What this PR changes to fix the problem. -->
- Added a try that wraps the version parsing and in the catch return if we find "git:" or "path:" in the message of the error.
- Added regression tests for `dependency_overrides` with git and path overrides 

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
