### PR TITLE
RM-59972 Release over_react_codemod 1.4.3 (hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 - Ignore `.g.dart` files in React 16 codemods.
 
+
 ## [1.4.1](https://github.com/Workiva/over_react_codemod/compare/1.4.0...1.4.1)
 
-- Fix a bug that would cause ErrorBoundary components with props to be wraped in
+- Fix a bug that would cause ErrorBoundary components with props to be wrapped in
   another ErrorBoundary.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.4.3](https://github.com/Workiva/over_react_codemod/compare/1.4.3...1.4.2)
+
+- Revert react16_upgrade change in 1.4.0 that forced over_react to be added whenever just react was listed as a dependency
+
+
 ## [1.4.2](https://github.com/Workiva/over_react_codemod/compare/1.4.1...1.4.2)
 
 - Ignore `.g.dart` files in React 16 codemods.

--- a/lib/src/executables/react16_upgrade.dart
+++ b/lib/src/executables/react16_upgrade.dart
@@ -52,7 +52,11 @@ void main(List<String> args) {
     AggregateSuggestor([
       PubspecReactUpdater(reactVersionConstraint, shouldAddDependencies: false),
       PubspecOverReactUpgrader(overReactVersionConstraint,
-          shouldAddDependencies: true),
+          // Don't always add this dependency.
+          // We often need it for ErrorBoundary, but not in all packages, and
+          // we don't want to force over_react to be added regardless.
+          // We can just add in the dependency when the codemod imports over_react.
+          shouldAddDependencies: false),
     ].map((s) => Ignoreable(s))),
     args: args,
     defaultYes: true,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_codemod
-version: 1.4.2
+version: 1.4.3
 homepage: https://github.com/Workiva/over_react_codemod
 
 description: >


### PR DESCRIPTION
Revert react16_upgrade change in 1.4.0 that forced `over_react` to be added whenever just `react` was listed as a dependency.

This changed was causing consumers' builds to fail unless they added the `over_react` dependency, which isn't desirable for every package.

@aaronlademann-wf @kealjones-wk @joebingham-wk 