### PR TITLE
Fix for version "any"

### DIFF
--- a/lib/src/dart2_suggestors/pubspec_over_react_upgrader.dart
+++ b/lib/src/dart2_suggestors/pubspec_over_react_upgrader.dart
@@ -94,8 +94,10 @@ class PubspecOverReactUpgrader implements Suggestor {
         }
       } catch (e) {
         // We can skip these. They are versions we don't want to mess with in this codemod.
-        if (e.toString().contains('git:') || e.toString().contains('path:'))
+        if (e.toString().contains('git:') || e.toString().contains('path:')) {
           return;
+        }
+
         rethrow;
       }
     } else if (shouldAddDependencies) {

--- a/lib/src/react16_suggestors/pubspec_react_upgrader.dart
+++ b/lib/src/react16_suggestors/pubspec_react_upgrader.dart
@@ -65,8 +65,10 @@ class PubspecReactUpdater implements Suggestor {
         }
       } catch (e) {
         // We can skip these. They are versions we don't want to mess with in this codemod.
-        if (e.toString().contains('git:') || e.toString().contains('path:'))
+        if (e.toString().contains('git:') || e.toString().contains('path:')) {
           return;
+        }
+
         rethrow;
       }
     } else if (shouldAddDependencies) {

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -361,9 +361,7 @@ bool shouldUpdateVersionRange({
     // Short circuit if the constraints are the same.
     if (targetConstraint == constraint) return false;
     // If this is null, the dependency is set to >= with no upper limit.
-    if (constraintsHaveMax &&
-        constraint.max == null &&
-        constraint.min != null) {
+    if (constraint.max == null && constraint.min != null) {
       // In that case, we need the min to be at least as high as our
       // target. If it is, do not update.
       if (constraint.min >= targetConstraint.min) {

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -352,12 +352,18 @@ bool shouldUpdateVersionRange({
   @required VersionRange targetConstraint,
   bool shouldIgnoreMin = false,
 }) {
+  if (constraint.isAny) return false;
   if (constraint is VersionRange) {
+    var constraintsHaveMax =
+        (targetConstraint.max != null && constraint.max != null);
+    var constraintsHaveMin =
+        (targetConstraint.min != null && constraint.min != null);
     // Short circuit if the constraints are the same.
     if (targetConstraint == constraint) return false;
-
     // If this is null, the dependency is set to >= with no upper limit.
-    if (constraint.max == null) {
+    if (constraintsHaveMax &&
+        constraint.max == null &&
+        constraint.min != null) {
       // In that case, we need the min to be at least as high as our
       // target. If it is, do not update.
       if (constraint.min >= targetConstraint.min) {
@@ -369,10 +375,12 @@ bool shouldUpdateVersionRange({
       // If there is a maximum, and it is higher than target max (but the
       // lower bound is still greater or equal to the target) do not
       // update.
-      if (constraint.max >= targetConstraint.max) {
+      if (constraintsHaveMax && constraint.max >= targetConstraint.max) {
         // If the codemod is asserting a specific minimum, the
         // constraint min does not matter.
-        if (constraint.min >= targetConstraint.min && !shouldIgnoreMin) {
+        if (constraintsHaveMin &&
+            constraint.min >= targetConstraint.min &&
+            !shouldIgnoreMin) {
           return false;
         }
       }

--- a/test/shared_pubspec_tests.dart
+++ b/test/shared_pubspec_tests.dart
@@ -91,6 +91,26 @@ void sharedPubspecTest({
     );
   });
 
+  test('does nothing if the dependency is set to `any`', () {
+    testSuggestor(
+      expectedPatchCount: 0,
+      shouldDartfmtOutput: false,
+      validateContents: validatePubspecYaml,
+      input: ''
+          'name: nothing\n'
+          'version: 0.0.0\n'
+          'dependencies:\n'
+          '  $dependency: any\n'
+          '',
+      expectedOutput: ''
+          'name: nothing\n'
+          'version: 0.0.0\n'
+          'dependencies:\n'
+          '  $dependency: any\n'
+          '',
+    );
+  });
+
   test(
       '${shouldAddDependencies ? 'adds the' : 'does not add the'} dependency '
       'if missing', () {

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -202,6 +202,16 @@ void overReactExample() {}''';
     });
 
     group('shouldUpdateVersionRange() updates correctly', () {
+      test('when the current dependency uses "any" as the version', () {
+        expect(
+          shouldUpdateVersionRange(
+            constraint: VersionConstraint.parse('any'),
+            targetConstraint: VersionConstraint.parse('^5.0.0'),
+          ),
+          isFalse,
+        );
+      });
+
       group('when the current dependency uses the caret syntax ', () {
         test('and the target uses caret syntax', () {
           expect(
@@ -314,7 +324,7 @@ void overReactExample() {}''';
             // Comment2
             var one;
             var two;
-            
+
             // Comment3
           }
         ''';
@@ -337,12 +347,12 @@ void overReactExample() {}''';
 
     group('allComments()', () {
       final content = '''
-          main() {  
+          main() {
             // Comment1
             // Comment2
             var one;
             var two;
-            
+
             // Comment3
           }
         ''';


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
If a version of over_react or react was set to "any" it would throw:
```
➜ pub global run over_react_codemod:react16_upgrade --verbose
searching...
[FINE] codemod: file: functional_tests/import_integration/pubspec.yaml
[SEVERE] codemod: Suggestor.generatePatches() threw unexpectedly.
NoSuchMethodError: The method '>=' was called on null.
Receiver: null
Tried calling: >=(Instance of 'Version')
dart:core                                                                               Object.noSuchMethod
package:over_react_codemod/src/util.dart 363:26                                         shouldUpdateVersionRange
package:over_react_codemod/src/dart2_suggestors/pubspec_over_react_upgrader.dart 77:13  PubspecOverReactUpgrader.generatePatches
dart:core                                                                               _SyncIterator.moveNext
package:codemod/src/run_interactive_codemod.dart 242:39                                 _runInteractiveCodemod
package:codemod/src/run_interactive_codemod.dart 146:15                                 runInteractiveCodemodSequence.<fn>
dart:async                                                                              runZoned
package:io/src/ansi_code.dart 34:5                                                      overrideAnsiOutput
package:codemod/src/run_interactive_codemod.dart 144:12                                 runInteractiveCodemodSequence
package:codemod/src/run_interactive_codemod.dart 84:5                                   runInteractiveCodemod
package:over_react_codemod/src/executables/react16_upgrade.dart 48:14                   main
```

## Changes
  <!-- What this PR changes to fix the problem. -->
- Add "any" escape hatch
- Add checks of `min` and `max` values before doing comparisons

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
