### PR TITLE
RM-57798 Release over_react_codemod 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,11 @@
 
 - Add `component2_upgrade` codemod
 
-  - Migrates components to `UiComponent2` (coming in OverReact 3.1.0)
+  - Migrates components to `UiComponent2` (coming in over_react 3.1.0)
 
 - Add `react16_dependency_override_update` codemod
 
-  - Adds dependency overrides to pubspec.yaml for testing wip branches of react16
+  - Adds dependency overrides to pubspec.yaml for testing wip branches of React 16
 
 - Add `react16_ci_precheck` codemod
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## [1.3.0](https://github.com/Workiva/over_react_codemod/compare/1.2.0...1.3.0)
 
-- Add a flag --no-partial-upgrades to Component2 codemod executable that will
+- Add a flag `--no-partial-upgrades` to `component2_upgrade` codemod that will
   prevent partial component upgrades from occurring.
 
-- Fix a bug that could occur when parsing a pubsec version in `dependency_overrides` section.
+- Fix a bug that could occur when parsing a pubsec version in
+  `dependency_overrides` section.
 
 
 ## [1.2.0](https://github.com/Workiva/over_react_codemod/compare/1.1.0...1.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+## [1.3.0](https://github.com/Workiva/over_react_codemod/compare/1.2.0...1.3.0)
+
+- Add a flag --no-partial-upgrades to Component2 codemod executable that will prevent partial component upgrades from occurring
+
+- Fix a bug that could occur when parsing a pubsec version in `dependency_overrides` section.
+
+
+## [1.2.0](https://github.com/Workiva/over_react_codemod/compare/1.1.0...1.2.0)
+
+- Add `react16_upgrade` codemod
+
+  - Fix compatibility issues common in react15 code
+  - Update version upper bound of react and over_react in pubspec.yaml to
+    allow for incoming react16 updates
+
+- Add `component2_upgrade` codemod
+
+  - Migrates components to `UiComponent2` (coming in OverReact 3.1.0)
+
+- Add `react16_dependency_override_update` codemod
+
+  - Adds dependency overrides to pubspec.yaml for testing wip branches of react16
+
+- Add `react16_ci_precheck` codemod
+
+  - Checks the version ranges of over_react and react and if they are in
+    transition will run the codemod and fail if there are unaddressed issues.
+
+
 ## [1.1.0](https://github.com/Workiva/over_react_codemod/compare/1.0.2...1.1.0)
 
 - Two additional changes are now made by the `dart2_upgrade` codemod when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [1.3.0](https://github.com/Workiva/over_react_codemod/compare/1.2.0...1.3.0)
 
-- Add a flag --no-partial-upgrades to Component2 codemod executable that will prevent partial component upgrades from occurring
+- Add a flag --no-partial-upgrades to Component2 codemod executable that will
+  prevent partial component upgrades from occurring.
 
 - Fix a bug that could occur when parsing a pubsec version in `dependency_overrides` section.
 
@@ -9,9 +10,9 @@
 
 - Add `react16_upgrade` codemod
 
-  - Fix compatibility issues common in react15 code
+  - Fix compatibility issues common in react15 code.
   - Update version upper bound of react and over_react in pubspec.yaml to
-    allow for incoming react16 updates
+    allow for incoming react16 updates.
 
 - Add `component2_upgrade` codemod
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_codemod
-version: 1.2.0
+version: 1.3.0
 homepage: https://github.com/Workiva/over_react_codemod
 
 description: >


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [CPLAT-6936 Add flag to skip components that codemod can only partially upgrade](https://github.com/Workiva/over_react_codemod/pull/42)
	* [CPLAT-7372: Fix errors caused by trying to parse versions from dependency overrides](https://github.com/Workiva/over_react_codemod/pull/50)


Requested by: @kealjones-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react_codemod/compare/1.2.0...Workiva:release_over_react_codemod_1.3.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react_codemod/compare/1.2.0...1.3.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6153708125028352/logs/)