### PR TITLE
CPLAT-9409 Remove props/state “companion” classes as part of the boilerplate update

### DIFF
--- a/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
+++ b/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
@@ -16,6 +16,8 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:codemod/codemod.dart';
 
+import 'boilerplate_utilities.dart';
+
 /// Suggestor that updates props and state classes to new boilerplate.
 ///
 /// This should only be done on cases where the props and state classes are not
@@ -29,5 +31,10 @@ class AdvancedPropsAndStateClassMigrator extends GeneralizingAstVisitor
   @override
   visitClassDeclaration(ClassDeclaration node) {
     super.visitClassDeclaration(node);
+
+    if (!shouldMigrateAdvancedPropsAndStateClass(node)) return;
   }
 }
+
+bool shouldMigrateAdvancedPropsAndStateClass(ClassDeclaration node) =>
+    shouldMigratePropsAndStateClass(node) && isAdvancedPropsOrStateClass(node);

--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -19,6 +19,17 @@ import 'package:over_react_codemod/src/util.dart';
 typedef void YieldPatch(
     int startingOffset, int endingOffset, String replacement);
 
+// Stub while <https://jira.atl.workiva.net/browse/CPLAT-9308> is in progress
+bool _isPublic(ClassDeclaration node) => false;
+
+/// Whether a props or state class class [node] should be migrated as part of the boilerplate codemod.
+bool shouldMigratePropsAndStateClass(ClassDeclaration node) {
+  return isAssociatedWithComponent2(node) &&
+      isAPropsOrStateClass(node) &&
+      // Stub while <https://jira.atl.workiva.net/browse/CPLAT-9308> is in progress
+      !_isPublic(node);
+}
+
 /// A simple RegExp against the parent of the class to verify it is `UiProps`
 /// or `UiState`.
 bool extendsFromUiPropsOrUiState(ClassDeclaration classNode) =>
@@ -47,6 +58,14 @@ bool isSimplePropsOrStateClass(ClassDeclaration classNode) {
   if (classNode.withClause != null) return false;
 
   return true;
+}
+
+// Stub while <https://jira.atl.workiva.net/browse/CPLAT-9407> is in progress
+bool isAdvancedPropsOrStateClass(ClassDeclaration classNode) {
+  // Only validate props or state classes
+  assert(isAPropsOrStateClass(classNode));
+
+  return false;
 }
 
 /// A map of props / state classes that have been migrated to the new boilerplate

--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:over_react_codemod/src/constants.dart';
 
 typedef void YieldPatch(
     int startingOffset, int endingOffset, String replacement);
@@ -71,11 +72,9 @@ void migrateClassToMixin(ClassDeclaration node, YieldPatch yieldPatch,
 
   yieldPatch(node.classKeyword.offset, node.classKeyword.charEnd, 'mixin');
 
-  final charsToRemoveFromClassName =
-      node.name.toSource().substring(0, 1).split('').first == '\$' ? 1 : 2;
 
   yieldPatch(node.name.token.offset,
-      node.name.token.offset + charsToRemoveFromClassName, '');
+      node.name.token.offset + privateGeneratedPrefix.length, '');
 
   yieldPatch(node.extendsClause.offset,
       node.extendsClause.extendsKeyword.charEnd, 'on');

--- a/lib/src/boilerplate_suggestors/props_meta_migrator.dart
+++ b/lib/src/boilerplate_suggestors/props_meta_migrator.dart
@@ -1,0 +1,50 @@
+// Copyright 2020 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:codemod/codemod.dart';
+import 'package:over_react_codemod/src/boilerplate_suggestors/boilerplate_utilities.dart';
+
+/// Suggestor that looks for `meta` getter access on props classes found within
+/// [propsAndStateClassNamesConvertedToNewBoilerplate] as a result of being converted to the new
+/// boilerplate via `SimplePropsAndStateClassMigrator` or `AdvancedPropsAndStateClassMigrator`, and converts
+/// them to the way meta is accessed using the new boilerplate.
+///
+/// ```dart
+/// // Before
+/// FooProps.meta
+///
+/// // After
+/// propsMeta.forMixin(FooProps)
+/// ```
+class PropsMetaMigrator extends GeneralizingAstVisitor
+    with AstVisitingSuggestorMixin
+    implements Suggestor {
+  @override
+  visitPrefixedIdentifier(PrefixedIdentifier node) {
+    super.visitPrefixedIdentifier(node);
+
+    if (node.identifier.name == 'meta') {
+      if (propsAndStateClassNamesConvertedToNewBoilerplate
+          .containsKey(node.prefix.name)) {
+        yieldPatch(
+          node.prefix.offset,
+          node.identifier.end,
+          'propsMeta.forMixin(${propsAndStateClassNamesConvertedToNewBoilerplate[node.prefix.name]})',
+        );
+      }
+    }
+  }
+}

--- a/lib/src/boilerplate_suggestors/simple_props_and_state_class_migrator.dart
+++ b/lib/src/boilerplate_suggestors/simple_props_and_state_class_migrator.dart
@@ -33,15 +33,11 @@ class SimplePropsAndStateClassMigrator extends GeneralizingAstVisitor
   visitClassDeclaration(ClassDeclaration node) {
     super.visitClassDeclaration(node);
 
-    if (!isAssociatedWithComponent2(node) ||
-        !isAPropsOrStateClass(node) ||
-        !isSimplePropsOrStateClass(node) ||
-        // Stub while <https://jira.atl.workiva.net/browse/CPLAT-9308> is in progress
-        _isPublic(node)) return;
+    if (!shouldMigrateSimplePropsAndStateClass(node)) return;
 
     migrateClassToMixin(node, yieldPatch);
   }
 }
 
-// Stub while <https://jira.atl.workiva.net/browse/CPLAT-9308> is in progress
-bool _isPublic(ClassDeclaration node) => false;
+bool shouldMigrateSimplePropsAndStateClass(ClassDeclaration node) =>
+    shouldMigratePropsAndStateClass(node) && isSimplePropsOrStateClass(node);

--- a/lib/src/boilerplate_suggestors/stubbed_props_and_state_class_remover.dart
+++ b/lib/src/boilerplate_suggestors/stubbed_props_and_state_class_remover.dart
@@ -13,15 +13,20 @@
 // limitations under the License.
 
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:codemod/codemod.dart';
+import 'package:over_react_codemod/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart';
+import 'package:over_react_codemod/src/boilerplate_suggestors/simple_props_and_state_class_migrator.dart';
+import 'package:over_react_codemod/src/dart2_suggestors/props_and_state_companion_class_remover.dart';
 
-/// Suggestor that removes the stubbed public facing props and state class.
-class StubbedPropsAndStateClassRemover extends GeneralizingAstVisitor
-    with AstVisitingSuggestorMixin
-    implements Suggestor {
+/// Suggestor that removes every companion class for props and state classes, as
+/// they were only temporarily required for backwards-compatibility with Dart 1.
+class StubbedPropsAndStateClassRemover
+    extends PropsAndStateCompanionClassRemover implements Suggestor {
   @override
-  visitClassDeclaration(ClassDeclaration node) {
-    super.visitClassDeclaration(node);
+  bool shouldRemoveCompanionClassFor(
+      ClassDeclaration candidate, CompilationUnit node) {
+    return super.shouldRemoveCompanionClassFor(candidate, node) &&
+        (shouldMigrateSimplePropsAndStateClass(candidate) ||
+            shouldMigrateAdvancedPropsAndStateClass(candidate));
   }
 }

--- a/lib/src/dart2_suggestors/props_and_state_companion_class_remover.dart
+++ b/lib/src/dart2_suggestors/props_and_state_companion_class_remover.dart
@@ -24,39 +24,65 @@ import '../util.dart';
 class PropsAndStateCompanionClassRemover extends RecursiveAstVisitor
     with AstVisitingSuggestorMixin
     implements Suggestor {
+  bool shouldRemoveCompanionClassFor(
+          ClassDeclaration candidate, CompilationUnit node) =>
+      true;
+
   @override
   visitCompilationUnit(CompilationUnit node) {
     final classDeclarations = node.declarations.whereType<ClassDeclaration>();
     for (final cd in classDeclarations) {
-      if (cd.metadata.any((m) =>
-          overReactPropsStateNonMixinAnnotationNames.contains(m.name.name))) {
-        final className = cd.name.name;
-        final companionClassName = stripPrivateGeneratedPrefix(className);
-        final companionClass = classDeclarations.firstWhere(
-            (cd) => cd.name.name == companionClassName,
-            orElse: () => null);
-        if (companionClass != null) {
-          // The single-line comment about the companion class being temporary
-          // isn't associated with the class declaration node, so we need to
-          // explicitly check for it on the preceding line and remove that line
-          // as well if found.
-          final declLine = sourceFile.getLine(companionClass.offset);
-          final precedingLine = sourceFile.getText(
+      final companionClass = _getCompanionClassFor(cd, node);
+
+      if (companionClass != null && shouldRemoveCompanionClassFor(cd, node)) {
+        // The single-line comment about the companion class being temporary
+        // isn't associated with the class declaration node, so we need to
+        // explicitly check for it on the preceding line and remove that line
+        // as well if found.
+        final declLine = sourceFile.getLine(companionClass.offset);
+        final precedingLines = [
+          sourceFile.getText(
+            sourceFile.getOffset(declLine - 2),
+            sourceFile.getOffset(declLine) - 2,
+          ),
+          sourceFile.getText(
             sourceFile.getOffset(declLine - 1),
             sourceFile.getOffset(declLine) - 1,
-          );
-          var startOffset = companionClass.offset;
-          if (precedingLine.contains(temporaryCompanionClassComment)) {
-            startOffset = sourceFile.getOffset(declLine - 1);
+          ),
+        ];
+        var startOffset = companionClass.offset;
+        for (var i = 0; i < precedingLines.length; i++) {
+          final lineDelta = 2 - i;
+          final line = precedingLines[i];
+          if (line.contains(temporaryCompanionClassComment)) {
+            startOffset = sourceFile.getOffset(declLine - lineDelta);
+            break;
           }
-
-          yieldPatch(
-            startOffset,
-            companionClass.rightBracket.offset + 1,
-            '',
-          );
         }
+
+        yieldPatch(
+          startOffset,
+          companionClass.rightBracket.offset + 1,
+          '',
+        );
       }
     }
+  }
+
+  ClassDeclaration _getCompanionClassFor(
+      ClassDeclaration classDeclaration, CompilationUnit node) {
+    final classDeclarations = node.declarations.whereType<ClassDeclaration>();
+
+    if (classDeclaration.metadata.any((m) =>
+        overReactPropsStateNonMixinAnnotationNames.contains(m.name.name))) {
+      final className = classDeclaration.name.name;
+      final companionClassName = stripPrivateGeneratedPrefix(className);
+      final companionClass = classDeclarations.firstWhere(
+          (cd) => cd.name.name == companionClassName,
+          orElse: () => null);
+      return companionClass;
+    }
+
+    return null;
   }
 }

--- a/lib/src/executables/boilerplate_upgrade.dart
+++ b/lib/src/executables/boilerplate_upgrade.dart
@@ -74,13 +74,12 @@ void main(List<String> args) {
   //      - If this is needed, it can be used for suggestors 3 and 4
   //
   //
-
   exitCode = runInteractiveCodemodSequence(
     query,
     <Suggestor>[
+      StubbedPropsAndStateClassRemover(),
       SimplePropsAndStateClassMigrator(),
       AdvancedPropsAndStateClassMigrator(),
-      StubbedPropsAndStateClassRemover(),
       PropsMixinMigrator(),
       PropsMetaMigrator(),
       AnnotationsRemover(),

--- a/lib/src/executables/boilerplate_upgrade.dart
+++ b/lib/src/executables/boilerplate_upgrade.dart
@@ -16,6 +16,7 @@ import 'dart:io';
 
 import 'package:codemod/codemod.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/annotations_remover.dart';
+import 'package:over_react_codemod/src/boilerplate_suggestors/props_meta_migrator.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/simple_props_and_state_class_migrator.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/props_mixins_migrator.dart';
@@ -81,6 +82,7 @@ void main(List<String> args) {
       AdvancedPropsAndStateClassMigrator(),
       StubbedPropsAndStateClassRemover(),
       PropsMixinMigrator(),
+      PropsMetaMigrator(),
       AnnotationsRemover(),
     ].map((s) => Ignoreable(s)),
     args: args,

--- a/test/boilerplate_suggestors/props_meta_migrator_test.dart
+++ b/test/boilerplate_suggestors/props_meta_migrator_test.dart
@@ -1,0 +1,131 @@
+// Copyright 2020 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react_codemod/src/boilerplate_suggestors/boilerplate_utilities.dart';
+import 'package:over_react_codemod/src/boilerplate_suggestors/props_meta_migrator.dart';
+import 'package:test/test.dart';
+
+import '../util.dart';
+
+main() {
+  group('PropsMetaMigrator', () {
+    final testSuggestor = getSuggestorTester(PropsMetaMigrator());
+
+    tearDown(() {
+      propsAndStateClassNamesConvertedToNewBoilerplate = {};
+    });
+
+    group('does not perform a migration', () {
+      test('when it encounters an empty file', () {
+        propsAndStateClassNamesConvertedToNewBoilerplate = {
+          'FooProps': 'FooProps',
+        };
+
+        testSuggestor(expectedPatchCount: 0, input: '');
+      });
+
+      test('when there are no `PropsClass.meta` identifiers', () {
+        propsAndStateClassNamesConvertedToNewBoilerplate = {
+          'FooProps': 'FooProps',
+        };
+
+        testSuggestor(
+          expectedPatchCount: 0,
+          input: '''
+          library foo;
+          var a = 'b';
+          class Foo {}
+        ''',
+        );
+      });
+    });
+
+    group(
+        'performs a migration when there are one or more `PropsClass.meta` identifiers',
+        () {
+      test('', () {
+        propsAndStateClassNamesConvertedToNewBoilerplate = {
+          'FooProps': 'FooProps',
+        };
+
+        testSuggestor(
+          expectedPatchCount: 1,
+          input: '''
+          @Component2()
+          class FooComponent extends UiComponent2<FooProps> {
+            @override
+            get consumedProps => const [
+              FooProps.meta,
+            ];
+        
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+        ''',
+          expectedOutput: '''
+        @Component2()
+        class FooComponent extends UiComponent2<FooProps> {
+          @override
+          get consumedProps => const [
+            propsMeta.forMixin(FooProps),
+          ];
+          
+          @override
+          render() {
+            return Dom.ul()(
+              Dom.li()('Foo: ', props.foo),
+              Dom.li()('Bar: ', props.bar),
+            );
+          }
+        }
+      ''',
+        );
+      });
+
+      test(
+          'unless the props class is not found within `propsAndStateClassNamesConvertedToNewBoilerplate`',
+          () {
+        propsAndStateClassNamesConvertedToNewBoilerplate = {
+          'BarProps': 'BarProps',
+        };
+
+        testSuggestor(
+          expectedPatchCount: 0,
+          input: '''
+          @Component2()
+          class FooComponent extends UiComponent2<FooProps> {
+            @override
+            get consumedProps => const [
+              FooProps.meta,
+            ];
+        
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+        ''',
+        );
+      });
+    });
+  });
+}

--- a/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:over_react_codemod/src/boilerplate_suggestors/boilerplate_utilities.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/simple_props_and_state_class_migrator.dart';
 import 'package:test/test.dart';
 
@@ -22,8 +23,14 @@ main() {
     final testSuggestor =
         getSuggestorTester(SimplePropsAndStateClassMigrator());
 
+    tearDown(() {
+      propsAndStateClassNamesConvertedToNewBoilerplate = {};
+    });
+
     test('empty file', () {
       testSuggestor(expectedPatchCount: 0, input: '');
+
+      expect(propsAndStateClassNamesConvertedToNewBoilerplate, isEmpty);
     });
 
     test('no matches', () {
@@ -35,6 +42,8 @@ main() {
         class Foo {}
       ''',
       );
+
+      expect(propsAndStateClassNamesConvertedToNewBoilerplate, isEmpty);
     });
 
     test('and the component is not Component2', () {
@@ -64,6 +73,8 @@ main() {
         }
       ''',
       );
+
+      expect(propsAndStateClassNamesConvertedToNewBoilerplate, isEmpty);
     });
 
     // TODO add a test for when the class is publicly exported
@@ -102,6 +113,8 @@ main() {
         }
       ''',
         );
+
+        expect(propsAndStateClassNamesConvertedToNewBoilerplate, isEmpty);
       });
 
       test('and there is just a props class', () {
@@ -131,6 +144,8 @@ main() {
         }
       ''',
         );
+
+        expect(propsAndStateClassNamesConvertedToNewBoilerplate, isEmpty);
       });
     });
 
@@ -197,6 +212,11 @@ main() {
           }
         ''',
         );
+
+        expect(propsAndStateClassNamesConvertedToNewBoilerplate, {
+          'FooProps': 'FooProps',
+          'FooState': 'FooState',
+        });
       });
 
       test('and there is only a props class', () {
@@ -249,6 +269,10 @@ main() {
           }
         ''',
         );
+
+        expect(propsAndStateClassNamesConvertedToNewBoilerplate, {
+          'FooProps': 'FooProps',
+        });
       });
 
       test('and are abstract', () {
@@ -313,6 +337,11 @@ main() {
           }
           ''',
         );
+
+        expect(propsAndStateClassNamesConvertedToNewBoilerplate, {
+          'FooProps': 'FooProps',
+          'FooState': 'FooState',
+        });
       });
     });
   });

--- a/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
@@ -135,303 +135,183 @@ main() {
     });
 
     group('when the classes are simple', () {
-      group('and there are both a props and a state class', () {
-        test('with classes prefaced with \$', () {
-          testSuggestor(
-            expectedPatchCount: 6,
-            input: '''
-        @Factory()
-        UiFactory<FooProps> Foo =
-            // ignore: undefined_identifier
-            \$Foo;
-
-        @Props()
-        class \$FooProps extends UiProps {
-          String foo;
-          int bar;
-        }
-
-        @State()
-        class \$FooState extends UiState {
-          String foo;
-          int bar;
-        }
-
-        @Component2()
-        class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
-          @override
-          render() {
-            return Dom.ul()(
-              Dom.li()('Foo: ', props.foo),
-              Dom.li()('Bar: ', props.bar),
-            );
+      test('and there are both a props and a state class', () {
+        testSuggestor(
+          expectedPatchCount: 6,
+          input: '''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              \$Foo;
+    
+          @Props()
+          class _\$FooProps extends UiProps {
+            String foo;
+            int bar;
           }
-        }
-      ''',
-            expectedOutput: '''
-       @Factory()
-        UiFactory<FooProps> Foo =
-            // ignore: undefined_identifier
-            \$Foo;
-
-        @Props()
-        mixin FooProps on UiProps {
-          String foo;
-          int bar;
-        }
-
-        @State()
-        mixin FooState on UiState {
-          String foo;
-          int bar;
-        }
-
-        @Component2()
-        class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
-          @override
-          render() {
-            return Dom.ul()(
-              Dom.li()('Foo: ', props.foo),
-              Dom.li()('Bar: ', props.bar),
-            );
+    
+          @State()
+          class _\$FooState extends UiState {
+            String foo;
+            int bar;
           }
-        }
-      ''',
-          );
-        });
-
-        test('with classes prefaced with _\$', () {
-          testSuggestor(
-            expectedPatchCount: 6,
-            input: '''
-        @Factory()
-        UiFactory<FooProps> Foo =
-            // ignore: undefined_identifier
-            \$Foo;
-
-        @Props()
-        class _\$FooProps extends UiProps {
-          String foo;
-          int bar;
-        }
-
-        @State()
-        class _\$FooState extends UiState {
-          String foo;
-          int bar;
-        }
-
-        @Component2()
-        class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
-          @override
-          render() {
-            return Dom.ul()(
-              Dom.li()('Foo: ', props.foo),
-              Dom.li()('Bar: ', props.bar),
-            );
+    
+          @Component2()
+          class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
           }
-        }
-      ''',
-            expectedOutput: '''
-       @Factory()
-        UiFactory<FooProps> Foo =
-            // ignore: undefined_identifier
-            \$Foo;
-
-        @Props()
-        mixin FooProps on UiProps {
-          String foo;
-          int bar;
-        }
-
-        @State()
-        mixin FooState on UiState {
-          String foo;
-          int bar;
-        }
-
-        @Component2()
-        class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
-          @override
-          render() {
-            return Dom.ul()(
-              Dom.li()('Foo: ', props.foo),
-              Dom.li()('Bar: ', props.bar),
-            );
+        ''',
+          expectedOutput: '''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              \$Foo;
+    
+          @Props()
+          mixin FooProps on UiProps {
+            String foo;
+            int bar;
           }
-        }
-      ''',
-          );
-        });
+    
+          @State()
+          mixin FooState on UiState {
+            String foo;
+            int bar;
+          }
+    
+          @Component2()
+          class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+        ''',
+        );
       });
 
-      group('and there is only a props class', () {
-        test('with classes prefaced with \$', () {
-          testSuggestor(
-            expectedPatchCount: 3,
-            input: '''
-        @Factory()
-        UiFactory<FooProps> Foo =
-            // ignore: undefined_identifier
-            \$Foo;
-
-        @Props()
-        class \$FooProps extends UiProps {
-          String foo;
-          int bar;
-        }
-
-        @Component2()
-        class FooComponent extends UiComponent2<FooProps> {
-          @override
-          render() {
-            return Dom.ul()(
-              Dom.li()('Foo: ', props.foo),
-              Dom.li()('Bar: ', props.bar),
-            );
+      test('and there is only a props class', () {
+        testSuggestor(
+          expectedPatchCount: 3,
+          input: '''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              \$Foo;
+    
+          @Props()
+          class _\$FooProps extends UiProps {
+            String foo;
+            int bar;
           }
-        }
-      ''',
-            expectedOutput: '''
-       @Factory()
-        UiFactory<FooProps> Foo =
-            // ignore: undefined_identifier
-            \$Foo;
-
-        @Props()
-        mixin FooProps on UiProps {
-          String foo;
-          int bar;
-        }
-
-        @Component2()
-        class FooComponent extends UiComponent2<FooProps> {
-          @override
-          render() {
-            return Dom.ul()(
-              Dom.li()('Foo: ', props.foo),
-              Dom.li()('Bar: ', props.bar),
-            );
+    
+          @Component2()
+          class FooComponent extends UiComponent2<FooProps> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
           }
-        }
-      ''',
-          );
-        });
-
-        test('with classes prefaced with _\$', () {
-          testSuggestor(
-            expectedPatchCount: 3,
-            input: '''
-        @Factory()
-        UiFactory<FooProps> Foo =
-            // ignore: undefined_identifier
-            \$Foo;
-
-        @Props()
-        class _\$FooProps extends UiProps {
-          String foo;
-          int bar;
-        }
-
-        @Component2()
-        class FooComponent extends UiComponent2<FooProps> {
-          @override
-          render() {
-            return Dom.ul()(
-              Dom.li()('Foo: ', props.foo),
-              Dom.li()('Bar: ', props.bar),
-            );
+        ''',
+          expectedOutput: '''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              \$Foo;
+    
+          @Props()
+          mixin FooProps on UiProps {
+            String foo;
+            int bar;
           }
-        }
-      ''',
-            expectedOutput: '''
-       @Factory()
-        UiFactory<FooProps> Foo =
-            // ignore: undefined_identifier
-            \$Foo;
-
-        @Props()
-        mixin FooProps on UiProps {
-          String foo;
-          int bar;
-        }
-
-        @Component2()
-        class FooComponent extends UiComponent2<FooProps> {
-          @override
-          render() {
-            return Dom.ul()(
-              Dom.li()('Foo: ', props.foo),
-              Dom.li()('Bar: ', props.bar),
-            );
+    
+          @Component2()
+          class FooComponent extends UiComponent2<FooProps> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
           }
-        }
-      ''',
-          );
-        });
+        ''',
+        );
       });
 
       test('and are abstract', () {
         testSuggestor(
           expectedPatchCount: 8,
           input: '''
-      @Factory()
-      UiFactory<FooProps> Foo =
-          // ignore: undefined_identifier
-          \$Foo;
-
-      @AbstractProps()
-      abstract class _\$FooProps extends UiProps {
-        String foo;
-        int bar;
-      }
-
-      @AbstractState()
-      abstract class _\$FooState extends UiState {
-        String foo;
-        int bar;
-      }
-
-      @AbstractComponent2()
-      abstract class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
-        @override
-        render() {
-          return Dom.ul()(
-            Dom.li()('Foo: ', props.foo),
-            Dom.li()('Bar: ', props.bar),
-          );
-        }
-      }
-    ''',
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              \$Foo;
+    
+          @AbstractProps()
+          abstract class _\$FooProps extends UiProps {
+            String foo;
+            int bar;
+          }
+    
+          @AbstractState()
+          abstract class _\$FooState extends UiState {
+            String foo;
+            int bar;
+          }
+    
+          @AbstractComponent2()
+          abstract class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+        ''',
           expectedOutput: '''
-     @Factory()
-      UiFactory<FooProps> Foo =
-          // ignore: undefined_identifier
-          \$Foo;
-
-      @AbstractProps()
-      mixin FooProps on UiProps {
-        String foo;
-        int bar;
-      }
-
-      @AbstractState()
-      mixin FooState on UiState {
-        String foo;
-        int bar;
-      }
-
-      @AbstractComponent2()
-      abstract class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
-        @override
-        render() {
-          return Dom.ul()(
-            Dom.li()('Foo: ', props.foo),
-            Dom.li()('Bar: ', props.bar),
-          );
-        }
-      }
-      ''',
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              \$Foo;
+    
+          @AbstractProps()
+          mixin FooProps on UiProps {
+            String foo;
+            int bar;
+          }
+    
+          @AbstractState()
+          mixin FooState on UiState {
+            String foo;
+            int bar;
+          }
+    
+          @AbstractComponent2()
+          abstract class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+          ''',
         );
       });
     });

--- a/test/boilerplate_suggestors/stubbed_props_and_state_class_remover_test.dart
+++ b/test/boilerplate_suggestors/stubbed_props_and_state_class_remover_test.dart
@@ -1,0 +1,255 @@
+// Copyright 2020 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react_codemod/src/boilerplate_suggestors/stubbed_props_and_state_class_remover.dart';
+import 'package:test/test.dart';
+
+import '../util.dart';
+
+main() {
+  group('StubbedPropsAndStateClassRemover', () {
+    final testSuggestor = getSuggestorTester(
+      StubbedPropsAndStateClassRemover(),
+    );
+
+    group('does not perform a migration', () {
+      test('when it encounters an empty file', () {
+        testSuggestor(expectedPatchCount: 0, input: '');
+      });
+
+      test('when there are no stubbed "companion" classes found', () {
+        testSuggestor(
+          expectedPatchCount: 0,
+          input: '''
+          library foo;
+          var a = 'b';
+          class Foo {}
+        ''',
+        );
+      });
+
+      test(
+          'when the stubbed "companion" class(es) are not associated with a UiComponent2 instance',
+          () {
+        testSuggestor(
+          expectedPatchCount: 0,
+          input: '''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              \$Foo;
+  
+          @Props()
+          class _\$FooProps extends UiProps {
+            String foo;
+            int bar;
+          }
+  
+          @Component()
+          class FooComponent extends UiComponent<FooProps, FooState> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+          
+          // AF-3369 This will be removed once the transition to Dart 2 is complete.
+          // ignore: mixin_of_non_class, undefined_class
+          class FooProps extends _\$FooProps with _\$FooPropsAccessorsMixin {
+            // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+            static const PropsMeta meta = _\$metaForFooProps;
+          }
+        ''',
+        );
+      });
+
+      test(
+          'when the class inheritance is advanced and unable able to be migrated',
+          () {
+        // TODO add a test for when the class is advanced and unable to be migrated
+      });
+
+      test('when the stubbed "companion" class(es) are publicly exported', () {
+        // TODO add a test for when the class is publicly exported
+      });
+    });
+
+    group('performs a migration', () {
+      test(
+          'when the class inheritance is advanced, but still able to be migrated',
+          () {
+        // TODO add a test for when the class is advanced, but still able to be migrated
+      });
+
+      test('when the class inheritance is simple (private)', () {
+        testSuggestor(
+          expectedPatchCount: 2,
+          input: '''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              \$Foo;
+      
+          @Props()
+          class _\$_FooProps extends UiProps {
+            String foo;
+            int bar;
+          }
+      
+          @State()
+          class _\$_FooState extends UiState {
+            String foo;
+            int bar;
+          }
+      
+          @Component2()
+          class FooComponent extends UiStatefulComponent2<_FooProps, _FooState> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+          
+          // AF-3369 This will be removed once the transition to Dart 2 is complete.
+          // ignore: mixin_of_non_class, undefined_class
+          class _FooProps extends _\$_FooProps with _\$_FooPropsAccessorsMixin {
+            // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+            static const PropsMeta meta = _\$metaFor_FooProps;
+          }
+          
+          // AF-3369 This will be removed once the transition to Dart 2 is complete.
+          // ignore: mixin_of_non_class, undefined_class
+          class _FooState extends _\$_FooState with _\$_FooStateAccessorsMixin {
+            // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+            static const StateMeta meta = _\$metaFor_FooState;
+          }
+        ''',
+          expectedOutput: '''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              \$Foo;
+      
+          @Props()
+          class _\$_FooProps extends UiProps {
+            String foo;
+            int bar;
+          }
+      
+          @State()
+          class _\$_FooState extends UiState {
+            String foo;
+            int bar;
+          }
+      
+          @Component2()
+          class FooComponent extends UiStatefulComponent2<_FooProps, _FooState> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+        ''',
+        );
+      });
+
+      test('when the class inheritance is simple (public)', () {
+        testSuggestor(
+          expectedPatchCount: 2,
+          input: '''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              \$Foo;
+      
+          @Props()
+          class _\$FooProps extends UiProps {
+            String foo;
+            int bar;
+          }
+      
+          @State()
+          class _\$FooState extends UiState {
+            String foo;
+            int bar;
+          }
+      
+          @Component2()
+          class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+          
+          // AF-3369 This will be removed once the transition to Dart 2 is complete.
+          // ignore: mixin_of_non_class, undefined_class
+          class FooProps extends _\$FooProps with _\$FooPropsAccessorsMixin {
+            // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+            static const PropsMeta meta = _\$metaForFooProps;
+          }
+          
+          // AF-3369 This will be removed once the transition to Dart 2 is complete.
+          // ignore: mixin_of_non_class, undefined_class
+          class FooState extends _\$FooState with _\$FooStateAccessorsMixin {
+            // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+            static const StateMeta meta = _\$metaForFooState;
+          }
+        ''',
+          expectedOutput: '''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              \$Foo;
+      
+          @Props()
+          class _\$FooProps extends UiProps {
+            String foo;
+            int bar;
+          }
+      
+          @State()
+          class _\$FooState extends UiState {
+            String foo;
+            int bar;
+          }
+      
+          @Component2()
+          class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+        ''',
+        );
+      });
+    });
+  });
+}

--- a/test/dart2_suggestors/props_and_state_companion_class_remover.suggestor_test
+++ b/test/dart2_suggestors/props_and_state_companion_class_remover.suggestor_test
@@ -22,7 +22,8 @@ class Foo {}
 >>> @Props() public (patches 1)
 @Props() class _$Foo {}
 
-// This will be removed once the transition to Dart 2 is complete.
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
 class Foo extends _$Foo
     with
         // ignore: mixin_of_non_class, undefined_class
@@ -39,7 +40,8 @@ class Foo extends _$Foo
 @State() class _$FooState {}
 
 @Component() class FooComponent {}
- // This will be removed once the transition to Dart 2 is complete.
+ // AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
 class Foo extends _$Foo
     with
         // ignore: mixin_of_non_class, undefined_class
@@ -57,7 +59,8 @@ class Foo extends _$Foo
 >>> @Props() private (patches 1)
 @Props() class _$_Foo {}
 
-// This will be removed once the transition to Dart 2 is complete.
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
 class _Foo extends _$_Foo
     with
         // ignore: mixin_of_non_class, undefined_class
@@ -72,7 +75,8 @@ class _Foo extends _$_Foo
 >>> @State() public (patches 1)
 @State() class _$Foo {}
 
-// This will be removed once the transition to Dart 2 is complete.
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
 class Foo extends _$Foo
     with
         // ignore: mixin_of_non_class, undefined_class
@@ -87,7 +91,8 @@ class Foo extends _$Foo
 >>> @State() private (patches 1)
 @State() class _$_Foo {}
 
-// This will be removed once the transition to Dart 2 is complete.
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
 class _Foo extends _$_Foo
     with
         // ignore: mixin_of_non_class, undefined_class
@@ -102,7 +107,8 @@ class _Foo extends _$_Foo
 >>> @AbstractProps() public (patches 1)
 @AbstractProps() class _$Foo {}
 
-// This will be removed once the transition to Dart 2 is complete.
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
 class Foo extends _$Foo
     with
         // ignore: mixin_of_non_class, undefined_class
@@ -117,7 +123,8 @@ class Foo extends _$Foo
 >>> @AbstractProps() private (patches 1)
 @AbstractProps() class _$_Foo {}
 
-// This will be removed once the transition to Dart 2 is complete.
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
 class _Foo extends _$_Foo
     with
         // ignore: mixin_of_non_class, undefined_class
@@ -132,7 +139,8 @@ class _Foo extends _$_Foo
 >>> @AbstractState() public (patches 1)
 @AbstractState() class _$Foo {}
 
-// This will be removed once the transition to Dart 2 is complete.
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
 class Foo extends _$Foo
     with
         // ignore: mixin_of_non_class, undefined_class
@@ -147,7 +155,8 @@ class Foo extends _$Foo
 >>> @AbstractState() private (patches 1)
 @AbstractState() class _$_Foo {}
 
-// This will be removed once the transition to Dart 2 is complete.
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
 class _Foo extends _$_Foo
     with
         // ignore: mixin_of_non_class, undefined_class
@@ -167,7 +176,8 @@ class _$Foo {}
 
 @Bar(test: true)
 @deprecated
-// This will be removed once the transition to Dart 2 is complete.
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
 class Foo extends _$Foo
     with
         // ignore: mixin_of_non_class, undefined_class
@@ -190,7 +200,8 @@ class _$Foo {}
 
 @Bar(test: true)
 @deprecated
-// This will be removed once the transition to Dart 2 is complete.
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
 class Foo extends _$Foo
     with
         // ignore: mixin_of_non_class, undefined_class
@@ -213,7 +224,8 @@ class _$Foo {}
 
 /// A doc comment.
 /// And a second line!
-// This will be removed once the transition to Dart 2 is complete.
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
 class Foo extends _$Foo
     with
         // ignore: mixin_of_non_class, undefined_class
@@ -236,7 +248,8 @@ class _$Foo {}
 
 /// A doc comment.
 /// And a second line!
-// This will be removed once the transition to Dart 2 is complete.
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
 class Foo extends _$Foo
     with
         // ignore: mixin_of_non_class, undefined_class
@@ -256,7 +269,8 @@ class _$Foo {}
 class _$DontRemove {}
 
 // orcm_ignore
-// This will be removed once the transition to Dart 2 is complete.
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
 class DontRemove extends _$DontRemove
     with
         // ignore: mixin_of_non_class, undefined_class
@@ -269,7 +283,8 @@ class DontRemove extends _$DontRemove
 class _$DontRemove {}
 
 // orcm_ignore
-// This will be removed once the transition to Dart 2 is complete.
+// AF-3369 This will be removed once the transition to Dart 2 is complete.
+// ignore: mixin_of_non_class, undefined_class
 class DontRemove extends _$DontRemove
     with
         // ignore: mixin_of_non_class, undefined_class


### PR DESCRIPTION
## Motivation
Need to remove props / state "companion" classes as part of the boilerplate update codemod.

## Changes
Use the suggestor that was already written as part of the dart2 codemod.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @greglittlefield-wf @joebingham-wk @sydneyjodon-wk 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
