### PR TITLE
CPLAT-6563 Codemod to migrate consumer overlays to new APIs, fixing deprecations

### DIFF
--- a/bin/react16_consumer_overlay_update.dart
+++ b/bin/react16_consumer_overlay_update.dart
@@ -1,0 +1,15 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export 'package:over_react_codemod/src/executables/react16_consumer_overlay_update.dart';

--- a/lib/src/component2_suggestors/component2_utilities.dart
+++ b/lib/src/component2_suggestors/component2_utilities.dart
@@ -141,7 +141,6 @@ bool fullyUpgradableToComponent2(ClassDeclaration classNode) {
 /// * Generic parameters on component class
 /// * `@AbstractProps` in the same file
 bool canBeExtendedFrom(ClassDeclaration classNode) {
-  var a = classNode.typeParameters;
   if (classNode != null &&
       (classNode.abstractKeyword != null ||
           classNode.typeParameters != null ||

--- a/lib/src/executables/react16_consumer_overlay_update.dart
+++ b/lib/src/executables/react16_consumer_overlay_update.dart
@@ -30,6 +30,7 @@ void main(List<String> args) {
     pathFilter: isDartFile,
     recursive: true,
   );
+
   exitCode = runInteractiveCodemodSequence(
     query,
     [

--- a/lib/src/executables/react16_consumer_overlay_update.dart
+++ b/lib/src/executables/react16_consumer_overlay_update.dart
@@ -20,7 +20,7 @@ import 'package:over_react_codemod/src/react16_suggestors/consumer_overlay_migra
 const _changesRequiredOutput = """
   To update your code, run the following commands in your repository:
   pub global activate over_react_codemod
-  pub global run over_react_codemod:react16_consumer_overlays_update
+  pub global run over_react_codemod:react16_consumer_overlay_update
   pub run dart_dev format (If you format this repository).
 Then, review the the changes, address any FIXMEs, and commit.
 """;

--- a/lib/src/executables/react16_consumer_overlay_update.dart
+++ b/lib/src/executables/react16_consumer_overlay_update.dart
@@ -1,0 +1,42 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:io';
+
+import 'package:codemod/codemod.dart';
+import 'package:over_react_codemod/src/react16_suggestors/consumer_overlay_migrator.dart';
+
+const _changesRequiredOutput = """
+  To update your code, run the following commands in your repository:
+  pub global activate over_react_codemod
+  pub global run over_react_codemod:react16_consumer_overlays_update
+  pub run dart_dev format (If you format this repository).
+Then, review the the changes, address any FIXMEs, and commit.
+""";
+
+void main(List<String> args) {
+  final query = FileQuery.dir(
+    pathFilter: isDartFile,
+    recursive: true,
+  );
+  exitCode = runInteractiveCodemodSequence(
+    query,
+    [
+      ConsumerOverlayMigrator(),
+    ],
+    args: args,
+    defaultYes: true,
+    changesRequiredOutput: _changesRequiredOutput,
+  );
+}

--- a/lib/src/react16_suggestors/consumer_overlay_migrator.dart
+++ b/lib/src/react16_suggestors/consumer_overlay_migrator.dart
@@ -1,0 +1,29 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:codemod/codemod.dart';
+
+/// Suggestor that migrates consumer overlay prop names in component usages.
+class ConsumerOverlayMigrator extends GeneralizingAstVisitor
+    with AstVisitingSuggestorMixin
+    implements Suggestor {
+  @override
+  visitMethodInvocation(MethodInvocation node) {
+    super.visitMethodInvocation(node);
+
+
+  }
+}

--- a/lib/src/react16_suggestors/consumer_overlay_migrator.dart
+++ b/lib/src/react16_suggestors/consumer_overlay_migrator.dart
@@ -15,6 +15,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:codemod/codemod.dart';
+import 'package:over_react_codemod/src/component2_suggestors/component2_utilities.dart';
 
 import '../constants.dart';
 
@@ -26,12 +27,23 @@ class ConsumerOverlayMigrator extends GeneralizingAstVisitor
   visitCascadeExpression(CascadeExpression node) {
     super.visitCascadeExpression(node);
 
-    // Check if usage is in a component class.
     final containingClass = node.thisOrAncestorOfType<ClassDeclaration>();
-    if (containingClass?.metadata != null &&
+
+    var extendsName = containingClass?.extendsClause?.superclass?.name;
+    if (extendsName == null) {
+      return;
+    }
+
+    String reactImportName =
+        getImportNamespace(containingClass, 'package:react/react.dart');
+
+    // Check if usage is in a component class.
+    if (extendsName.name != '$reactImportName.Component' &&
+        extendsName.name != '$reactImportName.Component2' &&
         !containingClass.metadata.any((m) =>
             overReact16ComponentAnnotationNamesToMigrate
-                .contains(m.name.name))) {
+                .contains(m.name.name) ||
+            overReact16Component2AnnotationNames.contains(m.name.name))) {
       return;
     }
 

--- a/lib/src/react16_suggestors/consumer_overlay_migrator.dart
+++ b/lib/src/react16_suggestors/consumer_overlay_migrator.dart
@@ -28,8 +28,10 @@ class ConsumerOverlayMigrator extends GeneralizingAstVisitor
 
     // Check if usage is in a component class.
     final containingClass = node.thisOrAncestorOfType<ClassDeclaration>();
-    if (!containingClass.metadata.any((m) =>
-        overReact16ComponentAnnotationNamesToMigrate.contains(m.name.name))) {
+    if (containingClass?.metadata != null &&
+        !containingClass.metadata.any((m) =>
+            overReact16ComponentAnnotationNamesToMigrate
+                .contains(m.name.name))) {
       return;
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,5 +45,5 @@ executables:
   react16_upgrade:
   react16_dependency_override_update:
   react16_ci_precheck:
-  component2_upgrade:
   react16_consumer_overlay_update:
+  component2_upgrade:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,3 +46,4 @@ executables:
   react16_dependency_override_update:
   react16_ci_precheck:
   component2_upgrade:
+  react16_consumer_overlay_update:

--- a/test/react16_suggestors/consumer_overlay_migrator_test.dart
+++ b/test/react16_suggestors/consumer_overlay_migrator_test.dart
@@ -68,8 +68,9 @@ main() {
       testSuggestor(
         expectedPatchCount: 1,
         input: '''
-          @Component()
-          class FooComponent extends UiComponent<FooProps> {
+          import 'package:react/react.dart' as react;
+          
+          class FooComponent extends react.Component<FooProps> {
             @override
             Map getDefaultProps() => (newProps()
               ..isFontSizeControl = false
@@ -79,8 +80,9 @@ main() {
           }
         ''',
         expectedOutput: '''
-          @Component()
-          class FooComponent extends UiComponent<FooProps> {
+          import 'package:react/react.dart' as react;
+          
+          class FooComponent extends react.Component<FooProps> {
             @override
             Map getDefaultProps() => (newProps()
               ..isFontSizeControl = false
@@ -96,8 +98,9 @@ main() {
       testSuggestor(
         expectedPatchCount: 1,
         input: '''
-          @Component()
-          class FooComponent extends UiComponent<FooProps> {
+          import 'package:react/react.dart' as react;
+          
+          class FooComponent extends react.Component2<FooProps> {
             @override
             render() {
               return (OverlayTrigger()
@@ -109,8 +112,9 @@ main() {
           }
         ''',
         expectedOutput: '''
-          @Component()
-          class FooComponent extends UiComponent<FooProps> {
+          import 'package:react/react.dart' as react;
+          
+          class FooComponent extends react.Component2<FooProps> {
             @override
             render() {
               return (OverlayTrigger()
@@ -127,7 +131,7 @@ main() {
       testSuggestor(
         expectedPatchCount: 3,
         input: '''
-          @Component()
+          @Component2()
           class FooComponent extends SomeOtherClass<FooProps> {
             @override
             Map getDefaultProps() => (newProps()
@@ -150,7 +154,7 @@ main() {
           }
         ''',
         expectedOutput: '''
-          @Component()
+          @Component2()
           class FooComponent extends SomeOtherClass<FooProps> {
             @override
             Map getDefaultProps() => (newProps()
@@ -178,8 +182,8 @@ main() {
       testSuggestor(
         expectedPatchCount: 0,
         input: '''
-          @Component()
-          class FooComponent extends SomeOtherClass<FooProps> {
+          @Component2()
+          class FooComponent extends UiComponent2<FooProps> {
             @override
             Map getDefaultProps() => (newProps()
               ..isFontSizeControl = false
@@ -202,7 +206,7 @@ main() {
       );
     });
 
-    test('props outside of component class', () {
+    test('not in component class', () {
       testSuggestor(
         expectedPatchCount: 0,
         input: '''

--- a/test/react16_suggestors/consumer_overlay_migrator_test.dart
+++ b/test/react16_suggestors/consumer_overlay_migrator_test.dart
@@ -1,0 +1,233 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react_codemod/src/react16_suggestors/consumer_overlay_migrator.dart';
+import 'package:test/test.dart';
+
+import '../util.dart';
+
+main() {
+  group('ConsumerOverlayMigrator', () {
+    final testSuggestor = getSuggestorTester(ConsumerOverlayMigrator());
+
+    test('empty file', () {
+      testSuggestor(expectedPatchCount: 0, input: '');
+    });
+
+    test('no matches', () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
+          library foo;
+          var a = 'b';
+          class Foo {}
+        ''',
+      );
+    });
+
+    test('`overlay` prop', () {
+      testSuggestor(
+        expectedPatchCount: 1,
+        input: '''
+          @Component()
+          class FooComponent extends UiComponent<FooProps> {
+            @override
+            render() {
+              return (OverlayTrigger()
+                ..overlay = _renderIndicator()
+              )(_renderMainContent());
+            }
+          }
+        ''',
+        expectedOutput: '''
+          @Component()
+          class FooComponent extends UiComponent<FooProps> {
+            @override
+            render() {
+              return (OverlayTrigger()
+                ..overlay2 = _renderIndicator()
+              )(_renderMainContent());
+            }
+          }
+        ''',
+      );
+    });
+
+    test('`isOverlay` prop', () {
+      testSuggestor(
+        expectedPatchCount: 1,
+        input: '''
+          @Component()
+          class FooComponent extends UiComponent<FooProps> {
+            @override
+            Map getDefaultProps() => (newProps()
+              ..isFontSizeControl = false
+              ..isOverlay = false
+              ..initiallyOpen = false
+            );
+          }
+        ''',
+        expectedOutput: '''
+          @Component()
+          class FooComponent extends UiComponent<FooProps> {
+            @override
+            Map getDefaultProps() => (newProps()
+              ..isFontSizeControl = false
+              ..isOverlay2 = false
+              ..initiallyOpen = false
+            );
+          }
+        ''',
+      );
+    });
+
+    test('`useLegacyPositioning` prop', () {
+      testSuggestor(
+        expectedPatchCount: 1,
+        input: '''
+          @Component()
+          class FooComponent extends UiComponent<FooProps> {
+            @override
+            render() {
+              return (OverlayTrigger()
+                ..addProps(props.overlayTriggerProps)
+                ..useLegacyPositioning = false
+                ..ref = ((ref) => overlayTriggerRef = ref)
+              )(_renderMainContent());
+            }
+          }
+        ''',
+        expectedOutput: '''
+          @Component()
+          class FooComponent extends UiComponent<FooProps> {
+            @override
+            render() {
+              return (OverlayTrigger()
+                ..addProps(props.overlayTriggerProps)
+                ..ref = ((ref) => overlayTriggerRef = ref)
+              )(_renderMainContent());
+            }
+          }
+        ''',
+      );
+    });
+
+    test('`overlay`, `isOverlay`, and `useLegacyPositioning` props', () {
+      testSuggestor(
+        expectedPatchCount: 3,
+        input: '''
+          @Component()
+          class FooComponent extends SomeOtherClass<FooProps> {
+            @override
+            Map getDefaultProps() => (newProps()
+              ..isFontSizeControl = false
+              ..isOverlay = false
+              ..initiallyOpen = false
+            );
+            
+            @override
+            render() {
+              return (OverlayTrigger()
+                ..addProps(props.overlayTriggerProps)
+                ..trigger = OverlayTriggerType.MANUAL
+                ..useLegacyPositioning = false
+                ..overlay = _renderIndicator()
+                ..repositionOverlay = repositionOverlayOverTrigger
+                ..ref = ((ref) => overlayTriggerRef = ref)
+              )(_renderMainContent());
+            }
+          }
+        ''',
+        expectedOutput: '''
+          @Component()
+          class FooComponent extends SomeOtherClass<FooProps> {
+            @override
+            Map getDefaultProps() => (newProps()
+              ..isFontSizeControl = false
+              ..isOverlay2 = false
+              ..initiallyOpen = false
+            );
+            
+            @override
+            render() {
+              return (OverlayTrigger()
+                ..addProps(props.overlayTriggerProps)
+                ..trigger = OverlayTriggerType.MANUAL
+                ..overlay2 = _renderIndicator()
+                ..repositionOverlay = repositionOverlayOverTrigger
+                ..ref = ((ref) => overlayTriggerRef = ref)
+              )(_renderMainContent());
+            }
+          }
+        ''',
+      );
+    });
+
+    test('already updated props', () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
+          @Component()
+          class FooComponent extends SomeOtherClass<FooProps> {
+            @override
+            Map getDefaultProps() => (newProps()
+              ..isFontSizeControl = false
+              ..isOverlay2 = false
+              ..initiallyOpen = false
+            );
+            
+            @override
+            render() {
+              return (OverlayTrigger()
+                ..addProps(props.overlayTriggerProps)
+                ..trigger = OverlayTriggerType.MANUAL
+                ..overlay2 = _renderIndicator()
+                ..repositionOverlay = repositionOverlayOverTrigger
+                ..ref = ((ref) => overlayTriggerRef = ref)
+              )(_renderMainContent());
+            }
+          }
+        ''',
+      );
+    });
+
+    test('props outside of component class', () {
+      testSuggestor(
+        expectedPatchCount: 0,
+        input: '''
+          class FooClass extends SomeOtherClass {
+            @override
+            Map getDefaultProps() => (newProps()
+              ..isFontSizeControl = false
+              ..isOverlay = false
+              ..initiallyOpen = false
+            );
+            
+            @override
+            render() {
+              return (OverlayTrigger()
+                ..addProps(props.overlayTriggerProps)
+                ..trigger = OverlayTriggerType.MANUAL
+                ..useLegacyPositioning = false
+                ..overlay = _renderIndicator()
+                ..repositionOverlay = repositionOverlayOverTrigger
+                ..ref = ((ref) => overlayTriggerRef = ref)
+              )(_renderMainContent());
+            }
+          }
+        ''',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
To aid in upgrading users, we should expose a codemod that migrates consumers.
## Changes
  <!-- What this PR changes to fix the problem. -->
- Set up new executable `react16_consumer_overlay_update`
- Add suggestor that, in component usages:
    - Replaces `..overlay = …` with `..overlay2 = …`
    - Replaces `..isOverlay = …` with `..isOverlay2 = …`
    - Removes `..useLegacyPositioning = …`
- Write tests
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->
@kealjones-wk @aaronlademann-wf @greglittlefield-wf @joebingham-wk 
### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
      - [ ] CI passes
      - [ ] Run the React16 Consumer Overlays Update codemod on web_skin_dart and verify that the codemod updates overlay props based on the above criteria.
        - `pub global run over_react_codemod:react16_consumer_overlay_update`
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
