### PR TITLE
CPLAT-8187 Use caret deps when possible in version range updates

### DIFF
--- a/lib/src/creator_utils.dart
+++ b/lib/src/creator_utils.dart
@@ -181,11 +181,19 @@ class DartProjectCreatorTestConfig {
     if (pubspecCreators.isEmpty) {
       name += 'no pubspecs';
     } else {
-      name += pubspecCreators
-          .map((creator) => 'pubspec'
-              ' at ${creator.path.isEmpty ? 'root' : 'path ${creator.path}/pubspec.yaml'}'
-              ' with dependencies: ${creator.dependencies}')
-          .join(', ');
+      name += pubspecCreators.map((creator) {
+        // Make it so that test names aren't multiline, trim/consolidate whitespace.
+        final humanReadableDependencies = creator.dependencies
+            .map((dep) => dep
+                .toString()
+                .trim()
+                .replaceAll('\n', '\\n')
+                .replaceAll(RegExp(r' +'), ' '))
+            .toList();
+        return 'pubspec'
+            ' at ${creator.path.isEmpty ? 'root' : 'path ${creator.path}/pubspec.yaml'}'
+            ' with dependencies: ${humanReadableDependencies}';
+      }).join(', ');
     }
     return name;
   }

--- a/lib/src/dart2_suggestors/pubspec_over_react_upgrader.dart
+++ b/lib/src/dart2_suggestors/pubspec_over_react_upgrader.dart
@@ -78,13 +78,14 @@ class PubspecOverReactUpgrader implements Suggestor {
             targetConstraint: targetConstraint,
             constraint: constraint,
             shouldIgnoreMin: shouldIgnoreMin)) {
-          // Wrap the new constraint in quotes if required.
-          var newValue = targetConstraint.toString().contains('-alpha') ||
-                  targetConstraint.toString().contains('-dev')
-              ? targetConstraint.toString()
-              : generateNewVersionRange(constraint, targetConstraint)
-                  .toString();
+          final newConstraint =
+              targetConstraint.toString().contains('-alpha') ||
+                      targetConstraint.toString().contains('-dev')
+                  ? targetConstraint
+                  : generateNewVersionRange(constraint, targetConstraint);
 
+          var newValue = friendlyVersionConstraint(newConstraint);
+          // Wrap the new constraint in quotes if required.
           if (mightNeedYamlEscaping(newValue)) {
             newValue = '"$newValue"';
           }

--- a/lib/src/react16_suggestors/pubspec_react_upgrader.dart
+++ b/lib/src/react16_suggestors/pubspec_react_upgrader.dart
@@ -49,13 +49,14 @@ class PubspecReactUpdater implements Suggestor {
 
         if (shouldUpdateVersionRange(
             constraint: constraint, targetConstraint: targetConstraint)) {
-          // Wrap the new constraint in quotes if required.
-          var newValue = targetConstraint.toString().contains('-alpha') ||
-                  targetConstraint.toString().contains('-dev')
-              ? targetConstraint.toString()
-              : generateNewVersionRange(constraint, targetConstraint)
-                  .toString();
+          final newConstraint =
+              targetConstraint.toString().contains('-alpha') ||
+                      targetConstraint.toString().contains('-dev')
+                  ? targetConstraint
+                  : generateNewVersionRange(constraint, targetConstraint);
 
+          var newValue = friendlyVersionConstraint(newConstraint);
+          // Wrap the new constraint in quotes if required.
           if (mightNeedYamlEscaping(newValue)) {
             newValue = '"$newValue"';
           }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -286,6 +286,28 @@ VersionRange generateNewVersionRange(
   );
 }
 
+/// Returns a string representation of [constraint], converting it to caret
+/// notation when possible.
+///
+/// Example:
+/// ```dart
+/// // ^1.2.3
+/// print(friendlyVersionConstraint(VersionConstraint.parse('>=1.2.3 <2.0.0')));
+///
+/// // >1.2.3 <3.0.0
+/// print(friendlyVersionConstraint(VersionConstraint.parse('>1.2.3 <3.0.0')));
+/// ```
+String friendlyVersionConstraint(VersionConstraint constraint) {
+  if (constraint is VersionRange && constraint.min != null) {
+    final caretConstraint = VersionConstraint.compatibleWith(constraint.min);
+    if (caretConstraint == constraint) {
+      return caretConstraint.toString();
+    }
+  }
+
+  return constraint.toString();
+}
+
 /// Return whether or not a particular pubspec.yaml dependency value string
 /// should be wrapped in quotations.
 bool mightNeedYamlEscaping(String scalarValue) =>

--- a/test/dart2_suggestors/pubspec_over_react_upgrader_test.dart
+++ b/test/dart2_suggestors/pubspec_over_react_upgrader_test.dart
@@ -164,9 +164,14 @@ main() {
 
 String getExpectedOutput({bool useMidVersionMin = false}) {
   if (useMidVersionMin) {
+    final expected =
+        VersionConstraint.parse('^2.0.0').allows(Version.parse(midRangeMark))
+            ? '^$midRangeMark'
+            : '">=$midRangeMark <3.0.0"';
+
     return ''
         'dependencies:\n'
-        '  over_react: ">=$midRangeMark <3.0.0"\n'
+        '  over_react: $expected\n'
         '  test: 1.5.1\n'
         '';
   }

--- a/test/react16_suggestors/pubspec_react_updater_test.dart
+++ b/test/react16_suggestors/pubspec_react_updater_test.dart
@@ -137,9 +137,14 @@ main() {
 
 String getExpectedOutput({bool useMidVersionMin = false}) {
   if (useMidVersionMin) {
+    final expected =
+        VersionConstraint.parse('^5.0.0').allows(Version.parse(midVersionMin))
+            ? '^$midVersionMin'
+            : '">=$midVersionMin <6.0.0"';
+
     return ''
         'dependencies:\n'
-        '  react: ">=$midVersionMin <6.0.0"\n'
+        '  react: $expected\n'
         '  test: 1.5.1\n'
         '';
   }

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -161,6 +161,30 @@ void overReactExample() {}''';
       });
     });
 
+    group('friendlyVersionConstraint()', () {
+      String friendlyFromString(String constraintSource) =>
+          friendlyVersionConstraint(VersionConstraint.parse(constraintSource));
+
+      test('returns a caret representation of a range if possible', () {
+        expect(friendlyFromString('^1.0.0'), '^1.0.0');
+        expect(friendlyFromString('>=1.0.0 <2.0.0'), '^1.0.0');
+        expect(friendlyFromString('>=1.1.0 <2.0.0'), '^1.1.0');
+        expect(friendlyFromString('>=1.1.0-alpha <2.0.0'), '^1.1.0-alpha');
+      });
+
+      test(
+          'returns the version constraint\'s toString if caret syntax cannot be used',
+          () {
+        expect(friendlyFromString('>1.0.0 <2.0.0'), '>1.0.0 <2.0.0');
+        expect(friendlyFromString('>=1.0.0 <3.0.0'), '>=1.0.0 <3.0.0');
+        expect(friendlyFromString('>=1.0.0 <1.5.0'), '>=1.0.0 <1.5.0');
+        // Edge cases
+        expect(friendlyFromString('any'), 'any');
+        expect(friendlyVersionConstraint(VersionConstraint.empty),
+            VersionConstraint.empty.toString());
+      });
+    });
+
     group('mightNeedYamlEscaping()', () {
       group('returns true if the value', () {
         test('starts with ">"', () {


### PR DESCRIPTION
## Motivation
The react16_post_rollout_cleanup updates react/over_react version ranges, but it's output always uses the greater-than/less-than syntax instead of the caret syntax, which is less than ideal, and will likely result in someone updating it manually at some point.

While not essential would be nice to just use carets from the get-go.

Current behavior when running `react16_post_rollout_cleanup`:
```diff
-  over_react: ">=2.5.0 <4.0.0"
-  react: ">=4.7.0 <6.0.0"
+  over_react: ">=3.1.0 <4.0.0"
+  react: ">=5.1.0 <6.0.0"
```

## Changes
Check to see if the new version constraint can be represented with the caret syntax, and use it when it can.

New behavior when running `react16_post_rollout_cleanup`:
```diff
-  over_react: ">=2.5.0 <4.0.0"
-  react: ">=4.7.0 <6.0.0"
+  over_react: ^3.1.0
+  react: ^5.1.0
```


#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - Run `react16_post_rollout_cleanup` and verify it uses caret ranges where possible
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
