### PR TITLE
RM-59076 Release over_react_codemod 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ## [1.4.0](https://github.com/Workiva/over_react_codemod/compare/1.3.2...1.4.0)
 
-- Update React 16 componentWillMount Migrator to migrate to componentDidMount
-- Add React 16 getDefaultProps getInitialState Migrator
+- Update Component2 ComponentWillMountMigrator to migrate the componentWillMount lifecycle code to componentDidMount
+- Add React 16 getDefaultProps & getInitialState Migrator
 - Add React 16 Post Rollout Codemod
 - Update React 16 pubspec updater to include over_react
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix a bug that would cause ErrorBoundary components with props to be wraped in
   another ErrorBoundary.
 
+
 ## [1.4.0](https://github.com/Workiva/over_react_codemod/compare/1.3.2...1.4.0)
 
 - Update React 16 componentWillMount Migrator to migrate to componentDidMount

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
+## [1.4.1](https://github.com/Workiva/over_react_codemod/compare/1.4.0...1.4.1)
+
+- Fix a bug that would cause ErrorBoundary components with props to be wraped in
+  another ErrorBoundary.
+
+## [1.4.0](https://github.com/Workiva/over_react_codemod/compare/1.3.2...1.4.0)
+
+- Update React 16 componentWillMount Migrator to migrate to componentDidMount
+- Add React 16 getDefaultProps getInitialState Migrator
+- Add React 16 Post Rollout Codemod
+- Update React 16 pubspec updater to include over_react
+
+
 ## [1.3.2](https://github.com/Workiva/over_react_codemod/compare/1.3.1...1.3.2)
 
 - Enable the use of `// orcm_ignore` comments when running the react16 / component2 codemods.
+
 
 ## [1.3.1](https://github.com/Workiva/over_react_codemod/compare/1.3.0...1.3.1)
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_codemod
-version: 1.4.0
+version: 1.4.1
 homepage: https://github.com/Workiva/over_react_codemod
 
 description: >


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [CPLAT-7863: Update logic to not rely on imports and allows over_react import](https://github.com/Workiva/over_react_codemod/pull/63)
	* [Just cleanup some unused import lints](https://github.com/Workiva/over_react_codemod/pull/64)


Requested by: @kealjones-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react_codemod/compare/1.4.0...Workiva:release_over_react_codemod_1.4.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react_codemod/compare/1.4.0...1.4.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6153708125028352/logs/)