### PR TITLE
Use utility class to contain map of converted classNames

### DIFF
--- a/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
+++ b/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
@@ -28,6 +28,10 @@ import 'boilerplate_utilities.dart';
 class AdvancedPropsAndStateClassMigrator extends GeneralizingAstVisitor
     with AstVisitingSuggestorMixin
     implements Suggestor {
+  final ClassToMixinConverter converter;
+
+  AdvancedPropsAndStateClassMigrator(this.converter);
+
   @override
   visitClassDeclaration(ClassDeclaration node) {
     super.visitClassDeclaration(node);

--- a/lib/src/boilerplate_suggestors/annotations_remover.dart
+++ b/lib/src/boilerplate_suggestors/annotations_remover.dart
@@ -15,11 +15,16 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:codemod/codemod.dart';
+import 'package:over_react_codemod/src/boilerplate_suggestors/boilerplate_utilities.dart';
 
 /// Suggestor that looks for @Props, @State, and @Component2 and removes them.
 class AnnotationsRemover extends GeneralizingAstVisitor
     with AstVisitingSuggestorMixin
     implements Suggestor {
+  final ClassToMixinConverter converter;
+
+  AnnotationsRemover(this.converter);
+
   @override
   visitAnnotatedNode(AnnotatedNode node) {
     super.visitAnnotatedNode(node);

--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -17,7 +17,7 @@ import 'package:meta/meta.dart';
 import 'package:over_react_codemod/src/constants.dart';
 import 'package:over_react_codemod/src/util.dart';
 
-typedef void YieldPatch(
+typedef YieldPatch = void Function(
     int startingOffset, int endingOffset, String replacement);
 
 @visibleForTesting
@@ -123,121 +123,135 @@ bool isAdvancedPropsOrStateClass(ClassDeclaration classNode) {
   return false;
 }
 
-/// A map of props / state classes that have been migrated to the new boilerplate
-/// via [migrateClassToMixin].
-var propsAndStateClassNamesConvertedToNewBoilerplate =
-    < /*old class name*/ String, /*new mixin name*/ String>{};
-
-/// Used to switch a props/state class, or a `@PropsMixin()`/`@StateMixin()` class to a mixin.
+/// A class used to handle the conversion of props / state classes to mixins.
 ///
-/// __EXAMPLE (Concrete Class):__
-/// ```dart
-/// // Before
-/// class _$TestProps extends UiProps {
-///   String var1;
-///   int var2;
-/// }
+/// Should only be constructed once to initialize the value of [convertedClassNames].
 ///
-/// // After
-/// mixin TestPropsMixin on UiProps {
-///   String var1;
-///   int var2;
-/// }
-/// ```
-///
-/// __EXAMPLE (`@PropsMixin`):__
-/// ```dart
-/// // Before
-/// @PropsMixin()
-/// abstract class TestPropsMixin implements UiProps, BarPropsMixin {
-///   // To ensure the codemod regression checking works properly, please keep this
-///   // field at the top of the class!
-///   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-///   static const PropsMeta meta = _$metaForTestPropsMixin;
-///
-///   @override
-///   Map get props;
-///
-///   String var1;
-///   String var2;
-/// }
-///
-/// // After
-/// mixin TestPropsMixin on UiProps implements BarPropsMixin {
-///   String var1;
-///   String var2;
-/// }
-/// ```
-///
-/// When a class is migrated, it gets added to [propsAndStateClassNamesConvertedToNewBoilerplate]
-/// so that suggestors that come after the suggestor that called this function - can know
-/// whether to yield a patch based on that information.
-void migrateClassToMixin(ClassDeclaration node, YieldPatch yieldPatch,
-    {bool shouldAddMixinToName = false}) {
-  if (node.abstractKeyword != null) {
-    yieldPatch(node.abstractKeyword.offset, node.abstractKeyword.charEnd, '');
-  }
+/// Then [migrate] should be called on that instance each time a class is visited and needs to be converted to a mixin.
+class ClassToMixinConverter {
+  ClassToMixinConverter() : _convertedClassNames = <String, String>{};
 
-  yieldPatch(node.classKeyword.offset, node.classKeyword.charEnd, 'mixin');
+  /// A map of props / state classes that have been migrated to the new boilerplate via [migrate].
+  ///
+  /// The keys of the map are the original class names, with the values representing the new mixin names.
+  Map<String, String> get convertedClassNames => _convertedClassNames;
+  Map<String, String> _convertedClassNames;
 
-  final originalPublicClassName = stripPrivateGeneratedPrefix(node.name.name);
-  String newMixinName = originalPublicClassName;
-
-  if (node.extendsClause?.extendsKeyword != null) {
-    // --- Convert concrete props/state class to a mixin --- //
-
-    yieldPatch(node.name.token.offset,
-        node.name.token.offset + privateGeneratedPrefix.length, '');
-
-    yieldPatch(node.extendsClause.offset,
-        node.extendsClause.extendsKeyword.charEnd, 'on');
-
-    if (shouldAddMixinToName) {
-      yieldPatch(node.name.token.charEnd, node.name.token.charEnd, 'Mixin');
-      newMixinName = '${newMixinName}Mixin';
+  /// Used to switch a props/state class, or a `@PropsMixin()`/`@StateMixin()` class to a mixin.
+  ///
+  /// __EXAMPLE (Concrete Class):__
+  /// ```dart
+  /// // Before
+  /// class _$TestProps extends UiProps {
+  ///   String var1;
+  ///   int var2;
+  /// }
+  ///
+  /// // After
+  /// mixin TestPropsMixin on UiProps {
+  ///   String var1;
+  ///   int var2;
+  /// }
+  /// ```
+  ///
+  /// __EXAMPLE (`@PropsMixin`):__
+  /// ```dart
+  /// // Before
+  /// @PropsMixin()
+  /// abstract class TestPropsMixin implements UiProps, BarPropsMixin {
+  ///   // To ensure the codemod regression checking works properly, please keep this
+  ///   // field at the top of the class!
+  ///   // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+  ///   static const PropsMeta meta = _$metaForTestPropsMixin;
+  ///
+  ///   @override
+  ///   Map get props;
+  ///
+  ///   String var1;
+  ///   String var2;
+  /// }
+  ///
+  /// // After
+  /// mixin TestPropsMixin on UiProps implements BarPropsMixin {
+  ///   String var1;
+  ///   String var2;
+  /// }
+  /// ```
+  ///
+  /// When a class is migrated, it gets added to [convertedClassNames]
+  /// so that suggestors that come after the suggestor that called this function - can know
+  /// whether to yield a patch based on that information.
+  void migrate(ClassDeclaration node, YieldPatch yieldPatch,
+      {bool shouldAddMixinToName = false}) {
+    if (node.abstractKeyword != null) {
+      yieldPatch(node.abstractKeyword.offset, node.abstractKeyword.charEnd, '');
     }
-  } else {
-    // --- Convert props/state mixin to an actual mixin --- //
 
-    if (node.implementsClause?.implementsKeyword != null) {
-      final nodeInterfaces = node.implementsClause.interfaces;
-      // Implements an interface, and does not extend from another class
-      if (implementsUiPropsOrUiState(node)) {
-        if (nodeInterfaces.length == 1) {
-          // Only implements UiProps / UiState
-          yieldPatch(node.implementsClause.offset,
-              node.implementsClause.implementsKeyword.charEnd, 'on');
-        } else {
-          // Implements UiProps / UiState along with other interfaces
-          final uiInterface = nodeInterfaces.firstWhere((interface) =>
-              interface.name.name == 'UiProps' ||
-              interface.name.name == 'UiState');
-          final otherInterfaces = List.of(nodeInterfaces)..remove(uiInterface);
+    yieldPatch(node.classKeyword.offset, node.classKeyword.charEnd, 'mixin');
 
-          yieldPatch(node.implementsClause.offset, node.implementsClause.end,
-              'on ${uiInterface.name.name} implements ${otherInterfaces.joinByName()}');
-        }
-      } else {
-        // Does not implement UiProps / UiState
-        final uiInterfaceStr = isAPropsMixin(node) ? 'UiProps' : 'UiState';
+    final originalPublicClassName = stripPrivateGeneratedPrefix(node.name.name);
+    String newMixinName = originalPublicClassName;
 
-        if (nodeInterfaces.isNotEmpty) {
-          // But does implement other stuff
-          yieldPatch(node.implementsClause.offset, node.implementsClause.end,
-              'on $uiInterfaceStr implements ${nodeInterfaces.joinByName()}');
-        }
+    if (node.extendsClause?.extendsKeyword != null) {
+      // --- Convert concrete props/state class to a mixin --- //
+
+      yieldPatch(node.name.token.offset,
+          node.name.token.offset + privateGeneratedPrefix.length, '');
+
+      yieldPatch(node.extendsClause.offset,
+          node.extendsClause.extendsKeyword.charEnd, 'on');
+
+      if (shouldAddMixinToName) {
+        yieldPatch(node.name.token.charEnd, node.name.token.charEnd, 'Mixin');
+        newMixinName = '${newMixinName}Mixin';
       }
     } else {
-      // Does not implement anything
-      final uiInterfaceStr = isAPropsMixin(node) ? 'UiProps' : 'UiState';
+      // --- Convert props/state mixin to an actual mixin --- //
 
-      yieldPatch(
-          node.name.token.end, node.name.token.end, ' on $uiInterfaceStr');
+      if (node.implementsClause?.implementsKeyword != null) {
+        final nodeInterfaces = node.implementsClause.interfaces;
+        // Implements an interface, and does not extend from another class
+        if (implementsUiPropsOrUiState(node)) {
+          if (nodeInterfaces.length == 1) {
+            // Only implements UiProps / UiState
+            yieldPatch(node.implementsClause.offset,
+                node.implementsClause.implementsKeyword.charEnd, 'on');
+          } else {
+            // Implements UiProps / UiState along with other interfaces
+            final uiInterface = nodeInterfaces.firstWhere((interface) =>
+                interface.name.name == 'UiProps' ||
+                interface.name.name == 'UiState');
+            final otherInterfaces = List.of(nodeInterfaces)
+              ..remove(uiInterface);
+
+            yieldPatch(node.implementsClause.offset, node.implementsClause.end,
+                'on ${uiInterface.name.name} implements ${otherInterfaces.joinByName()}');
+          }
+        } else {
+          // Does not implement UiProps / UiState
+          final uiInterfaceStr = isAPropsMixin(node) ? 'UiProps' : 'UiState';
+
+          if (nodeInterfaces.isNotEmpty) {
+            // But does implement other stuff
+            yieldPatch(node.implementsClause.offset, node.implementsClause.end,
+                'on $uiInterfaceStr implements ${nodeInterfaces.joinByName()}');
+          }
+        }
+      } else {
+        // Does not implement anything
+        final uiInterfaceStr = isAPropsMixin(node) ? 'UiProps' : 'UiState';
+
+        yieldPatch(
+            node.name.token.end, node.name.token.end, ' on $uiInterfaceStr');
+      }
     }
+
+    convertedClassNames[originalPublicClassName] = newMixinName;
   }
 
-  propsAndStateClassNamesConvertedToNewBoilerplate[originalPublicClassName] =
-      newMixinName;
+  @visibleForTesting
+  void setConvertedClassNames(Map<String, String> mapOfConvertedClassNames) =>
+      _convertedClassNames = mapOfConvertedClassNames;
 }
 
 extension IterableAstUtils on Iterable<NamedType> {

--- a/lib/src/boilerplate_suggestors/props_meta_migrator.dart
+++ b/lib/src/boilerplate_suggestors/props_meta_migrator.dart
@@ -18,7 +18,7 @@ import 'package:codemod/codemod.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/boilerplate_utilities.dart';
 
 /// Suggestor that looks for `meta` getter access on props classes found within
-/// [propsAndStateClassNamesConvertedToNewBoilerplate] as a result of being converted to the new
+/// [convertedClassNames] as a result of being converted to the new
 /// boilerplate via `SimplePropsAndStateClassMigrator` or `AdvancedPropsAndStateClassMigrator`, and converts
 /// them to the way meta is accessed using the new boilerplate.
 ///
@@ -34,17 +34,20 @@ import 'package:over_react_codemod/src/boilerplate_suggestors/boilerplate_utilit
 class PropsMetaMigrator extends GeneralizingAstVisitor
     with AstVisitingSuggestorMixin
     implements Suggestor {
+  final ClassToMixinConverter converter;
+
+  PropsMetaMigrator(this.converter);
+
   @override
   visitPrefixedIdentifier(PrefixedIdentifier node) {
     super.visitPrefixedIdentifier(node);
 
     if (node.identifier.name == 'meta') {
-      if (propsAndStateClassNamesConvertedToNewBoilerplate
-          .containsKey(node.prefix.name)) {
+      if (converter.convertedClassNames.containsKey(node.prefix.name)) {
         yieldPatch(
           node.prefix.offset,
           node.identifier.end,
-          'propsMeta.forMixin(${propsAndStateClassNamesConvertedToNewBoilerplate[node.prefix.name]})',
+          'propsMeta.forMixin(${converter.convertedClassNames[node.prefix.name]})',
         );
       }
     }

--- a/lib/src/boilerplate_suggestors/props_mixins_migrator.dart
+++ b/lib/src/boilerplate_suggestors/props_mixins_migrator.dart
@@ -24,13 +24,17 @@ import 'boilerplate_utilities.dart';
 class PropsMixinMigrator extends GeneralizingAstVisitor
     with AstVisitingSuggestorMixin
     implements Suggestor {
+  final ClassToMixinConverter converter;
+
+  PropsMixinMigrator(this.converter);
+
   @override
   visitClassDeclaration(ClassDeclaration node) {
     super.visitClassDeclaration(node);
 
     if (!shouldMigratePropsAndStateMixin(node)) return;
 
-    migrateClassToMixin(node, yieldPatch);
+    converter.migrate(node, yieldPatch);
     _removePropsOrStateGetter(node);
     _removePropsOrStateMixinAnnotation(node);
     _migrateMixinMetaField(node);

--- a/lib/src/boilerplate_suggestors/simple_props_and_state_class_migrator.dart
+++ b/lib/src/boilerplate_suggestors/simple_props_and_state_class_migrator.dart
@@ -28,13 +28,17 @@ import 'boilerplate_utilities.dart';
 class SimplePropsAndStateClassMigrator extends GeneralizingAstVisitor
     with AstVisitingSuggestorMixin
     implements Suggestor {
+  final ClassToMixinConverter converter;
+
+  SimplePropsAndStateClassMigrator(this.converter);
+
   @override
   visitClassDeclaration(ClassDeclaration node) {
     super.visitClassDeclaration(node);
 
     if (!shouldMigrateSimplePropsAndStateClass(node)) return;
 
-    migrateClassToMixin(node, yieldPatch);
+    converter.migrate(node, yieldPatch);
   }
 }
 

--- a/lib/src/executables/boilerplate_upgrade.dart
+++ b/lib/src/executables/boilerplate_upgrade.dart
@@ -16,6 +16,7 @@ import 'dart:io';
 
 import 'package:codemod/codemod.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/annotations_remover.dart';
+import 'package:over_react_codemod/src/boilerplate_suggestors/boilerplate_utilities.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/props_meta_migrator.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/simple_props_and_state_class_migrator.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart';
@@ -38,6 +39,8 @@ void main(List<String> args) {
     },
     recursive: true,
   );
+
+  final classToMixinConverter = ClassToMixinConverter();
 
   // General plan:
   //  - Things that need to be accomplished (very simplified)
@@ -79,11 +82,11 @@ void main(List<String> args) {
     query,
     <Suggestor>[
       StubbedPropsAndStateClassRemover(),
-      SimplePropsAndStateClassMigrator(),
-      AdvancedPropsAndStateClassMigrator(),
-      PropsMixinMigrator(),
-      PropsMetaMigrator(),
-      AnnotationsRemover(),
+      SimplePropsAndStateClassMigrator(classToMixinConverter),
+      AdvancedPropsAndStateClassMigrator(classToMixinConverter),
+      PropsMixinMigrator(classToMixinConverter),
+      PropsMetaMigrator(classToMixinConverter),
+      AnnotationsRemover(classToMixinConverter),
     ].map((s) => Ignoreable(s)),
     args: args,
     defaultYes: true,

--- a/test/boilerplate_suggestors/props_meta_migrator_test.dart
+++ b/test/boilerplate_suggestors/props_meta_migrator_test.dart
@@ -20,25 +20,26 @@ import '../util.dart';
 
 main() {
   group('PropsMetaMigrator', () {
-    final testSuggestor = getSuggestorTester(PropsMetaMigrator());
+    final converter = ClassToMixinConverter();
+    final testSuggestor = getSuggestorTester(PropsMetaMigrator(converter));
 
     tearDown(() {
-      propsAndStateClassNamesConvertedToNewBoilerplate = {};
+      converter.setConvertedClassNames({});
     });
 
     group('does not perform a migration', () {
       test('when it encounters an empty file', () {
-        propsAndStateClassNamesConvertedToNewBoilerplate = {
+        converter.setConvertedClassNames({
           'FooProps': 'FooProps',
-        };
+        });
 
         testSuggestor(expectedPatchCount: 0, input: '');
       });
 
       test('when there are no `PropsClass.meta` identifiers', () {
-        propsAndStateClassNamesConvertedToNewBoilerplate = {
+        converter.setConvertedClassNames({
           'FooProps': 'FooProps',
-        };
+        });
 
         testSuggestor(
           expectedPatchCount: 0,
@@ -55,9 +56,9 @@ main() {
         'performs a migration when there are one or more `PropsClass.meta` identifiers',
         () {
       test('', () {
-        propsAndStateClassNamesConvertedToNewBoilerplate = {
+        converter.setConvertedClassNames({
           'FooProps': 'FooProps',
-        };
+        });
 
         testSuggestor(
           expectedPatchCount: 1,
@@ -101,9 +102,9 @@ main() {
       test(
           'unless the props class is not found within `propsAndStateClassNamesConvertedToNewBoilerplate`',
           () {
-        propsAndStateClassNamesConvertedToNewBoilerplate = {
+        converter.setConvertedClassNames({
           'BarProps': 'BarProps',
-        };
+        });
 
         testSuggestor(
           expectedPatchCount: 0,

--- a/test/boilerplate_suggestors/props_mixin_migrator_test.dart
+++ b/test/boilerplate_suggestors/props_mixin_migrator_test.dart
@@ -20,10 +20,11 @@ import '../util.dart';
 
 main() {
   group('PropsMixinMigrator', () {
-    final testSuggestor = getSuggestorTester(PropsMixinMigrator());
+    final converter = ClassToMixinConverter();
+    final testSuggestor = getSuggestorTester(PropsMixinMigrator(converter));
 
     tearDown(() {
-      propsAndStateClassNamesConvertedToNewBoilerplate = {};
+      converter.setConvertedClassNames({});
     });
 
     group('does not perform a migration', () {
@@ -74,7 +75,7 @@ main() {
             ''',
             );
 
-            expect(propsAndStateClassNamesConvertedToNewBoilerplate, {
+            expect(converter.convertedClassNames, {
               'Foo${typeStr}Mixin': 'Foo${typeStr}Mixin',
             });
           });
@@ -105,7 +106,7 @@ main() {
             ''',
             );
 
-            expect(propsAndStateClassNamesConvertedToNewBoilerplate, {
+            expect(converter.convertedClassNames, {
               'Foo${typeStr}Mixin': 'Foo${typeStr}Mixin',
             });
           });
@@ -136,7 +137,7 @@ main() {
             ''',
             );
 
-            expect(propsAndStateClassNamesConvertedToNewBoilerplate, {
+            expect(converter.convertedClassNames, {
               'Foo${typeStr}Mixin': 'Foo${typeStr}Mixin',
             });
           });
@@ -169,7 +170,7 @@ main() {
             ''',
             );
 
-            expect(propsAndStateClassNamesConvertedToNewBoilerplate, {
+            expect(converter.convertedClassNames, {
               'Foo${typeStr}Mixin': 'Foo${typeStr}Mixin',
             });
           });
@@ -199,7 +200,7 @@ main() {
             ''',
             );
 
-            expect(propsAndStateClassNamesConvertedToNewBoilerplate, {
+            expect(converter.convertedClassNames, {
               'Foo${typeStr}Mixin': 'Foo${typeStr}Mixin',
             });
           });

--- a/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
@@ -20,18 +20,19 @@ import '../util.dart';
 
 main() {
   group('SimplePropsAndStateClassMigrator', () {
+    final converter = ClassToMixinConverter();
     final testSuggestor =
-        getSuggestorTester(SimplePropsAndStateClassMigrator());
+        getSuggestorTester(SimplePropsAndStateClassMigrator(converter));
 
     tearDown(() {
-      propsAndStateClassNamesConvertedToNewBoilerplate = {};
+      converter.setConvertedClassNames({});
     });
 
     group('does not run when', () {
       test('its an empty file', () {
         testSuggestor(expectedPatchCount: 0, input: '');
 
-        expect(propsAndStateClassNamesConvertedToNewBoilerplate, isEmpty);
+        expect(converter.convertedClassNames, isEmpty);
       });
 
       test('there are no matches', () {
@@ -44,7 +45,7 @@ main() {
       ''',
         );
 
-        expect(propsAndStateClassNamesConvertedToNewBoilerplate, isEmpty);
+        expect(converter.convertedClassNames, isEmpty);
       });
 
       test('the component is not Component2', () {
@@ -75,7 +76,7 @@ main() {
       ''',
         );
 
-        expect(propsAndStateClassNamesConvertedToNewBoilerplate, isEmpty);
+        expect(converter.convertedClassNames, isEmpty);
       });
 
       test('the class is a PropsMixin', () {
@@ -112,7 +113,7 @@ main() {
       ''',
         );
 
-        expect(propsAndStateClassNamesConvertedToNewBoilerplate, isEmpty);
+        expect(converter.convertedClassNames, isEmpty);
       });
 
       // TODO add a test for when the class is publicly exported
@@ -152,7 +153,7 @@ main() {
       ''',
           );
 
-          expect(propsAndStateClassNamesConvertedToNewBoilerplate, isEmpty);
+          expect(converter.convertedClassNames, isEmpty);
         });
 
         test('and there is just a props class', () {
@@ -183,7 +184,7 @@ main() {
       ''',
           );
 
-          expect(propsAndStateClassNamesConvertedToNewBoilerplate, isEmpty);
+          expect(converter.convertedClassNames, isEmpty);
         });
       });
     });
@@ -252,7 +253,7 @@ main() {
         ''',
         );
 
-        expect(propsAndStateClassNamesConvertedToNewBoilerplate, {
+        expect(converter.convertedClassNames, {
           'FooProps': 'FooProps',
           'FooState': 'FooState',
         });
@@ -309,7 +310,7 @@ main() {
         ''',
         );
 
-        expect(propsAndStateClassNamesConvertedToNewBoilerplate, {
+        expect(converter.convertedClassNames, {
           'FooProps': 'FooProps',
         });
       });
@@ -377,7 +378,7 @@ main() {
           ''',
         );
 
-        expect(propsAndStateClassNamesConvertedToNewBoilerplate, {
+        expect(converter.convertedClassNames, {
           'FooProps': 'FooProps',
           'FooState': 'FooState',
         });


### PR DESCRIPTION
## Motivation
We want to change the global variable being used to keep track of props / state classes that have been converted to the new boilerplate by sibling migrators to a variable within an object that can be passed around by utilities / migrators that need it.

In doing so, we'll

* eliminate the risk of different areas of the code unintentionally interfering with each other's data (including in tests like this)
* make it easier to reason about where the data is used
* decouple code that reads/writes to this map from the consuming code

## Changes
* Create a `ClassToMixinConverter` class, which contains a `convertedClassNames` getter to access the private `_convertedClassNames` field.
* Create a single instance of this class within `main()` of `boilerplate_upgrade.dart`, and pass the instance around to the migrators that make use of it as constructor arguments.

FYA @sydneyjodon-wk @joebingham-wk @greglittlefield-wf 