### PR TITLE
CPLAT-9411 Add standalone PropsMixin / StateMixin migrator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart:2.4 as build
+FROM drydock-prod.workiva.net/workiva/dart2_base_image:1 as build
 
 # Build Environment Vars
 ARG BUILD_ID

--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -66,15 +66,14 @@ bool shouldMigratePropsAndStateClass(ClassDeclaration node) {
 /// A simple RegExp against the parent of the class to verify it is `UiProps`
 /// or `UiState`.
 bool extendsFromUiPropsOrUiState(ClassDeclaration classNode) =>
-    classNode.extendsClause.superclass.name
-        .toSource()
+    classNode.extendsClause.superclass.name.name
         .contains(RegExp('(UiProps)|(UiState)'));
 
 /// A simple RegExp against the parent of the class to verify it is `UiProps`
 /// or `UiState`.
 bool implementsUiPropsOrUiState(ClassDeclaration classNode) {
   return classNode.implementsClause.interfaces
-      .map((typeName) => typeName.toSource())
+      .map((typeName) => typeName.name.name)
       .any((typeStr) => typeStr.contains(RegExp('(UiProps)|(UiState)')));
 }
 
@@ -102,7 +101,7 @@ bool isSimplePropsOrStateClass(ClassDeclaration classNode) {
   // Only validate props or state classes
   assert(isAPropsOrStateClass(classNode));
 
-  final superClass = classNode.extendsClause.superclass.name.toSource();
+  final superClass = classNode.extendsClause.superclass.name.name;
 
   if (superClass != 'UiProps' && superClass != 'UiState') return false;
   if (classNode.withClause != null) return false;
@@ -175,8 +174,7 @@ void migrateClassToMixin(ClassDeclaration node, YieldPatch yieldPatch,
 
   yieldPatch(node.classKeyword.offset, node.classKeyword.charEnd, 'mixin');
 
-  final originalPublicClassName =
-      stripPrivateGeneratedPrefix(node.name.toSource());
+  final originalPublicClassName = stripPrivateGeneratedPrefix(node.name.name);
   String newMixinName = originalPublicClassName;
 
   if (node.extendsClause?.extendsKeyword != null) {
@@ -206,12 +204,12 @@ void migrateClassToMixin(ClassDeclaration node, YieldPatch yieldPatch,
         } else {
           // Implements UiProps / UiState along with other interfaces
           final uiInterface = nodeInterfaces.singleWhere((interface) =>
-              interface.toSource() == 'UiProps' ||
-              interface.toSource() == 'UiState');
+              interface.name.name == 'UiProps' ||
+              interface.name.name == 'UiState');
           final otherInterfaces = List.of(nodeInterfaces)..remove(uiInterface);
 
           yieldPatch(node.implementsClause.offset, node.implementsClause.end,
-              'on ${uiInterface.toSource()} implements ${otherInterfaces.joinByName()}');
+              'on ${uiInterface.name.name} implements ${otherInterfaces.joinByName()}');
         }
       } else {
         // Does not implement UiProps / UiState

--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -74,7 +74,7 @@ bool extendsFromUiPropsOrUiState(ClassDeclaration classNode) =>
 bool implementsUiPropsOrUiState(ClassDeclaration classNode) {
   return classNode.implementsClause.interfaces
       .map((typeName) => typeName.name.name)
-      .any((typeStr) => typeStr.contains(RegExp('(UiProps)|(UiState)')));
+      .any({'UiProps', 'UiState'}.contains);
 }
 
 /// A simple evaluation of the annotation(s) of the [classNode]

--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -224,10 +224,6 @@ void migrateClassToMixin(ClassDeclaration node, YieldPatch yieldPatch,
           // But does implement other stuff
           yieldPatch(node.implementsClause.offset, node.implementsClause.end,
               'on $uiInterfaceStr implements ${nodeInterfaces.joinByName()}');
-        } else {
-          // Does not implement anything
-          yieldPatch(node.leftBracket.offset - 1, node.leftBracket.offset - 1,
-              'on $uiInterfaceStr');
         }
       }
     } else {

--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -26,32 +26,30 @@ bool isPublicForTest = false;
 // Stub while <https://jira.atl.workiva.net/browse/CPLAT-9308> is in progress
 bool isPublic(ClassDeclaration node) => isPublicForTest;
 
+/// Returns the annotation node associated with the provided [classNode]
+/// that matches the provided [annotationName], if one exists.
+AstNode getAnnotationNode(ClassDeclaration classNode, String annotationName) {
+  if (classNode.metadata.isEmpty) return null;
+
+  return classNode.metadata.singleWhere(
+      (node) => node.name.name == annotationName,
+      orElse: () => null);
+}
+
 /// A simple evaluation of the annotation(s) of the [classNode]
 /// to verify it is either a `@PropsMixin()` or `@StateMixin`.
 bool isAPropsOrStateMixin(ClassDeclaration classNode) =>
     isAPropsMixin(classNode) || isAStateMixin(classNode);
 
-/// Returns the node of a `@PropsMixin()` annotation for the provided [classNode], if one exists.
-AstNode getPropsMixinAnnotationNode(ClassDeclaration classNode) =>
-    classNode.sortedCommentAndAnnotations.singleWhere(
-        (node) => node?.toSource()?.startsWith('@PropsMixin') == true,
-        orElse: () => null);
-
 /// A simple evaluation of the annotation(s) of the [classNode]
 /// to verify it is a `@PropsMixin()`.
 bool isAPropsMixin(ClassDeclaration classNode) =>
-    getPropsMixinAnnotationNode(classNode) != null;
-
-/// Returns the node of a `@PropsMixin()` annotation for the provided [classNode], if one exists.
-AstNode getStateMixinAnnotationNode(ClassDeclaration classNode) =>
-    classNode.sortedCommentAndAnnotations.singleWhere(
-        (node) => node?.toSource()?.startsWith('@StateMixin') == true,
-        orElse: () => null);
+    getAnnotationNode(classNode, 'PropsMixin') != null;
 
 /// A simple evaluation of the annotation(s) of the [classNode]
 /// to verify it is a `@StateMixin()`.
 bool isAStateMixin(ClassDeclaration classNode) =>
-    getStateMixinAnnotationNode(classNode) != null;
+    getAnnotationNode(classNode, 'StateMixin') != null;
 
 /// Whether a props or state mixin class [classNode] should be migrated as part of the boilerplate codemod.
 bool shouldMigratePropsAndStateMixin(ClassDeclaration classNode) =>

--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -29,9 +29,7 @@ bool isPublic(ClassDeclaration node) => isPublicForTest;
 /// Returns the annotation node associated with the provided [classNode]
 /// that matches the provided [annotationName], if one exists.
 AstNode getAnnotationNode(ClassDeclaration classNode, String annotationName) {
-  if (classNode.metadata.isEmpty) return null;
-
-  return classNode.metadata.singleWhere(
+  return classNode.metadata.firstWhere(
       (node) => node.name.name == annotationName,
       orElse: () => null);
 }
@@ -65,9 +63,12 @@ bool shouldMigratePropsAndStateClass(ClassDeclaration node) {
 
 /// A simple RegExp against the parent of the class to verify it is `UiProps`
 /// or `UiState`.
-bool extendsFromUiPropsOrUiState(ClassDeclaration classNode) =>
-    classNode.extendsClause.superclass.name.name
-        .contains(RegExp('(UiProps)|(UiState)'));
+bool extendsFromUiPropsOrUiState(ClassDeclaration classNode) {
+  return {
+    'UiProps',
+    'UiState',
+  }.contains(classNode.extendsClause.superclass.name.name);
+}
 
 /// A simple RegExp against the parent of the class to verify it is `UiProps`
 /// or `UiState`.
@@ -208,7 +209,7 @@ void migrateClassToMixin(ClassDeclaration node, YieldPatch yieldPatch,
               node.implementsClause.implementsKeyword.charEnd, 'on');
         } else {
           // Implements UiProps / UiState along with other interfaces
-          final uiInterface = nodeInterfaces.singleWhere((interface) =>
+          final uiInterface = nodeInterfaces.firstWhere((interface) =>
               interface.name.name == 'UiProps' ||
               interface.name.name == 'UiState');
           final otherInterfaces = List.of(nodeInterfaces)..remove(uiInterface);

--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -78,11 +78,20 @@ bool implementsUiPropsOrUiState(ClassDeclaration classNode) {
       .any((typeStr) => typeStr.contains(RegExp('(UiProps)|(UiState)')));
 }
 
-/// A simple RegExp against the name of the class to verify it contains `props`
-/// or `state`.
-bool isAPropsOrStateClass(ClassDeclaration classNode) => classNode.name
-    .toSource()
-    .contains(RegExp('([A-Za-z]+Props)|([A-Za-z]+State)'));
+/// A simple evaluation of the annotation(s) of the [classNode]
+/// to verify it is either `@Props()` or `@State()` annotated class.
+bool isAPropsOrStateClass(ClassDeclaration classNode) =>
+    isAPropsClass(classNode) || isAStateClass(classNode);
+
+/// A simple evaluation of the annotation(s) of the [classNode]
+/// to verify it is a `@Props()` annotated class.
+bool isAPropsClass(ClassDeclaration classNode) =>
+    getAnnotationNode(classNode, 'Props') != null;
+
+/// A simple evaluation of the annotation(s) of the [classNode]
+/// to verify it is a `@State()` annotated class.
+bool isAStateClass(ClassDeclaration classNode) =>
+    getAnnotationNode(classNode, 'State') != null;
 
 /// Detects if the Props or State class is considered simple.
 ///

--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -202,11 +202,9 @@ void migrateClassToMixin(ClassDeclaration node, YieldPatch yieldPatch,
               interface.toSource() == 'UiProps' ||
               interface.toSource() == 'UiState');
           final otherInterfaces = List.of(nodeInterfaces)..remove(uiInterface);
-          final otherInterfacesStr =
-              commaSeparatedAstNodeNames(otherInterfaces);
 
           yieldPatch(node.implementsClause.offset, node.implementsClause.end,
-              'on ${uiInterface.toSource()} implements $otherInterfacesStr');
+              'on ${uiInterface.toSource()} implements ${otherInterfaces.joinByName()}');
         }
       } else {
         // Does not implement UiProps / UiState
@@ -214,10 +212,8 @@ void migrateClassToMixin(ClassDeclaration node, YieldPatch yieldPatch,
 
         if (nodeInterfaces.isNotEmpty) {
           // But does implement other stuff
-          final otherInterfacesStr = commaSeparatedAstNodeNames(nodeInterfaces);
-
           yieldPatch(node.implementsClause.offset, node.implementsClause.end,
-              'on $uiInterfaceStr implements $otherInterfacesStr');
+              'on $uiInterfaceStr implements ${nodeInterfaces.joinByName()}');
         } else {
           // Does not implement anything
           yieldPatch(node.leftBracket.offset - 1, node.leftBracket.offset - 1,
@@ -235,4 +231,19 @@ void migrateClassToMixin(ClassDeclaration node, YieldPatch yieldPatch,
 
   propsAndStateClassNamesConvertedToNewBoilerplate[originalPublicClassName] =
       newMixinName;
+}
+
+extension IterableAstUtils on Iterable<NamedType> {
+  /// Utility to join an `Iterable` based on the `name` of the `name` field
+  /// rather than the `toString()` of the object.
+  String joinByName(
+      {String startingString, String endingString, String seperator}) {
+    final itemString = map((t) => t.name.name).join('${seperator ?? ','} ');
+    final returnString = StringBuffer()
+      ..write(startingString != null ? '${startingString.trimRight()} ' : '')
+      ..write(itemString)
+      ..write(endingString != null ? '${endingString.trimLeft()}' : '');
+
+    return returnString.toString();
+  }
 }

--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -85,12 +85,14 @@ bool isAPropsOrStateClass(ClassDeclaration classNode) =>
 /// A simple evaluation of the annotation(s) of the [classNode]
 /// to verify it is a `@Props()` annotated class.
 bool isAPropsClass(ClassDeclaration classNode) =>
-    getAnnotationNode(classNode, 'Props') != null;
+    getAnnotationNode(classNode, 'Props') != null ||
+    getAnnotationNode(classNode, 'AbstractProps') != null;
 
 /// A simple evaluation of the annotation(s) of the [classNode]
 /// to verify it is a `@State()` annotated class.
 bool isAStateClass(ClassDeclaration classNode) =>
-    getAnnotationNode(classNode, 'State') != null;
+    getAnnotationNode(classNode, 'State') != null ||
+    getAnnotationNode(classNode, 'AbstractState') != null;
 
 /// Detects if the Props or State class is considered simple.
 ///

--- a/lib/src/boilerplate_suggestors/props_meta_migrator.dart
+++ b/lib/src/boilerplate_suggestors/props_meta_migrator.dart
@@ -29,6 +29,8 @@ import 'package:over_react_codemod/src/boilerplate_suggestors/boilerplate_utilit
 /// // After
 /// propsMeta.forMixin(FooProps)
 /// ```
+///
+/// > Related: [PropsMixinMigrator]
 class PropsMetaMigrator extends GeneralizingAstVisitor
     with AstVisitingSuggestorMixin
     implements Suggestor {

--- a/lib/src/boilerplate_suggestors/props_mixins_migrator.dart
+++ b/lib/src/boilerplate_suggestors/props_mixins_migrator.dart
@@ -40,7 +40,7 @@ class PropsMixinMigrator extends GeneralizingAstVisitor
     final classGetters = node.members
         .whereType<MethodDeclaration>()
         .where((method) => method.isGetter);
-    final propsOrStateGetter = classGetters.singleWhere(
+    final propsOrStateGetter = classGetters.firstWhere(
         (getter) => getter.name.name == 'props' || getter.name.name == 'state',
         orElse: () => null);
     if (propsOrStateGetter != null) {
@@ -53,10 +53,10 @@ class PropsMixinMigrator extends GeneralizingAstVisitor
     if (propsMixinAnnotationNode != null) {
       yieldPatch(
           propsMixinAnnotationNode.offset,
-          // +1 to ensure that any comments that were on the line immediately before the annotation
-          // we are removing - end up on the line immediately before the mixin declaration instead
-          // of having a newline separating them.
-          propsMixinAnnotationNode.end + 1,
+          // Use the offset of the next token to ensure that any comments that were on the line
+          // immediately before the annotation we are removing - end up on the line immediately
+          // before the mixin declaration instead of having a newline separating them.
+          propsMixinAnnotationNode.endToken.next.offset,
           '');
     }
 
@@ -64,10 +64,10 @@ class PropsMixinMigrator extends GeneralizingAstVisitor
     if (stateMixinAnnotationNode != null) {
       yieldPatch(
           stateMixinAnnotationNode.offset,
-          // +1 to ensure that any comments that were on the line immediately before the annotation
-          // we are removing - end up on the line immediately before the mixin declaration instead
-          // of having a newline separating them.
-          stateMixinAnnotationNode.end + 1,
+          // Use the offset of the next token to ensure that any comments that were on the line
+          // immediately before the annotation we are removing - end up on the line immediately
+          // before the mixin declaration instead of having a newline separating them.
+          stateMixinAnnotationNode.endToken.next.offset,
           '');
     }
   }
@@ -79,8 +79,8 @@ class PropsMixinMigrator extends GeneralizingAstVisitor
         .whereType<FieldDeclaration>()
         .map((decl) => decl.fields)
         .toList();
-    final metaField = classFields.singleWhere(
-        (field) => field.variables.single.name.name == 'meta',
+    final metaField = classFields.firstWhere(
+        (field) => field.variables.first.name.name == 'meta',
         orElse: () => null);
     if (metaField == null) return;
 

--- a/lib/src/boilerplate_suggestors/props_mixins_migrator.dart
+++ b/lib/src/boilerplate_suggestors/props_mixins_migrator.dart
@@ -49,13 +49,13 @@ class PropsMixinMigrator extends GeneralizingAstVisitor
   }
 
   void _removePropsOrStateMixinAnnotation(ClassDeclaration node) {
-    final propsMixinAnnotationNode = getPropsMixinAnnotationNode(node);
+    final propsMixinAnnotationNode = getAnnotationNode(node, 'PropsMixin');
     if (propsMixinAnnotationNode != null) {
       yieldPatch(propsMixinAnnotationNode.offset,
           propsMixinAnnotationNode.end + 1, '');
     }
 
-    final stateMixinAnnotationNode = getStateMixinAnnotationNode(node);
+    final stateMixinAnnotationNode = getAnnotationNode(node, 'StateMixin');
     if (stateMixinAnnotationNode != null) {
       yieldPatch(stateMixinAnnotationNode.offset,
           stateMixinAnnotationNode.end + 1, '');

--- a/lib/src/boilerplate_suggestors/props_mixins_migrator.dart
+++ b/lib/src/boilerplate_suggestors/props_mixins_migrator.dart
@@ -90,12 +90,8 @@ class PropsMixinMigrator extends GeneralizingAstVisitor
     } else {
       // Remove the meta field, along with any comment lines that preceded it.
       final metaFieldDecl = metaField.parent;
-      final previousMember = metaFieldDecl == classMembers.first
-          ? null
-          : classMembers[classMembers.indexOf(metaFieldDecl) - 1];
-      final begin = previousMember != null
-          ? previousMember.end + 1
-          : node.leftBracket.offset + 1;
+      final begin = metaFieldDecl.beginToken.precedingComments?.offset ??
+          metaField.offset;
 
       yieldPatch(begin, metaFieldDecl.end, '');
     }

--- a/lib/src/boilerplate_suggestors/props_mixins_migrator.dart
+++ b/lib/src/boilerplate_suggestors/props_mixins_migrator.dart
@@ -16,12 +16,78 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:codemod/codemod.dart';
 
+import 'boilerplate_utilities.dart';
+
 /// Suggestor that updates stand alone props mixins to be actual mixins.
+///
+/// > Related: [PropsMetaMigrator]
 class PropsMixinMigrator extends GeneralizingAstVisitor
     with AstVisitingSuggestorMixin
     implements Suggestor {
   @override
   visitClassDeclaration(ClassDeclaration node) {
     super.visitClassDeclaration(node);
+
+    if (!shouldMigratePropsAndStateMixin(node)) return;
+
+    migrateClassToMixin(node, yieldPatch);
+    _removePropsOrStateGetter(node);
+    _removePropsOrStateMixinAnnotation(node);
+    _migrateMixinMetaField(node);
+  }
+
+  void _removePropsOrStateGetter(ClassDeclaration node) {
+    final classGetters = node.members
+        .whereType<MethodDeclaration>()
+        .where((method) => method.isGetter);
+    final propsOrStateGetter = classGetters.singleWhere(
+        (getter) => getter.name.name == 'props' || getter.name.name == 'state',
+        orElse: () => null);
+    if (propsOrStateGetter != null) {
+      yieldPatch(propsOrStateGetter.offset, propsOrStateGetter.end + 1, '');
+    }
+  }
+
+  void _removePropsOrStateMixinAnnotation(ClassDeclaration node) {
+    final propsMixinAnnotationNode = getPropsMixinAnnotationNode(node);
+    if (propsMixinAnnotationNode != null) {
+      yieldPatch(propsMixinAnnotationNode.offset,
+          propsMixinAnnotationNode.end + 1, '');
+    }
+
+    final stateMixinAnnotationNode = getStateMixinAnnotationNode(node);
+    if (stateMixinAnnotationNode != null) {
+      yieldPatch(stateMixinAnnotationNode.offset,
+          stateMixinAnnotationNode.end + 1, '');
+    }
+  }
+
+  /// NOTE: Usage of the meta field elsewhere will be migrated via the [PropsMetaMigrator].
+  void _migrateMixinMetaField(ClassDeclaration node) {
+    final classMembers = node.members;
+    final classFields = classMembers
+        .whereType<FieldDeclaration>()
+        .map((decl) => decl.fields)
+        .toList();
+    final metaField = classFields.singleWhere(
+        (field) => field.variables.single.name.name == 'meta',
+        orElse: () => null);
+    if (metaField == null) return;
+
+    if (isPublic(node)) {
+      yieldPatch(metaField.parent.offset, metaField.parent.offset,
+          '@Deprecated(\'Use `propsMeta.forMixin(${node.name.name})` instead.\')\n');
+    } else {
+      // Remove the meta field, along with any comment lines that preceded it.
+      final metaFieldDecl = metaField.parent;
+      final previousMember = metaFieldDecl == classMembers.first
+          ? null
+          : classMembers[classMembers.indexOf(metaFieldDecl) - 1];
+      final begin = previousMember != null
+          ? previousMember.end + 1
+          : node.leftBracket.offset + 1;
+
+      yieldPatch(begin, metaField.end + 1, '');
+    }
   }
 }

--- a/lib/src/boilerplate_suggestors/props_mixins_migrator.dart
+++ b/lib/src/boilerplate_suggestors/props_mixins_migrator.dart
@@ -44,21 +44,31 @@ class PropsMixinMigrator extends GeneralizingAstVisitor
         (getter) => getter.name.name == 'props' || getter.name.name == 'state',
         orElse: () => null);
     if (propsOrStateGetter != null) {
-      yieldPatch(propsOrStateGetter.offset, propsOrStateGetter.end + 1, '');
+      yieldPatch(propsOrStateGetter.offset, propsOrStateGetter.end, '');
     }
   }
 
   void _removePropsOrStateMixinAnnotation(ClassDeclaration node) {
     final propsMixinAnnotationNode = getAnnotationNode(node, 'PropsMixin');
     if (propsMixinAnnotationNode != null) {
-      yieldPatch(propsMixinAnnotationNode.offset,
-          propsMixinAnnotationNode.end + 1, '');
+      yieldPatch(
+          propsMixinAnnotationNode.offset,
+          // +1 to ensure that any comments that were on the line immediately before the annotation
+          // we are removing - end up on the line immediately before the mixin declaration instead
+          // of having a newline separating them.
+          propsMixinAnnotationNode.end + 1,
+          '');
     }
 
     final stateMixinAnnotationNode = getAnnotationNode(node, 'StateMixin');
     if (stateMixinAnnotationNode != null) {
-      yieldPatch(stateMixinAnnotationNode.offset,
-          stateMixinAnnotationNode.end + 1, '');
+      yieldPatch(
+          stateMixinAnnotationNode.offset,
+          // +1 to ensure that any comments that were on the line immediately before the annotation
+          // we are removing - end up on the line immediately before the mixin declaration instead
+          // of having a newline separating them.
+          stateMixinAnnotationNode.end + 1,
+          '');
     }
   }
 
@@ -87,7 +97,7 @@ class PropsMixinMigrator extends GeneralizingAstVisitor
           ? previousMember.end + 1
           : node.leftBracket.offset + 1;
 
-      yieldPatch(begin, metaField.end + 1, '');
+      yieldPatch(begin, metaFieldDecl.end, '');
     }
   }
 }

--- a/lib/src/boilerplate_suggestors/simple_props_and_state_class_migrator.dart
+++ b/lib/src/boilerplate_suggestors/simple_props_and_state_class_migrator.dart
@@ -16,7 +16,6 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:codemod/codemod.dart';
 
-import '../util.dart';
 import 'boilerplate_utilities.dart';
 
 /// Suggestor that updates props and state classes to new boilerplate.

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -446,3 +446,14 @@ String stripPrivateGeneratedPrefix(String value) {
       ? value.substring(privateGeneratedPrefix.length)
       : value;
 }
+
+/// Takes an iterable of AstNodes and returns their name in a comma separated string.
+///
+/// Optionally, you can pass a function to [getName] if you want something other
+/// than [AstNode.toSource] to be used to generate the name for the list.
+String commaSeparatedAstNodeNames<T extends AstNode>(Iterable<T> nodeList,
+    {String Function(T node) getName}) {
+  getName ??= (node) => node.toSource();
+
+  return nodeList.map(getName).toString().replaceAll(RegExp(r'[\(\)]'), '');
+}

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -446,14 +446,3 @@ String stripPrivateGeneratedPrefix(String value) {
       ? value.substring(privateGeneratedPrefix.length)
       : value;
 }
-
-/// Takes an iterable of AstNodes and returns their name in a comma separated string.
-///
-/// Optionally, you can pass a function to [getName] if you want something other
-/// than [AstNode.toSource] to be used to generate the name for the list.
-String commaSeparatedAstNodeNames<T extends AstNode>(Iterable<T> nodeList,
-    {String Function(T node) getName}) {
-  getName ??= (node) => node.toSource();
-
-  return nodeList.map(getName).toString().replaceAll(RegExp(r'[\(\)]'), '');
-}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ authors:
   - Sydney Jodon <sydney.jodon@workiva.com>
 
 environment:
-  sdk: ">=2.4.0 <3.0.0"
+  sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
   analyzer: '>=0.37.0 <0.39.0'
@@ -33,7 +33,7 @@ dependencies:
 
 dev_dependencies:
   dart_dev: ^2.0.1
-  dart_style: ^1.2.0
+  dart_style: ^1.3.3
   dependency_validator: ^1.2.3
   mockito: ^4.0.0
   pedantic: ^1.4.0

--- a/test/boilerplate_suggestors/props_mixin_migrator_test.dart
+++ b/test/boilerplate_suggestors/props_mixin_migrator_test.dart
@@ -1,0 +1,354 @@
+// Copyright 2020 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react_codemod/src/boilerplate_suggestors/boilerplate_utilities.dart';
+import 'package:over_react_codemod/src/boilerplate_suggestors/props_mixins_migrator.dart';
+import 'package:test/test.dart';
+
+import '../util.dart';
+
+main() {
+  group('PropsMixinMigrator', () {
+    final testSuggestor = getSuggestorTester(PropsMixinMigrator());
+
+    tearDown(() {
+      propsAndStateClassNamesConvertedToNewBoilerplate = {};
+    });
+
+    group('does not perform a migration', () {
+      test('when it encounters an empty file', () {
+        testSuggestor(expectedPatchCount: 0, input: '');
+      });
+
+      test('when there are no `PropsMixin()` annotations found', () {
+        testSuggestor(
+          expectedPatchCount: 0,
+          input: '''
+          abstract class FooPropsMixin implements UiProps {
+            String foo;
+          }
+        ''',
+        );
+      });
+    });
+
+    void sharedTests(MixinType type) {
+      final typeStr = mixinStrByType[type];
+
+      group('converting the class to a mixin', () {
+        group('when the class implements Ui$typeStr', () {
+          test('only', () {
+            testSuggestor(
+              expectedPatchCount: 6,
+              input: '''
+              /// Some doc comment
+              @${typeStr}Mixin()
+              abstract class Foo${typeStr}Mixin implements Ui${typeStr} {
+                // To ensure the codemod regression checking works properly, please keep this
+                // field at the top of the class!
+                // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+                static const ${typeStr}Meta meta = _\$metaForFoo${typeStr}Mixin;
+                
+                @override
+                Map get ${typeStr.toLowerCase()};
+                
+                String foo;
+              }
+            ''',
+              expectedOutput: '''
+              /// Some doc comment
+              mixin Foo${typeStr}Mixin on Ui${typeStr} {
+                String foo;
+              }
+            ''',
+            );
+
+            expect(propsAndStateClassNamesConvertedToNewBoilerplate, {
+              'Foo${typeStr}Mixin': 'Foo${typeStr}Mixin',
+            });
+          });
+
+          test('along with other interfaces (Ui$typeStr first)', () {
+            testSuggestor(
+              expectedPatchCount: 6,
+              input: '''
+              /// Some doc comment
+              @${typeStr}Mixin()
+              abstract class Foo${typeStr}Mixin implements Ui${typeStr}, Bar${typeStr}Mixin, Baz${typeStr}Mixin {
+                // To ensure the codemod regression checking works properly, please keep this
+                // field at the top of the class!
+                // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+                static const ${typeStr}Meta meta = _\$metaForFoo${typeStr}Mixin;
+                
+                @override
+                Map get ${typeStr.toLowerCase()};
+                
+                String foo;
+              }
+            ''',
+              expectedOutput: '''
+              /// Some doc comment
+              mixin Foo${typeStr}Mixin on Ui${typeStr} implements Bar${typeStr}Mixin, Baz${typeStr}Mixin {
+                String foo;
+              }
+            ''',
+            );
+
+            expect(propsAndStateClassNamesConvertedToNewBoilerplate, {
+              'Foo${typeStr}Mixin': 'Foo${typeStr}Mixin',
+            });
+          });
+
+          test('along with other interfaces (Ui$typeStr last)', () {
+            testSuggestor(
+              expectedPatchCount: 6,
+              input: '''
+              /// Some doc comment
+              @${typeStr}Mixin()
+              abstract class Foo${typeStr}Mixin implements Bar${typeStr}Mixin, Baz${typeStr}Mixin, Ui${typeStr} {
+                // To ensure the codemod regression checking works properly, please keep this
+                // field at the top of the class!
+                // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+                static const ${typeStr}Meta meta = _\$metaForFoo${typeStr}Mixin;
+                
+                @override
+                Map get ${typeStr.toLowerCase()};
+                
+                String foo;
+              }
+            ''',
+              expectedOutput: '''
+              /// Some doc comment
+              mixin Foo${typeStr}Mixin on Ui${typeStr} implements Bar${typeStr}Mixin, Baz${typeStr}Mixin {
+                String foo;
+              }
+            ''',
+            );
+
+            expect(propsAndStateClassNamesConvertedToNewBoilerplate, {
+              'Foo${typeStr}Mixin': 'Foo${typeStr}Mixin',
+            });
+          });
+        });
+
+        group('when the class does not implement Ui$typeStr', () {
+          test('but it does implement other interface(s)', () {
+            testSuggestor(
+              expectedPatchCount: 6,
+              input: '''
+              /// Some doc comment
+              @${typeStr}Mixin()
+              abstract class Foo${typeStr}Mixin implements Bar${typeStr}Mixin, Baz${typeStr}Mixin {
+                // To ensure the codemod regression checking works properly, please keep this
+                // field at the top of the class!
+                // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+                static const ${typeStr}Meta meta = _\$metaForFoo${typeStr}Mixin;
+                
+                @override
+                Map get ${typeStr.toLowerCase()};
+                
+                String foo;
+              }
+            ''',
+              expectedOutput: '''
+              /// Some doc comment
+              mixin Foo${typeStr}Mixin on Ui${typeStr} implements Bar${typeStr}Mixin, Baz${typeStr}Mixin {
+                String foo;
+              }
+            ''',
+            );
+
+            expect(propsAndStateClassNamesConvertedToNewBoilerplate, {
+              'Foo${typeStr}Mixin': 'Foo${typeStr}Mixin',
+            });
+          });
+
+          test('or any other interface', () {
+            testSuggestor(
+              expectedPatchCount: 6,
+              input: '''
+              /// Some doc comment
+              @${typeStr}Mixin()
+              abstract class Foo${typeStr}Mixin {
+                // To ensure the codemod regression checking works properly, please keep this
+                // field at the top of the class!
+                // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+                static const ${typeStr}Meta meta = _\$metaForFoo${typeStr}Mixin;
+                
+                Map get ${typeStr.toLowerCase()};
+                
+                String foo;
+              }
+            ''',
+              expectedOutput: '''
+              /// Some doc comment
+              mixin Foo${typeStr}Mixin on Ui${typeStr} {
+                String foo;
+              }
+            ''',
+            );
+
+            expect(propsAndStateClassNamesConvertedToNewBoilerplate, {
+              'Foo${typeStr}Mixin': 'Foo${typeStr}Mixin',
+            });
+          });
+        });
+      });
+
+      group('meta field', () {
+        group('is removed if the class is not part of the public API', () {
+          test('and the meta field is the first field in the class', () {
+            testSuggestor(
+              expectedPatchCount: 5,
+              input: '''
+              /// Some doc comment
+              @${typeStr}Mixin()
+              abstract class Foo${typeStr}Mixin implements Ui${typeStr} {
+                // To ensure the codemod regression checking works properly, please keep this
+                // field at the top of the class!
+                // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+                static const ${typeStr}Meta meta = _\$metaForFoo${typeStr}Mixin;
+                
+                String foo;
+              }
+            ''',
+              expectedOutput: '''
+              /// Some doc comment
+              mixin Foo${typeStr}Mixin on Ui${typeStr} {
+                String foo;
+              }
+            ''',
+            );
+          });
+
+          test('and the meta field is not the first field in the class', () {
+            testSuggestor(
+              expectedPatchCount: 5,
+              input: '''
+              /// Some doc comment
+              @${typeStr}Mixin()
+              abstract class Foo${typeStr}Mixin implements Ui${typeStr} {
+                // foooooo
+                final baz = 'bar';
+              
+                // To ensure the codemod regression checking works properly, please keep this
+                // field at the top of the class!
+                // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+                static const ${typeStr}Meta meta = _\$metaForFoo${typeStr}Mixin;
+                
+                String foo;
+              }
+            ''',
+              expectedOutput: '''
+              /// Some doc comment
+              mixin Foo${typeStr}Mixin on Ui${typeStr} {
+                // foooooo
+                final baz = 'bar';
+                
+                String foo;
+              }
+            ''',
+            );
+          });
+
+          test(
+              'and the meta field is the first field in the class, but not the first member',
+              () {
+            testSuggestor(
+              expectedPatchCount: 5,
+              input: '''
+              /// Some doc comment
+              @${typeStr}Mixin()
+              abstract class Foo${typeStr}Mixin implements Ui${typeStr} {
+                // foooooo
+                baz() => 'bar';
+              
+                // To ensure the codemod regression checking works properly, please keep this
+                // field at the top of the class!
+                // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+                static const ${typeStr}Meta meta = _\$metaForFoo${typeStr}Mixin;
+                
+                String foo;
+              }
+            ''',
+              expectedOutput: '''
+              /// Some doc comment
+              mixin Foo${typeStr}Mixin on Ui${typeStr} {
+                // foooooo
+                baz() => 'bar';
+                
+                String foo;
+              }
+            ''',
+            );
+          });
+        });
+
+        test('is deprecated if the class is part of the public API', () {
+          addTearDown(() {
+            isPublicForTest = false;
+          });
+          isPublicForTest = true;
+
+          testSuggestor(
+            expectedPatchCount: 5,
+            input: '''
+            /// Some doc comment
+            @${typeStr}Mixin()
+            abstract class Foo${typeStr}Mixin implements Ui${typeStr} {
+              // To ensure the codemod regression checking works properly, please keep this
+              // field at the top of the class!
+              // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+              static const ${typeStr}Meta meta = _\$metaForFoo${typeStr}Mixin;
+              
+              String foo;
+            }
+          ''',
+            expectedOutput: '''
+            /// Some doc comment
+            mixin Foo${typeStr}Mixin on Ui${typeStr} {
+              // To ensure the codemod regression checking works properly, please keep this
+              // field at the top of the class!
+              // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+              @Deprecated('Use `propsMeta.forMixin(Foo${typeStr}Mixin)` instead.')
+              static const ${typeStr}Meta meta = _\$metaForFoo${typeStr}Mixin;
+              
+              String foo;
+            }
+          ''',
+          );
+        });
+      });
+    }
+
+    group(
+        'performs a migration when there is a `@PropsMixin()` annotation present:',
+        () {
+      sharedTests(MixinType.props);
+    });
+
+    group(
+        'performs a migration when there is a `@StateMixin()` annotation present:',
+        () {
+      sharedTests(MixinType.state);
+    });
+  });
+}
+
+enum MixinType { props, state }
+
+const mixinStrByType = {
+  MixinType.props: 'Props',
+  MixinType.state: 'State',
+};


### PR DESCRIPTION
## Motivation
We need a migrator that converts standalone `@PropsMixin()` / `@StateMixin` classes into mixins, and removes / deprecates the `meta` / `props` / `state` fields/getters in the class.

## Changes
1. Add logic for the migrator
2. Write tests

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @joebingham-wk @sydneyjodon-wk @greglittlefield-wf 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
