### PR TITLE
RM-58005 Release over_react_codemod 1.3.2 (CPLAT-7563 comment escape hatch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.3.2](https://github.com/Workiva/over_react_codemod/compare/1.3.1...1.3.2)
+
+- Enable the use of `// orcm_ignore` comments when running the react16 / component2 codemods.
+
 ## [1.3.1](https://github.com/Workiva/over_react_codemod/compare/1.3.0...1.3.1)
 
 - Fix a bug that would occur when parsing a pubspec version of "any"

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -104,7 +104,13 @@ final RegExp overReactDependencyRegExp = RegExp(
 
 /// Regex to find the dependency pubspec.yaml key.
 final RegExp dependencyRegExp = RegExp(
-  r'^dependencies:$',
+  r'^dependencies:\s*$',
+  multiLine: true,
+);
+
+/// Regex to find the dependency pubspec.yaml key.
+final RegExp devDependencyRegExp = RegExp(
+  r'^dev_dependencies:\s*$',
   multiLine: true,
 );
 

--- a/lib/src/creator_utils.dart
+++ b/lib/src/creator_utils.dart
@@ -99,11 +99,13 @@ class DependencyCreator {
   String gitOverride;
   String pathOverride;
   bool asDev;
+  bool asNonGitOrPathOverride;
 
   DependencyCreator(
     this.name, {
     this.version = 'any',
     this.asDev = false,
+    this.asNonGitOrPathOverride = false,
     this.gitOverride = '',
     this.pathOverride = '',
     this.ref,
@@ -119,18 +121,21 @@ class DependencyCreator {
     }
   }
 
-  bool get asOverride => (gitOverride.isNotEmpty || pathOverride.isNotEmpty);
+  bool get asOverride =>
+      asNonGitOrPathOverride ||
+      gitOverride.isNotEmpty ||
+      pathOverride.isNotEmpty;
 
   @override
   String toString() {
-    if (asOverride) {
+    if (asOverride && !asNonGitOrPathOverride) {
       var temp = '  $name:\n';
       if (gitOverride.isNotEmpty) temp += '    git:\n      url: $gitOverride\n';
       if (pathOverride.isNotEmpty) temp += '    path: $pathOverride\n';
       if (ref != null) temp += '      ref: $ref\n';
       return temp;
     }
-    return '  $name: $version';
+    return '  $name: $version\n';
   }
 }
 

--- a/lib/src/executables/component2_upgrade.dart
+++ b/lib/src/executables/component2_upgrade.dart
@@ -21,6 +21,7 @@ import 'package:over_react_codemod/src/component2_suggestors/componentwillmount_
 import 'package:over_react_codemod/src/component2_suggestors/deprecated_lifecycle_suggestor.dart';
 import 'package:over_react_codemod/src/component2_suggestors/setstate_updater.dart';
 import 'package:over_react_codemod/src/component2_suggestors/copyunconsumeddomprops_migrator.dart';
+import 'package:over_react_codemod/src/ignoreable.dart';
 
 const _noPartialUpgradesFlag = '--no-partial-upgrades';
 const _upgradeAbstractComponentsFlag = '--upgrade-abstract-components';
@@ -45,7 +46,7 @@ void main(List<String> args) {
   );
   exitCode = runInteractiveCodemodSequence(
     query,
-    [
+    <Suggestor>[
       // This suggestor needs to be run first in order for subsequent suggestors
       // to run when converting Component to Component2 for the first time.
       ClassNameAndAnnotationMigrator(
@@ -72,7 +73,7 @@ void main(List<String> args) {
         allowPartialUpgrades: allowPartialUpgrades,
         shouldUpgradeAbstractComponents: shouldUpgradeAbstractComponents,
       ),
-    ],
+    ].map((s) => Ignoreable(s)),
     args: args,
     defaultYes: true,
     changesRequiredOutput: _changesRequiredOutput,

--- a/lib/src/executables/react16_dependency_override_update.dart
+++ b/lib/src/executables/react16_dependency_override_update.dart
@@ -15,6 +15,7 @@
 import 'dart:io';
 
 import 'package:codemod/codemod.dart';
+import 'package:over_react_codemod/src/ignoreable.dart';
 import 'package:over_react_codemod/src/react16_suggestors/dependency_override_updater.dart';
 import 'package:path/path.dart' as p;
 
@@ -33,7 +34,7 @@ void main(List<String> args) {
 
   exitCode = runInteractiveCodemod(
     pubspecYamlQuery,
-    DependencyOverrideUpdater(),
+    Ignoreable(DependencyOverrideUpdater()),
     args: args,
     defaultYes: true,
     changesRequiredOutput: _changesRequiredOutput,

--- a/lib/src/executables/react16_upgrade.dart
+++ b/lib/src/executables/react16_upgrade.dart
@@ -16,6 +16,7 @@ import 'dart:io';
 
 import 'package:logging/logging.dart';
 import 'package:codemod/codemod.dart';
+import 'package:over_react_codemod/src/ignoreable.dart';
 import 'package:over_react_codemod/src/react16_suggestors/constants.dart';
 import 'package:over_react_codemod/src/react16_suggestors/react_dom_render_migrator.dart';
 import 'package:over_react_codemod/src/react16_suggestors/react_style_maps_updater.dart';
@@ -51,7 +52,7 @@ void main(List<String> args) {
       PubspecReactUpdater(reactVersionConstraint, shouldAddDependencies: false),
       PubspecOverReactUpgrader(overReactVersionConstraint,
           shouldAddDependencies: false)
-    ]),
+    ].map((s) => Ignoreable(s))),
     args: args,
     defaultYes: true,
     changesRequiredOutput: _changesRequiredOutput,
@@ -68,10 +69,10 @@ void main(List<String> args) {
   );
   exitCode = runInteractiveCodemodSequence(
     query,
-    [
+    <Suggestor>[
       ReactDomRenderMigrator(),
       ReactStyleMapsUpdater(),
-    ],
+    ].map((s) => Ignoreable(s)),
     args: args,
     defaultYes: true,
     changesRequiredOutput: _changesRequiredOutput,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_codemod
-version: 1.3.1
+version: 1.3.2
 homepage: https://github.com/Workiva/over_react_codemod
 
 description: >

--- a/test/react16_suggestors/dependency_override_updater_test.dart
+++ b/test/react16_suggestors/dependency_override_updater_test.dart
@@ -21,6 +21,117 @@ main() {
   group('DependencyOverrideUpdater', () {
     final testSuggestor = getSuggestorTester(DependencyOverrideUpdater());
 
+    const defaultDependencies = '  test: 1.5.1\n'
+        '  react: ^4.6.0\n'
+        '  over_react: ^2.0.0\n';
+    const defaultDevDependencies = '  dart_dev: ^2.0.1\n';
+    const expectedOverrides = '  react: ^5.0.0-alpha\n'
+        '  over_react: ^3.0.0-alpha\n';
+    const expectedOutputSections = {
+      'dependencies': defaultDependencies,
+      'dev_dependencies': defaultDevDependencies,
+      'dependency_overrides': expectedOverrides,
+    };
+
+    void testDependencyOverridesSectionByPosition(Map inputSections,
+        {String additionalOverrides}) {
+      var dependencyOverrides = expectedOutputSections['dependency_overrides'];
+      if (additionalOverrides != null) {
+        dependencyOverrides += additionalOverrides;
+      }
+
+      test('and the dependency_overrides section is last', () {
+        testSuggestor(
+          expectedPatchCount: 2,
+          shouldDartfmtOutput: false,
+          input: ''
+                  'dependencies:\n' +
+              inputSections['dependencies'] +
+              '\n'
+                  'dev_dependencies:\n' +
+              inputSections['dev_dependencies'] +
+              '\n'
+                  'dependency_overrides:\n' +
+              inputSections['dependency_overrides'] +
+              '',
+          expectedOutput: ''
+                  'dependencies:\n' +
+              expectedOutputSections['dependencies'] +
+              '\n'
+                  'dev_dependencies:\n' +
+              expectedOutputSections['dev_dependencies'] +
+              '\n'
+                  'dependency_overrides:\n' +
+              dependencyOverrides +
+              '',
+        );
+      });
+
+      test('and the dependency_overrides section is first', () {
+        // The extra line-break is not ideal, but the effort to make it be a
+        // single break no matter the order of the sections is not worth it, IMO.
+        final lineBreaksAfterDepOverridesSection =
+            additionalOverrides == null ? '\n\n' : '\n';
+
+        testSuggestor(
+          expectedPatchCount: 2,
+          shouldDartfmtOutput: false,
+          input: ''
+                  'dependency_overrides:\n' +
+              inputSections['dependency_overrides'] +
+              '\n'
+                  'dependencies:\n' +
+              inputSections['dependencies'] +
+              '\n'
+                  'dev_dependencies:\n' +
+              inputSections['dev_dependencies'] +
+              '',
+          expectedOutput: ''
+                  'dependency_overrides:\n' +
+              dependencyOverrides +
+              lineBreaksAfterDepOverridesSection +
+              'dependencies:\n' +
+              expectedOutputSections['dependencies'] +
+              '\n'
+                  'dev_dependencies:\n' +
+              expectedOutputSections['dev_dependencies'] +
+              '',
+        );
+      });
+
+      test('and the dependency_overrides section is in the middle', () {
+        // The extra line-break is not ideal, but the effort to make it be a
+        // single break no matter the order of the sections is not worth it, IMO.
+        final lineBreaksAfterDepOverridesSection =
+            additionalOverrides == null ? '\n\n' : '\n';
+
+        testSuggestor(
+          expectedPatchCount: 2,
+          shouldDartfmtOutput: false,
+          input: ''
+                  'dependencies:\n' +
+              inputSections['dependencies'] +
+              '\n'
+                  'dependency_overrides:\n' +
+              inputSections['dependency_overrides'] +
+              '\n'
+                  'dev_dependencies:\n' +
+              inputSections['dev_dependencies'] +
+              '',
+          expectedOutput: ''
+                  'dependencies:\n' +
+              expectedOutputSections['dependencies'] +
+              '\n'
+                  'dependency_overrides:\n' +
+              dependencyOverrides +
+              lineBreaksAfterDepOverridesSection +
+              'dev_dependencies:\n' +
+              expectedOutputSections['dev_dependencies'] +
+              '',
+        );
+      });
+    }
+
     group('adds the dependencies if', () {
       test('the pubspec is empty', () {
         // The output has a new line because the testSuggester appends one.
@@ -29,15 +140,8 @@ main() {
           shouldDartfmtOutput: false,
           input: '',
           expectedOutput: '\n'
-              'dependency_overrides:\n'
-              '  react:\n'
-              '    git:\n'
-              '      url: https://github.com/cleandart/react-dart.git\n'
-              '      ref: 5.0.0-wip\n'
-              '  over_react:\n'
-              '    git:\n'
-              '      url: https://github.com/Workiva/over_react.git\n'
-              '      ref: 3.0.0-wip\n'
+                  'dependency_overrides:\n' +
+              expectedOverrides +
               '',
         );
       });
@@ -54,155 +158,64 @@ main() {
               '  dart_dev: ^2.0.1\n'
               '',
           expectedOutput: ''
-              'dependencies:\n'
-              '  test: 1.5.1\n'
-              '\n'
-              'dev_dependencies:\n'
-              '  dart_dev: ^2.0.1\n'
-              '\n'
-              'dependency_overrides:\n'
-              '  react:\n'
-              '    git:\n'
-              '      url: https://github.com/cleandart/react-dart.git\n'
-              '      ref: 5.0.0-wip\n'
-              '  over_react:\n'
-              '    git:\n'
-              '      url: https://github.com/Workiva/over_react.git\n'
-              '      ref: 3.0.0-wip\n'
+                  'dependencies:\n'
+                  '  test: 1.5.1\n'
+                  '\n'
+                  'dev_dependencies:\n'
+                  '  dart_dev: ^2.0.1\n'
+                  '\n'
+                  'dependency_overrides:\n' +
+              expectedOverrides +
               '',
         );
       });
 
       group('the dependencies are already being overridden via', () {
-        test('git (SSH)', () {
-          testSuggestor(
-            expectedPatchCount: 2,
-            shouldDartfmtOutput: false,
-            input: ''
-                'dependencies:\n'
-                '  test: 1.5.1\n'
-                '  react: ^4.6.0\n'
-                '  over_react: ^2.0.0\n'
-                '\n'
-                'dev_dependencies:\n'
-                '  dart_dev: ^2.0.1\n'
-                '\n'
-                'dependency_overrides:\n'
-                '  react:\n'
+        group('git (SSH)', () {
+          const inputSections = {
+            'dependencies': defaultDependencies,
+            'dev_dependencies': defaultDevDependencies,
+            'dependency_overrides': '  react:\n'
                 '    git:\n'
                 '      url: git@github.com:cleandart/react-dart.git\n'
                 '      ref: 5.0.0-wip\n'
                 '  over_react:\n'
                 '    git:\n'
                 '      url: git@github.com:Workiva/over_react.git\n'
-                '      ref: 3.0.0-wip\n'
-                '',
-            expectedOutput: ''
-                'dependencies:\n'
-                '  test: 1.5.1\n'
-                '  react: ^4.6.0\n'
-                '  over_react: ^2.0.0\n'
-                '\n'
-                'dev_dependencies:\n'
-                '  dart_dev: ^2.0.1\n'
-                '\n'
-                'dependency_overrides:\n'
-                '  react:\n'
-                '    git:\n'
-                '      url: https://github.com/cleandart/react-dart.git\n'
-                '      ref: 5.0.0-wip\n'
-                '  over_react:\n'
-                '    git:\n'
-                '      url: https://github.com/Workiva/over_react.git\n'
-                '      ref: 3.0.0-wip\n'
-                '',
-          );
+                '      ref: 3.0.0-wip\n',
+          };
+
+          testDependencyOverridesSectionByPosition(inputSections);
         });
 
-        test('git (HTTPS)', () {
-          testSuggestor(
-            expectedPatchCount: 2,
-            shouldDartfmtOutput: false,
-            input: ''
-                'dependencies:\n'
-                '  test: 1.5.1\n'
-                '  react: ^4.6.0\n'
-                '  over_react: ^2.0.0\n'
-                '\n'
-                'dev_dependencies:\n'
-                '  dart_dev: ^2.0.1\n'
-                '\n'
-                'dependency_overrides:\n'
-                '  react:\n'
+        group('git (HTTPS)', () {
+          const inputSections = {
+            'dependencies': defaultDependencies,
+            'dev_dependencies': defaultDevDependencies,
+            'dependency_overrides': '  react:\n'
                 '    git:\n'
                 '      url: https://github.com/cleandart/react-dart.git\n'
                 '      ref: 5.0.0-wip\n'
                 '  over_react:\n'
                 '    git:\n'
                 '      url: https://github.com/Workiva/over_react.git\n'
-                '      ref: 3.0.0-wip\n'
-                '',
-            expectedOutput: ''
-                'dependencies:\n'
-                '  test: 1.5.1\n'
-                '  react: ^4.6.0\n'
-                '  over_react: ^2.0.0\n'
-                '\n'
-                'dev_dependencies:\n'
-                '  dart_dev: ^2.0.1\n'
-                '\n'
-                'dependency_overrides:\n'
-                '  react:\n'
-                '    git:\n'
-                '      url: https://github.com/cleandart/react-dart.git\n'
-                '      ref: 5.0.0-wip\n'
-                '  over_react:\n'
-                '    git:\n'
-                '      url: https://github.com/Workiva/over_react.git\n'
-                '      ref: 3.0.0-wip\n'
-                '',
-          );
+                '      ref: 3.0.0-wip\n',
+          };
+
+          testDependencyOverridesSectionByPosition(inputSections);
         });
 
-        test('path', () {
-          testSuggestor(
-            expectedPatchCount: 2,
-            shouldDartfmtOutput: false,
-            input: ''
-                'dependencies:\n'
-                '  test: 1.5.1\n'
-                '  react: ^4.6.0\n'
-                '  over_react: ^2.0.0\n'
-                '\n'
-                'dev_dependencies:\n'
-                '  dart_dev: ^2.0.1\n'
-                '\n'
-                'dependency_overrides:\n'
-                '  react:\n'
+        group('path', () {
+          const inputSections = {
+            'dependencies': defaultDependencies,
+            'dev_dependencies': defaultDevDependencies,
+            'dependency_overrides': '  react:\n'
                 '    path: ../../anywhere\n'
                 '  over_react:\n'
-                '    path: ../../anywhere\n'
-                '',
-            expectedOutput: ''
-                'dependencies:\n'
-                '  test: 1.5.1\n'
-                '  react: ^4.6.0\n'
-                '  over_react: ^2.0.0\n'
-                '\n'
-                'dev_dependencies:\n'
-                '  dart_dev: ^2.0.1\n'
-                '\n'
-                'dependency_overrides:\n'
-                '  react:\n'
-                '    git:\n'
-                '      url: https://github.com/cleandart/react-dart.git\n'
-                '      ref: 5.0.0-wip\n'
-                '  over_react:\n'
-                '    git:\n'
-                '      url: https://github.com/Workiva/over_react.git\n'
-                '      ref: 3.0.0-wip\n'
-                '',
-          );
+                '    path: ../../anywhere\n',
+          };
+
+          testDependencyOverridesSectionByPosition(inputSections);
         });
       });
     });
@@ -212,85 +225,38 @@ main() {
         expectedPatchCount: 2,
         shouldDartfmtOutput: false,
         input: ''
-            'dependencies:\n'
-            '  test: 1.5.1\n'
-            '  react: ^4.6.0\n'
-            '  over_react: ^2.0.0\n'
+                'dependencies:\n' +
+            defaultDependencies +
             '\n'
-            'dev_dependencies:\n'
-            '  dart_dev: ^2.0.1\n'
+                'dev_dependencies:\n' +
+            defaultDevDependencies +
             '',
         expectedOutput: ''
-            'dependencies:\n'
-            '  test: 1.5.1\n'
-            '  react: ^4.6.0\n'
-            '  over_react: ^2.0.0\n'
+                'dependencies:\n' +
+            defaultDependencies +
             '\n'
-            'dev_dependencies:\n'
-            '  dart_dev: ^2.0.1\n'
+                'dev_dependencies:\n' +
+            defaultDevDependencies +
             '\n'
-            'dependency_overrides:\n'
-            '  react:\n'
-            '    git:\n'
-            '      url: https://github.com/cleandart/react-dart.git\n'
-            '      ref: 5.0.0-wip\n'
-            '  over_react:\n'
-            '    git:\n'
-            '      url: https://github.com/Workiva/over_react.git\n'
-            '      ref: 3.0.0-wip\n'
+                'dependency_overrides:\n' +
+            expectedOverrides +
             '',
       );
     });
 
-    test('preserves existing, unrelated dependency overrides', () {
-      testSuggestor(
-        expectedPatchCount: 2,
-        shouldDartfmtOutput: false,
-        // On this test, and the following tests, idemopotency is disabled
-        // because of the codemod's tendency to add a line between already the
-        // existing and the new overrides being added (only after the initial
-        // run). The behavior is minor but finding a solution to stop it is
-        // non-trivial.
-        testIdempotency: false,
-        input: ''
-            'dependencies:\n'
-            '  test: 1.5.1\n'
-            '  react: ^4.6.0\n'
-            '  over_react: ^2.0.0\n'
-            '\n'
-            'dev_dependencies:\n'
-            '  dart_dev: ^2.0.1\n'
-            '\n'
-            'dependency_overrides:\n'
-            '  foo:\n'
-            '    git:\n'
-            '      url: git@github.com:Workiva/foo.git\n'
-            '      ref: 100.0.0\n'
-            '',
-        expectedOutput: ''
-            'dependencies:\n'
-            '  test: 1.5.1\n'
-            '  react: ^4.6.0\n'
-            '  over_react: ^2.0.0\n'
-            '\n'
-            'dev_dependencies:\n'
-            '  dart_dev: ^2.0.1\n'
-            '\n'
-            'dependency_overrides:\n'
-            '  react:\n'
-            '    git:\n'
-            '      url: https://github.com/cleandart/react-dart.git\n'
-            '      ref: 5.0.0-wip\n'
-            '  over_react:\n'
-            '    git:\n'
-            '      url: https://github.com/Workiva/over_react.git\n'
-            '      ref: 3.0.0-wip\n'
-            '  foo:\n'
-            '    git:\n'
-            '      url: git@github.com:Workiva/foo.git\n'
-            '      ref: 100.0.0\n'
-            '',
-      );
+    group('preserves existing, unrelated dependency overrides', () {
+      const unrelatedOverride = '  foo:\n'
+          '    git:\n'
+          '      url: git@github.com:Workiva/foo.git\n'
+          '      ref: 100.0.0\n';
+      const inputSections = {
+        'dependencies': defaultDependencies,
+        'dev_dependencies': defaultDevDependencies,
+        'dependency_overrides': unrelatedOverride,
+      };
+
+      testDependencyOverridesSectionByPosition(inputSections,
+          additionalOverrides: unrelatedOverride);
     });
 
     test('does not override sections after dependency_overrides', () {
@@ -327,14 +293,8 @@ main() {
             '  dart_dev: ^2.0.1\n'
             '\n'
             'dependency_overrides:\n'
-            '  react:\n'
-            '    git:\n'
-            '      url: https://github.com/cleandart/react-dart.git\n'
-            '      ref: 5.0.0-wip\n'
-            '  over_react:\n'
-            '    git:\n'
-            '      url: https://github.com/Workiva/over_react.git\n'
-            '      ref: 3.0.0-wip\n'
+            '  react: ^5.0.0-alpha\n'
+            '  over_react: ^3.0.0-alpha\n'
             '  foo:\n'
             '    git:\n'
             '      url: git@github.com:Workiva/foo.git\n'
@@ -370,14 +330,8 @@ main() {
             '  dart_dev: ^2.0.1\n'
             '\n'
             'dependency_overrides:\n'
-            '  react:\n'
-            '    git:\n'
-            '      url: https://github.com/cleandart/react-dart.git\n'
-            '      ref: 5.0.0-wip\n'
-            '  over_react:\n'
-            '    git:\n'
-            '      url: https://github.com/Workiva/over_react.git\n'
-            '      ref: 3.0.0-wip\n'
+            '  react: ^5.0.0-alpha\n'
+            '  over_react: ^3.0.0-alpha\n'
             '',
       );
     });


### PR DESCRIPTION
This release updates the React 16 / Component2 executables to utilize the `Ignorable` class - ensuring that consumers can utilize a comment like so to fend off edge cases in which the codemod should not apply a patch.

```dart
// orcm_ignore
```

FYA: @greglittlefield-wf @joebingham-wk @kealjones-wk @sydneyjodon-wk 