### PR TITLE
CPLAT-7393 Add logic to handle components with mixin(s)

### DIFF
--- a/lib/src/component2_suggestors/component2_constants.dart
+++ b/lib/src/component2_suggestors/component2_constants.dart
@@ -35,6 +35,3 @@ String getDeperecationMessage(String methodName) {
   ///
   $revertInstructions''';
 }
-
-const abstractClassMessage =
-    '/// FIXME: Abstract class has been updated to Component2. This is a breaking change if this class is exported.';

--- a/lib/src/component2_suggestors/component2_utilities.dart
+++ b/lib/src/component2_suggestors/component2_utilities.dart
@@ -50,10 +50,15 @@ bool extendsComponent2(ClassDeclaration classNode) {
   }
 }
 
+/// Returns whether or not [classNode] has one or more mixins.
+bool hasOneOrMoreMixins(ClassDeclaration classNode) =>
+    classNode?.withClause != null;
+
 /// Returns whether or not [classNode] can be fully upgraded to Component2.
 ///
 /// In order for a component to be fully upgradable, the component must:
 ///
+/// * not have a `with` clause
 /// * extend directly from `UiComponent`, `UiStatefulComponent`,
 /// `FluxUiComponent`, `FluxUiStatefulComponent`, or `react.Component`
 /// * contain only the lifecycle methods that the codemod updates:
@@ -63,6 +68,10 @@ bool extendsComponent2(ClassDeclaration classNode) {
 bool fullyUpgradableToComponent2(ClassDeclaration classNode) {
   var extendsName = classNode?.extendsClause?.superclass?.name;
   if (extendsName == null) {
+    return false;
+  }
+
+  if (hasOneOrMoreMixins(classNode)) {
     return false;
   }
 

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -72,6 +72,14 @@ const List<String> overReactMixinAnnotationNames = [
   'StateMixin',
 ];
 
+/// A list of the names of the core component classes that can be upgraded to a "v2" version.
+const List<String> upgradableV1ComponentClassNames = [
+  'UiComponent',
+  'UiStatefulComponent',
+  'FluxUiComponent',
+  'FluxUiStatefulComponent',
+];
+
 /// Dart type for the static meta field on props classes.
 const String propsMetaType = 'PropsMeta';
 

--- a/lib/src/react16_suggestors/react16_utilities.dart
+++ b/lib/src/react16_suggestors/react16_utilities.dart
@@ -51,13 +51,53 @@ bool hasComment(AstNode node, SourceFile sourceFile, String comment) {
   return commentText?.contains(comment) ?? false;
 }
 
+/// Whether the [node] has a documentation comment that has
+/// any lines that match lines found within the provided [comment].
+bool hasMultilineDocComment(
+    AnnotatedNode node, SourceFile sourceFile, String comment) {
+  final nodeComments = nodeCommentSpan(node, sourceFile)
+      .text
+      .replaceAll('///', '')
+      .split('\n')
+      .map((line) => line.replaceAll('\n', '').trim())
+      .toList()
+        ..removeWhere((line) => line.isEmpty);
+  final commentLines = comment
+      .replaceAll('///', '')
+      .trimLeft()
+      .split('\n')
+      .map((line) => line.replaceAll('\n', '').trim())
+      .toList()
+        ..removeWhere((line) => line.isEmpty);
+
+  bool match = false;
+
+  for (var i = 0; i < commentLines.length; i++) {
+    final potentialMatch = commentLines[i];
+    if (nodeComments.any((line) => line == potentialMatch)) {
+      match = true;
+      break;
+    }
+  }
+
+  return match;
+}
+
+/// Returns the `SourceSpan` value of any comments on the provided [node] within the [sourceFile].
+SourceSpan nodeCommentSpan(AnnotatedNode node, SourceFile sourceFile) {
+  return sourceFile.span(
+      node.beginToken.offset,
+      node.metadata?.beginToken?.offset ??
+          node.firstTokenAfterCommentAndMetadata.offset);
+}
+
 /// Returns an iterable of all the comments from [beginToken] to the end of the
 /// file.
 ///
 /// Comments are part of the normal stream, and need to be accessed via
 /// [Token.precedingComments], so it's difficult to iterate over them without
 /// this method.
-Iterable allComments(Token beginToken) sync* {
+Iterable<Token> allComments(Token beginToken) sync* {
   var currentToken = beginToken;
   while (!currentToken.isEof) {
     var currentComment = currentToken.precedingComments;

--- a/test/component2_suggestors/component2_utilities_test.dart
+++ b/test/component2_suggestors/component2_utilities_test.dart
@@ -280,6 +280,50 @@ void main() {
       });
     });
 
+    group('hasOneOrMoreMixins()', () {
+      group('returns true when a class has one mixin', () {
+        final input = '''
+          class FooComponent extends UiComponent with FooMixin {
+            // class body
+          }
+        ''';
+
+        testUtilityFunction(
+          input: input,
+          expectedValue: true,
+          functionToTest: hasOneOrMoreMixins,
+        );
+      });
+
+      group('returns true when a class has more than one mixin', () {
+        final input = '''
+          class FooComponent extends UiComponent with FooMixin, BarMixin {
+            // class body
+          }
+        ''';
+
+        testUtilityFunction(
+          input: input,
+          expectedValue: true,
+          functionToTest: hasOneOrMoreMixins,
+        );
+      });
+
+      group('returns false when a class has no mixins', () {
+        final input = '''
+          class FooComponent extends UiComponent {
+            // class body
+          }
+        ''';
+
+        testUtilityFunction(
+          input: input,
+          expectedValue: false,
+          functionToTest: hasOneOrMoreMixins,
+        );
+      });
+    });
+
     group('canBeFullyUpgradedToComponent2()', () {
       group('(fully upgradable) when a class', () {
         group('extends a base class and has no lifecycle methods', () {
@@ -363,6 +407,21 @@ void main() {
       });
 
       group('(not fully upgradable) when a class', () {
+        group('has one or more mixins', () {
+          final input = '''
+            @Component
+            class FooComponent extends UiComponent with FooMixin {
+              // class body
+            }
+          ''';
+
+          testUtilityFunction(
+            input: input,
+            expectedValue: false,
+            functionToTest: fullyUpgradableToComponent2,
+          );
+        });
+
         group('extends non-base classes', () {
           final input = '''
             @Component


### PR DESCRIPTION
## Motivation
`UIComponent`s with mixins could potentially be mixing in a class that implement component lifecycle methods that are unsupported in `Component2`.

## Changes
1. When [the `--no-partial-upgrades` flag](https://github.com/Workiva/over_react_codemod/pull/42) is `false`, add a `/// FIXME` comment to the component that has one or more mixins.
2. When [the `--no-partial-upgrades` flag](https://github.com/Workiva/over_react_codemod/pull/42) is `true`, skips the upgrade for the component that has one or more mixins.

#### Release Notes
Add logic to handle components with mixin(s) when upgrading to `UiComponent2`.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @greglittlefield-wf @kealjones-wk @sydneyjodon-wk @joebingham-wk 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - Passing CI
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
