### PR TITLE
React 16 testing dependency logic update

### DIFF
--- a/lib/src/dart2_suggestors/pubspec_over_react_upgrader.dart
+++ b/lib/src/dart2_suggestors/pubspec_over_react_upgrader.dart
@@ -79,8 +79,11 @@ class PubspecOverReactUpgrader implements Suggestor {
             constraint: constraint,
             shouldIgnoreMin: shouldIgnoreMin)) {
           // Wrap the new constraint in quotes if required.
-          var newValue =
-              generateNewVersionRange(constraint, targetConstraint).toString();
+          var newValue = targetConstraint.toString().contains('-alpha') ||
+                  targetConstraint.toString().contains('-dev')
+              ? targetConstraint.toString()
+              : generateNewVersionRange(constraint, targetConstraint)
+                  .toString();
 
           if (mightNeedYamlEscaping(newValue)) {
             newValue = '"$newValue"';

--- a/lib/src/executables/react16_upgrade.dart
+++ b/lib/src/executables/react16_upgrade.dart
@@ -51,7 +51,7 @@ void main(List<String> args) {
     AggregateSuggestor([
       PubspecReactUpdater(reactVersionConstraint, shouldAddDependencies: false),
       PubspecOverReactUpgrader(overReactVersionConstraint,
-          shouldAddDependencies: false)
+          shouldAddDependencies: true),
     ].map((s) => Ignoreable(s))),
     args: args,
     defaultYes: true,

--- a/lib/src/react16_suggestors/constants.dart
+++ b/lib/src/react16_suggestors/constants.dart
@@ -24,5 +24,7 @@ const styleMapExample = '''
     // Incorrect value for 'width': '40'. Correct values: 40, '40px', '4em'.''';
 
 const reactVersionRange = '>=4.7.0 <6.0.0';
+const reactVersionRangeForTesting = '^5.0.0-alpha';
 
 const overReactVersionRange = '>=2.4.0 <4.0.0';
+const overReactVersionRangeForTesting = '^3.0.0-alpha';

--- a/lib/src/react16_suggestors/pubspec_react_upgrader.dart
+++ b/lib/src/react16_suggestors/pubspec_react_upgrader.dart
@@ -50,8 +50,11 @@ class PubspecReactUpdater implements Suggestor {
         if (shouldUpdateVersionRange(
             constraint: constraint, targetConstraint: targetConstraint)) {
           // Wrap the new constraint in quotes if required.
-          var newValue =
-              generateNewVersionRange(constraint, targetConstraint).toString();
+          var newValue = targetConstraint.toString().contains('-alpha') ||
+                  targetConstraint.toString().contains('-dev')
+              ? targetConstraint.toString()
+              : generateNewVersionRange(constraint, targetConstraint)
+                  .toString();
 
           if (mightNeedYamlEscaping(newValue)) {
             newValue = '"$newValue"';

--- a/test/react16_suggestors/pubspec_react_updater_test.dart
+++ b/test/react16_suggestors/pubspec_react_updater_test.dart
@@ -47,6 +47,17 @@ main() {
           startingRange: VersionConstraint.parse('>=4.6.1 <4.9.0'),
           dependency: 'react',
           midVersionRange: '^$midVersionMin');
+
+      group('and the new version is a pre-release version', () {
+        sharedPubspecTest(
+            testSuggestor: getSuggestorTester(PubspecReactUpdater(
+                VersionConstraint.parse(reactVersionRangeForTesting))),
+            getExpectedOutput: getExpectedPreReleaseOutput,
+            startingRange: VersionConstraint.parse('>=4.6.1 <4.9.0'),
+            midVersionRange: '^5.5.3',
+            shouldUpdateMidRange: false,
+            dependency: 'react');
+      });
     });
 
     group('when the codemod should not add dependencies', () {
@@ -136,6 +147,14 @@ String getExpectedOutput({bool useMidVersionMin = false}) {
   return ''
       'dependencies:\n'
       '  react: ">=4.7.0 <6.0.0"\n'
+      '  test: 1.5.1\n'
+      '';
+}
+
+String getExpectedPreReleaseOutput({bool useMidVersionMin = false}) {
+  return ''
+      'dependencies:\n'
+      '  react: ^5.0.0-alpha\n'
       '  test: 1.5.1\n'
       '';
 }


### PR DESCRIPTION
## Motivation
1. We modify all top-level renders to have a root of `ErrorBoundary` - but we are not forcing the addition of the `over_react` dependency.
2. We need consumers to pull in the alpha release of `web_skin_dart` for testing purposes - which means we need these alpha releases of `react` / `over_react` to be specified as `dependencies`, not `dependency_overrides` in order to automatically pull in WSD as well for the testing branch.

## Changes
1. https://github.com/Workiva/over_react_codemod/pull/60/commits/64f312541f6a0f6b9795a1377c4588719bc9f635
2. https://github.com/Workiva/over_react_codemod/pull/60/commits/34a1d45bdc6845fd06dc34efdcfa0858a6570daa

#### Release Notes
Update React 16 codemod dependency update logic

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @greglittlefield-wf @kealjones-wk @joebingham-wk 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - [ ] Verify that in https://github.com/Workiva/dart_storybook/pull/117, the deps updated as expected, and that the `pubspec.lock` file generated by the CI build includes `web_skin_dart 2.42.0-alpha.0`.
          (I created that PR using these changes)
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
