### PR TITLE
CPLAT-9677 Improve class migration short-circuit logic + consumer communication

### DIFF
--- a/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
+++ b/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
@@ -384,6 +384,11 @@ MigrationDecision shouldMigrateAdvancedPropsAndStateClass(
       final reasons = migrationDecisions.values
           .where((decision) => !decision.yee && decision.reason != null)
           .map((decisionWithReason) => decisionWithReason.reason);
+
+      if (reasons.isEmpty) {
+        return MigrationDecision(false);
+      }
+
       return MigrationDecision(false, reason: reasons.join('//\n'));
     }
   }

--- a/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
+++ b/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
@@ -99,7 +99,7 @@ class AdvancedPropsAndStateClassMigrator extends GeneralizingAstVisitor
       }
 
       if (forUseInImplementsOrWithClause) {
-        if (!node.isAbstract) {
+        if (!isAbstract(node)) {
           return node.typeParameters.toString();
         } else {
           // The node is abstract, and these typeArgs will be used on a mixin/interface for that node
@@ -174,10 +174,10 @@ class AdvancedPropsAndStateClassMigrator extends GeneralizingAstVisitor
       // `AnnotationsRemover` migrator in a later step of the migration.
       ..write('${node.metadata.join('\n')}\n')
       // Create the class name
-      ..write(node.isAbstract ? 'abstract class ' : 'class ')
+      ..write(isAbstract(node) ? 'abstract class ' : 'class ')
       ..write('$className${getClassTypeArgs()}');
 
-    if (node.isAbstract) {
+    if (isAbstract(node)) {
       mixins = getMixinsForNewDeclaration();
       // Since its abstract, we'll create an interface-only class which can then be implemented by
       // concrete subclasses that have component classes that extend from the analogous abstract component class.
@@ -244,7 +244,7 @@ class AdvancedPropsAndStateClassMigrator extends GeneralizingAstVisitor
             dupeClassInSameRoot.rightBracket.offset,
             node.members.map((member) => member.toSource()).join('\n'));
 
-        newDeclarationBuffer.write(node.isAbstract ? '{}' : ';');
+        newDeclarationBuffer.write(isAbstract(node) ? '{}' : ';');
       } else {
         newDeclarationBuffer
           ..write('{\n')
@@ -257,7 +257,7 @@ class AdvancedPropsAndStateClassMigrator extends GeneralizingAstVisitor
       }
     } else {
       newDeclarationBuffer
-          .write(node.isAbstract || mixins.isEmpty ? '{}' : ';');
+          .write(isAbstract(node) || mixins.isEmpty ? '{}' : ';');
     }
 
     converter.migrate(node, yieldPatch,

--- a/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
+++ b/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
@@ -66,8 +66,8 @@ class AdvancedPropsAndStateClassMigrator extends GeneralizingAstVisitor
       converter,
       convertClassesWithExternalSuperclass:
           convertClassesWithExternalSuperclass,
-      parentClassHasBeenVisited: converter.classWasVisited(parentClassName),
-      parentClassHasBeenConverted: converter.classWasMigrated(parentClassName),
+      parentClassHasBeenVisited: converter.wasVisited(parentClassName),
+      parentClassHasBeenConverted: converter.wasMigrated(parentClassName),
       treatUnvisitedClassesAsExternal: _treatUnvisitedClassesAsExternal,
       mixinNames: mixinNames,
     );
@@ -249,7 +249,7 @@ class AdvancedPropsAndStateClassMigrator extends GeneralizingAstVisitor
     // If a class did not get migrated previously because it extended from a custom superclass that
     // did not get migrated, the FIX ME comment that was added may now need to be removed if the
     // consumer has gone through and manually addressed issues such that the superclass is now "migratable".
-    if (extendsFromCustomClass && converter.classWasMigrated(parentClassName)) {
+    if (extendsFromCustomClass && converter.wasMigrated(parentClassName)) {
       final commentToRemove = getUnMigratedSuperclassReasonComment(
           stripPrivateGeneratedPrefix(node.name.name), parentClassName);
       removeCommentFromNode(node, commentToRemove, yieldPatch);
@@ -266,7 +266,7 @@ MigrationDecision shouldMigrateAdvancedPropsAndStateClass(
   bool treatUnvisitedClassesAsExternal = false,
   List<String> mixinNames = const [],
 }) {
-  if (converter.classWasMigrated(node.name.name)) {
+  if (converter.wasMigrated(node.name.name)) {
     return MigrationDecision(false);
   }
 
@@ -295,7 +295,7 @@ MigrationDecision shouldMigrateAdvancedPropsAndStateClass(
 
       // Has one or more mixins
       for (var mixinName in mixinNames) {
-        if (!converter.classWasVisited(mixinName)) {
+        if (!converter.wasVisited(mixinName)) {
           if (isFirstTimeVisitingClasses) {
             // An advanced class with a mixin that has not been visited yet.
             // However, this is the first run through the script since `treatUnvisitedClassesAsExternal` is false,

--- a/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
+++ b/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
@@ -143,6 +143,10 @@ class AdvancedPropsAndStateClassMigrator extends GeneralizingAstVisitor
                 convertClassesWithExternalSuperclass,
           ) ??
           '')
+      // The metadata (e.g. `@Props()` / `@State()` annotations) must remain
+      // on the concrete class in order for the `StubbedPropsAndStateClassRemover`
+      // migrator to work correctly. The vast majority of these will be removed by the
+      // `AnnotationsRemover` migrator in a later step of the migration.
       ..write('${node.metadata.join('\n')}\n')
       // Create the class name
       ..write(node.isAbstract ? 'abstract class ' : 'class ')

--- a/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
+++ b/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
@@ -318,7 +318,8 @@ MigrationDecision shouldMigrateAdvancedPropsAndStateClass(
 
       // Has one or more mixins
       for (var mixinName in mixinNames) {
-        if (!converter.wasVisited(mixinName)) {
+        if (!isReservedBaseClass(mixinName) &&
+            !converter.wasVisited(mixinName)) {
           if (isFirstTimeVisitingClasses) {
             // An advanced class with a mixin that has not been visited yet.
             // However, this is the first run through the script since `treatUnvisitedClassesAsExternal` is false,

--- a/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
+++ b/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
@@ -143,6 +143,7 @@ class AdvancedPropsAndStateClassMigrator extends GeneralizingAstVisitor
                 convertClassesWithExternalSuperclass,
           ) ??
           '')
+      ..write('${node.metadata.join('\n')}\n')
       // Create the class name
       ..write(node.isAbstract ? 'abstract class ' : 'class ')
       ..write('$className$classTypeArgs');
@@ -261,6 +262,10 @@ MigrationDecision shouldMigrateAdvancedPropsAndStateClass(
   bool treatUnvisitedClassesAsExternal = false,
   List<String> mixinNames = const [],
 }) {
+  if (converter.classWasMigrated(node.name.name)) {
+    return MigrationDecision(false);
+  }
+
   final _shouldMigratePropsAndStateClass =
       shouldMigratePropsAndStateClass(node);
   if (!_shouldMigratePropsAndStateClass.yee) {

--- a/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
+++ b/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
@@ -161,6 +161,11 @@ class AdvancedPropsAndStateClassMigrator extends GeneralizingAstVisitor
 
     final newDeclarationBuffer = StringBuffer()
       ..write('\n\n')
+      // The metadata (e.g. `@Props()` / `@State()` annotations) must remain
+      // on the concrete class in order for the `StubbedPropsAndStateClassRemover`
+      // migrator to work correctly. The vast majority of these will be removed by the
+      // `AnnotationsRemover` migrator in a later step of the migration.
+      ..write('${node.metadata.join('\n')}\n')
       ..write(getFixMeCommentForConvertedClassDeclaration(
         converter: converter,
         mixinNames: mixinNames,
@@ -168,11 +173,6 @@ class AdvancedPropsAndStateClassMigrator extends GeneralizingAstVisitor
         convertClassesWithExternalSuperclass:
             convertClassesWithExternalSuperclass,
       ))
-      // The metadata (e.g. `@Props()` / `@State()` annotations) must remain
-      // on the concrete class in order for the `StubbedPropsAndStateClassRemover`
-      // migrator to work correctly. The vast majority of these will be removed by the
-      // `AnnotationsRemover` migrator in a later step of the migration.
-      ..write('${node.metadata.join('\n')}\n')
       // Create the class name
       ..write(isAbstract(node) ? 'abstract class ' : 'class ')
       ..write('$className${getClassTypeArgs()}');

--- a/lib/src/boilerplate_suggestors/annotations_remover.dart
+++ b/lib/src/boilerplate_suggestors/annotations_remover.dart
@@ -40,7 +40,7 @@ class AnnotationsRemover extends GeneralizingAstVisitor
     // --- Short Circuit Conditions --- //
     if (annotationToRemove == null) return;
     if (annotationToRemove.arguments.arguments.isNotEmpty) return;
-    if (!_propsOrStateClassWasConvertedToNewBoilerplate(node)) return;
+    if (!_propsOrStateClassBoilerplateIsCompatible(node)) return;
 
     // --- Migrate --- //
     yieldPatch(annotationToRemove.offset, annotationToRemove.end, '');
@@ -77,8 +77,7 @@ class AnnotationsRemover extends GeneralizingAstVisitor
     return null;
   }
 
-  bool _propsOrStateClassWasConvertedToNewBoilerplate(
-      CompilationUnitMember node) {
+  bool _propsOrStateClassBoilerplateIsCompatible(CompilationUnitMember node) {
     if (_nodeHasAnnotationWithName(node, 'Factory') ||
         _nodeHasAnnotationWithName(node, 'Component2') ||
         _nodeHasAnnotationWithName(node, 'AbstractComponent2')) {
@@ -86,10 +85,10 @@ class AnnotationsRemover extends GeneralizingAstVisitor
       // but it is a UiComponent-related class with an annotation.
       final analogousPropsMixinOrClassName =
           _getNameOfPropsClassThatMayHaveBeenConverted(node);
-      return converter.wasMigrated(analogousPropsMixinOrClassName);
+      return converter.isBoilerplateCompatible(analogousPropsMixinOrClassName);
     } else if (_nodeHasRelevantAnnotation(node) &&
         node is NamedCompilationUnitMember) {
-      return converter.wasMigrated(node.name.name);
+      return converter.isBoilerplateCompatible(node.name.name);
     }
 
     return false;

--- a/lib/src/boilerplate_suggestors/annotations_remover.dart
+++ b/lib/src/boilerplate_suggestors/annotations_remover.dart
@@ -52,6 +52,7 @@ class AnnotationsRemover extends GeneralizingAstVisitor
     'Props',
     'AbstractState',
     'State',
+    'AbstractComponent2',
     'Component2',
   ];
 
@@ -79,18 +80,16 @@ class AnnotationsRemover extends GeneralizingAstVisitor
   bool _propsOrStateClassWasConvertedToNewBoilerplate(
       CompilationUnitMember node) {
     if (_nodeHasAnnotationWithName(node, 'Factory') ||
-        _nodeHasAnnotationWithName(node, 'Component2')) {
+        _nodeHasAnnotationWithName(node, 'Component2') ||
+        _nodeHasAnnotationWithName(node, 'AbstractComponent2')) {
       // Its not a props or state class that would have been converted to the new boilerplate by a previous migrator.
       // but it is a UiComponent-related class with an annotation.
       final analogousPropsMixinOrClassName =
           _getNameOfPropsClassThatMayHaveBeenConverted(node);
-      return converter.visitedClassNames
-          .containsKey(analogousPropsMixinOrClassName);
-    } else if (_nodeHasRelevantAnnotation(node)) {
-      // Its a props, abstract props, state or abstract state annotated mixin
-      // If it has the annotation, and it is a `MixinDeclaration`,
-      // we can be confident that it has been converted to the new boilerplate.
-      return node is MixinDeclaration;
+      return converter.classWasMigrated(analogousPropsMixinOrClassName);
+    } else if (_nodeHasRelevantAnnotation(node) &&
+        node is NamedCompilationUnitMember) {
+      return converter.classWasMigrated(node.name.name);
     }
 
     return false;

--- a/lib/src/boilerplate_suggestors/annotations_remover.dart
+++ b/lib/src/boilerplate_suggestors/annotations_remover.dart
@@ -86,10 +86,10 @@ class AnnotationsRemover extends GeneralizingAstVisitor
       // but it is a UiComponent-related class with an annotation.
       final analogousPropsMixinOrClassName =
           _getNameOfPropsClassThatMayHaveBeenConverted(node);
-      return converter.classWasMigrated(analogousPropsMixinOrClassName);
+      return converter.wasMigrated(analogousPropsMixinOrClassName);
     } else if (_nodeHasRelevantAnnotation(node) &&
         node is NamedCompilationUnitMember) {
-      return converter.classWasMigrated(node.name.name);
+      return converter.wasMigrated(node.name.name);
     }
 
     return false;

--- a/lib/src/boilerplate_suggestors/annotations_remover.dart
+++ b/lib/src/boilerplate_suggestors/annotations_remover.dart
@@ -84,7 +84,7 @@ class AnnotationsRemover extends GeneralizingAstVisitor
       // but it is a UiComponent-related class with an annotation.
       final analogousPropsMixinOrClassName =
           _getNameOfPropsClassThatMayHaveBeenConverted(node);
-      return converter.convertedClassNames
+      return converter.visitedClassNames
           .containsKey(analogousPropsMixinOrClassName);
     } else if (_nodeHasRelevantAnnotation(node)) {
       // Its a props, abstract props, state or abstract state annotated mixin

--- a/lib/src/boilerplate_suggestors/annotations_remover.dart
+++ b/lib/src/boilerplate_suggestors/annotations_remover.dart
@@ -81,7 +81,7 @@ class AnnotationsRemover extends GeneralizingAstVisitor
     if (_nodeHasAnnotationWithName(node, 'Factory') ||
         _nodeHasAnnotationWithName(node, 'Component2') ||
         _nodeHasAnnotationWithName(node, 'AbstractComponent2')) {
-      // Its not a props or state class that would have been converted to the new boilerplate by a previous migrator.
+      // It's not a props or state class that would have been converted to the new boilerplate by a previous migrator.
       // but it is a UiComponent-related class with an annotation.
       final analogousPropsMixinOrClassName =
           _getNameOfPropsClassThatMayHaveBeenConverted(node);

--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -261,7 +261,7 @@ class ClassToMixinConverter {
   ///
   /// > NOTE: The key will be the name of the [node] with the [privateGeneratedPrefix] removed.
   void recordVisit(ClassOrMixinDeclaration node) {
-    if (!isAPropsOrStateClass(node)) return;
+    if (!(isAPropsOrStateClass(node) || isAPropsOrStateMixin(node))) return;
 
     _visitedNames.putIfAbsent(
         stripPrivateGeneratedPrefix(node.name.name), () => null);

--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -397,13 +397,6 @@ class ClassToMixinConverter {
       if (shouldAddMixinToName) {
         yieldPatch(node.name.token.charEnd, node.name.token.charEnd, 'Mixin');
         newMixinName = '${newMixinName}Mixin';
-
-        final metadataThatBelongsOnConcreteClassDeclOnly = node.metadata.where(
-            (m) => overReactPropsStateNonMixinAnnotationNames
-                .contains(m.name.name));
-        for (var metadata in metadataThatBelongsOnConcreteClassDeclOnly) {
-          yieldPatch(metadata.offset, metadata.end, '');
-        }
       }
 
       if (shouldSwapParentClass) {

--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -71,7 +71,7 @@ const reservedBaseClassNames = {
   'DomPropsMixin': 'DomPropsMixin',
 };
 
-/// Whether the provided [className] is considered a "reserved" (non-custom) base class name to extend from or implement.
+/// Returns whether the provided [className] is considered a "reserved" (non-custom) base class name to extend from or implement.
 bool isReservedBaseClass(String className) {
   return ['UiProps', 'UiState', ...reservedBaseClassNames.keys]
       .contains(className);
@@ -100,12 +100,13 @@ bool isAPropsMixin(ClassDeclaration classNode) =>
 bool isAStateMixin(ClassDeclaration classNode) =>
     getAnnotationNode(classNode, 'StateMixin') != null;
 
-/// Whether a props or state mixin class [classNode] should be migrated as part of the boilerplate codemod.
+/// Returns whether a props or state mixin class [classNode] should be migrated as part of the boilerplate codemod.
 bool shouldMigratePropsAndStateMixin(ClassDeclaration classNode) =>
     isAPropsOrStateMixin(classNode);
 
-/// Whether a props or state class class [node] should be migrated as part of the boilerplate codemod.
-MigrationDecision shouldMigratePropsAndStateClass(ClassDeclaration node) {
+/// Returns whether a props or state class class [node] should be migrated as part of the boilerplate codemod.
+MigrationDecision getPropsAndStateClassMigrationDecision(
+    ClassDeclaration node) {
   final publicNodeName = stripPrivateGeneratedPrefix(node.name.name);
   const reRunMigrationScriptInstructions =
       'pub run over_react_codemod:boilerplate_upgrade';
@@ -123,7 +124,7 @@ MigrationDecision shouldMigratePropsAndStateClass(ClassDeclaration node) {
       false,
       reason: '''
       // FIXME: `$publicNodeName` could not be auto-migrated to the new over_react boilerplate 
-      // because `${getComponentNodeInRoot(node).name.name}` does not extend from `react.Component2`.
+      // because `${getComponentNodeInRoot(node).name.name}` does not extend from `UiComponent2`.
       // 
       // Once you have upgraded the component, you can remove this FIXME comment and 
       // re-run the boilerplate migration script:
@@ -246,11 +247,12 @@ class ClassToMixinConverter {
   ///
   /// > Instead of trying to parse the keys / values for semantic meaning,
   ///   it is strongly recommended that you utilize helper methods like
-  ///   [wasVisited] and [wasMigrated] and [isBoilerplateCompatible] instead.
+  ///   [wasVisited], [wasMigrated] and [isBoilerplateCompatible] instead.
+  @visibleForTesting
   Map<String, String> get visitedNames => _visitedNames;
   Map<String, String> _visitedNames;
 
-  /// Whether the provided [classOrMixinName] was either created or migrated
+  /// Returns whether the provided [classOrMixinName] was either created or migrated
   /// as a result of [migrate] being called.
   ///
   /// A true return value indicates that the [classOrMixinName] is
@@ -259,7 +261,7 @@ class ClassToMixinConverter {
       visitedNames.containsValue(classOrMixinName) ||
       wasMigrated(classOrMixinName);
 
-  /// Whether the provided [classOrMixinName] was migrated as a result of [migrate] being called.
+  /// Returns whether the provided [classOrMixinName] was migrated as a result of [migrate] being called.
   ///
   /// Returns true if:
   ///
@@ -270,7 +272,7 @@ class ClassToMixinConverter {
   bool wasMigrated(String classOrMixinName) =>
       visitedNames[classOrMixinName] != null;
 
-  /// Whether the provided [classOrMixinName] was migrated as a result of [migrate] being called.
+  /// Returns whether the provided [classOrMixinName] was migrated as a result of [migrate] being called.
   bool wasVisited(String classOrMixinName) =>
       visitedNames.containsKey(classOrMixinName);
 
@@ -501,16 +503,9 @@ String getConvertedClassMixinName(
 }
 
 extension IterableAstUtils on Iterable<NamedType> {
-  /// Utility to join an `Iterable` based on the `name` of the `name` field
-  /// rather than the `toString()` of the object when the named type is:
-  ///
-  /// 1. A non-generated _(no `$` prefix)_ mixin / class
-  /// 2. A generated mixin name that has not been converted by a migrator
-  ///     * The `// ignore` comments will be preserved in this case
-  String joinConvertedClassesByName({
+  List<String> getConvertedClassesByName({
     ClassToMixinConverter converter,
     SourceFile sourceFile,
-    String separator,
     bool includeGenericParameters = true,
     bool includeComments = true,
     bool includePrivateGeneratedClassNames = true,
@@ -553,6 +548,29 @@ extension IterableAstUtils on Iterable<NamedType> {
       }
 
       return '${t.name.name}${_typeArgs(t)}';
-    }).join('${separator ?? ','} ');
+    }).toList();
+  }
+
+  /// Utility to join an `Iterable` based on the `name` of the `name` field
+  /// rather than the `toString()` of the object when the named type is:
+  ///
+  /// 1. A non-generated _(no `$` prefix)_ mixin / class
+  /// 2. A generated mixin name that has not been converted by a migrator
+  ///     * The `// ignore` comments will be preserved in this case
+  String joinConvertedClassesByName({
+    ClassToMixinConverter converter,
+    SourceFile sourceFile,
+    String separator,
+    bool includeGenericParameters = true,
+    bool includeComments = true,
+    bool includePrivateGeneratedClassNames = true,
+  }) {
+    return getConvertedClassesByName(
+      converter: converter,
+      sourceFile: sourceFile,
+      includeGenericParameters: includeGenericParameters,
+      includeComments: includeComments,
+      includePrivateGeneratedClassNames: includePrivateGeneratedClassNames,
+    ).join('${separator ?? ','} ');
   }
 }

--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -63,13 +63,17 @@ AstNode getAnnotationNode(ClassDeclaration classNode, String annotationName) {
       orElse: () => null);
 }
 
+/// A map with keys of "reserved" base props/state class names, and values of the
+/// analogous mixin that the migrator(s) can assume will exist - even if the
+/// base class is never visited by them.
+const reservedBaseClassNames = {
+  'FluxUiProps': 'FluxUiPropsMixin',
+};
+
 /// Whether the provided [className] is considered a "reserved" (non-custom) base class name to extend from or implement.
 bool isReservedBaseClass(String className) {
-  return [
-    'UiProps',
-    'UiState',
-    'FluxUiProps',
-  ].contains(className);
+  return ['UiProps', 'UiState', ...reservedBaseClassNames.keys]
+      .contains(className);
 }
 
 /// A simple evaluation of the annotation(s) of the [classNode]
@@ -463,10 +467,6 @@ String getPropsClassNameFromFactoryDeclaration(
 /// if no matching key is found within [ClassToMixinConverter.visitedClassNames] on the provided [converter] instance.
 String getConvertedClassMixinName(
     String originalClassName, ClassToMixinConverter converter) {
-  const reservedBaseClassNames = {
-    'FluxUiProps': 'FluxUiPropsMixin',
-  };
-
   // If it is a "reserved" base class that the consumer doesn't control / won't be converted as
   // part of running the codemod in their repo, return the new "known" mixin name.
   if (reservedBaseClassNames.containsKey(originalClassName)) {

--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -68,6 +68,7 @@ AstNode getAnnotationNode(ClassDeclaration classNode, String annotationName) {
 /// base class is never visited by them.
 const reservedBaseClassNames = {
   'FluxUiProps': 'FluxUiPropsMixin',
+  'DomPropsMixin': 'DomPropsMixin',
 };
 
 /// Whether the provided [className] is considered a "reserved" (non-custom) base class name to extend from or implement.
@@ -514,8 +515,11 @@ extension IterableAstUtils on Iterable<NamedType> {
     bool includeComments = true,
     bool includePrivateGeneratedClassNames = true,
   }) {
-    bool _mixinBoilerplateIsCompatible(NamedType t) =>
-        converter.isBoilerplateCompatible(t.name.name.replaceFirst('\$', ''));
+    bool _mixinBoilerplateIsCompatible(NamedType t) {
+      final publicName = t.name.name.replaceFirst('\$', '');
+      return converter.isBoilerplateCompatible(publicName) ||
+          isReservedBaseClass(publicName);
+    }
 
     bool _mixinNameIsOldGeneratedBoilerplate(NamedType t) =>
         t.name.name.startsWith('\$');

--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -76,6 +76,14 @@ bool isReservedBaseClass(String className) {
       .contains(className);
 }
 
+/// Returns whether the [classNode] should be considered "abstract" based on both
+/// the presence of the `abstract` keyword, and also the `@AbstractProps()` / `@AbstractState()`
+/// annotations present.
+bool isAbstract(ClassDeclaration classNode) =>
+    classNode.isAbstract ||
+    getAnnotationNode(classNode, 'AbstractProps') != null ||
+    getAnnotationNode(classNode, 'AbstractState') != null;
+
 /// A simple evaluation of the annotation(s) of the [classNode]
 /// to verify it is either a `@PropsMixin()` or `@StateMixin`.
 bool isAPropsOrStateMixin(ClassDeclaration classNode) =>

--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -354,6 +354,13 @@ class ClassToMixinConverter {
       if (shouldAddMixinToName) {
         yieldPatch(node.name.token.charEnd, node.name.token.charEnd, 'Mixin');
         newMixinName = '${newMixinName}Mixin';
+
+        final metadataThatBelongsOnConcreteClassDeclOnly = node.metadata.where(
+            (m) => overReactPropsStateNonMixinAnnotationNames
+                .contains(m.name.name));
+        for (var metadata in metadataThatBelongsOnConcreteClassDeclOnly) {
+          yieldPatch(metadata.offset, metadata.end, '');
+        }
       }
 
       if (shouldSwapParentClass) {

--- a/lib/src/boilerplate_suggestors/migration_decision.dart
+++ b/lib/src/boilerplate_suggestors/migration_decision.dart
@@ -117,7 +117,7 @@ String getFixMeCommentForConvertedClassDeclaration({
 }) {
   final extendsFromCustomNonReservedClass =
       !isReservedBaseClass(parentClassName);
-  final usesExternalMixins = !mixinNames.every(converter.classWasVisited);
+  final usesExternalMixins = !mixinNames.every(converter.wasVisited);
   if (!extendsFromCustomNonReservedClass && !usesExternalMixins) return null;
 
   final fixMeBuffer = StringBuffer()..writeln('// FIXME:');
@@ -134,9 +134,9 @@ String getFixMeCommentForConvertedClassDeclaration({
   // Add more context about what they need to do next after they force the initial migration.
   if (convertClassesWithExternalSuperclass) {
     final extendsFromExternalCustomClass = extendsFromCustomNonReservedClass &&
-        !converter.classWasVisited(parentClassName);
+        !converter.wasVisited(parentClassName);
     final externalMixins =
-        mixinNames.where((name) => !converter.classWasVisited(name));
+        mixinNames.where((name) => !converter.wasVisited(name));
     var externalApis = extendsFromExternalCustomClass
         ? [parentClassName, ...externalMixins]
         : [...externalMixins];

--- a/lib/src/boilerplate_suggestors/migration_decision.dart
+++ b/lib/src/boilerplate_suggestors/migration_decision.dart
@@ -1,0 +1,158 @@
+// Copyright 2020 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:meta/meta.dart';
+
+import 'boilerplate_utilities.dart';
+
+/// A data model used to inform whether a migration should occur,
+/// and also - optionally - what comment should be left in place if a migration cannot occur.
+class MigrationDecision {
+  /// Whether the migration should take place.
+  final bool yee;
+
+  /// An optional "reason" comment that can be patched onto the node by calling [patchWithReasonComment].
+  final String reason;
+
+  MigrationDecision(this.yee, {this.reason});
+
+  /// Patch the provided [node] with a "FIX ME" comment giving the [reason] that the migration was short-circuited.
+  void patchWithReasonComment(
+      ClassOrMixinDeclaration node, YieldPatch yieldPatch) {
+    var fixmeCommentAlreadyAdded = false;
+    if (reason != null) {
+      final firstLineOfReasonComment = reason.split('\n').first.trim();
+      final firstLineOfNodeComment =
+          node.beginToken.precedingComments.toString();
+      fixmeCommentAlreadyAdded =
+          firstLineOfReasonComment == firstLineOfNodeComment;
+    }
+
+    if (reason == null || fixmeCommentAlreadyAdded) {
+      return;
+    }
+
+    yieldPatch(node.offset, node.offset, reason);
+  }
+}
+
+String getExternalSuperclassOrMixinReasonComment(
+  String nodeName,
+  List<String> superclassOrMixinNames, {
+  bool mixinsAreExternal = false,
+}) {
+  final inheritanceReasonPortion =
+      mixinsAreExternal ? 'mixes in' : 'extends from';
+
+  return '''
+  // FIXME: `$nodeName` could not be auto-migrated to the new over_react boilerplate 
+  // because it $inheritanceReasonPortion: ${superclassOrMixinNames.join(', ')} - which ${superclassOrMixinNames.length == 1 ? 'comes' : 'come'} from an external library.
+  //
+  // To complete the migration, you should:
+  //   1. Check on the boilerplate migration status of the library ${superclassOrMixinNames.length == 1 ? 'it comes' : 'they come'} from.
+  //   2. Once the library has released a version that includes updated boilerplate,
+  //      bump the lower bound of your dependency to that version in your `pubspec.yaml`, and run `pub get`.
+  //   3. Re-run the migration script with the following flag:
+  //      pub run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
+  //   4. Once the migration is complete, you should notice that ${superclassOrMixinNames.join(', ')} ${superclassOrMixinNames.length == 1 ? 'has' : 'have'} been deprecated. 
+  //      Follow the deprecation instructions to consume the ${superclassOrMixinNames.length == 1 ? 'replacement' : 'replacements'} by either updating your usage to
+  //      the new ${mixinsAreExternal ? 'mixin' : 'class'} ${superclassOrMixinNames.length == 1 ? 'name' : 'names'} and/or updating to a different entrypoint that exports the version(s) of 
+  //      ${superclassOrMixinNames.join(', ')} that ${superclassOrMixinNames.length == 1 ? 'is' : 'are'} compatible with the new over_react boilerplate.
+  ''';
+}
+
+String getPublicApiReasonComment(String nodeName) {
+  return '''
+  // FIXME: `$nodeName` could not be auto-migrated to the new over_react boilerplate 
+  // because doing so would be a breaking change since `$nodeName` is exported from a 
+  // library in this repo.
+  //
+  // To complete the migration, you should: 
+  //   1. Deprecate `$nodeName`.
+  //   2. Make a copy of it, renaming it something like `${nodeName}V2`.
+  //   3. Replace all your current usage of the deprecated `$nodeName` with `${nodeName}V2`.
+  //   4. Add a `hide ${nodeName}V2` clause to all places where it is exported, and then run:
+  //        pub run over_react_codemod:boilerplate_upgrade
+  //   5a. If `$nodeName` had consumers outside this repo, and it was intentionally made public,
+  //       remove the `hide` clause you added in step 4 so that the new mixin created from `${nodeName}V2` 
+  //       will be a viable replacement for `$nodeName`.
+  //   5b. If `$nodeName` had no consumers outside this repo, and you have no reason to make the new
+  //       "V2" class / mixin public, update the `hide` clause you added in step 4 to include both the 
+  //       concrete class and the newly created mixin.
+  //   6. Remove this FIXME comment.
+  ''';
+}
+
+String getUnMigratedSuperclassReasonComment(
+    String nodeName, String superclassName) {
+  return '''
+  // FIXME: `$nodeName` could not be auto-migrated to the new over_react boilerplate 
+  // because it extends from `$superclassName`, which was not able to be migrated.
+  //
+  // To complete the migration, you should:
+  //   1. Look at the "FIXME" comment that has been added to `$superclassName` - 
+  //      and follow the steps outlined there to complete the migration.
+  //   2. Re-run the migration script:
+  //      pub run over_react_codemod:boilerplate_upgrade
+  ''';
+}
+
+String getFixMeCommentForConvertedClassDeclaration({
+  @required ClassToMixinConverter converter,
+  @required String parentClassName,
+  @required bool convertClassesWithExternalSuperclass,
+  List<String> mixinNames = const [],
+}) {
+  final extendsFromCustomNonReservedClass =
+      !isReservedBaseClass(parentClassName);
+  final usesExternalMixins = !mixinNames.every(converter.classWasVisited);
+  if (!extendsFromCustomNonReservedClass && !usesExternalMixins) return null;
+
+  final fixMeBuffer = StringBuffer()..writeln('// FIXME:');
+
+  if (extendsFromCustomNonReservedClass) {
+    fixMeBuffer
+      ..writeln(
+          '//   1. Ensure that all mixins used by $parentClassName are also mixed into this class.')
+      ..writeln(
+          '//   2. Fix any analyzer warnings on this class about missing mixins.');
+  }
+
+  // Consumer is forcing classes that extend from / mix in external APIs to be converted.
+  // Add more context about what they need to do next after they force the initial migration.
+  if (convertClassesWithExternalSuperclass) {
+    final extendsFromExternalCustomClass = extendsFromCustomNonReservedClass &&
+        !converter.classWasVisited(parentClassName);
+    final externalMixins =
+        mixinNames.where((name) => !converter.classWasVisited(name));
+    var externalApis = extendsFromExternalCustomClass
+        ? [parentClassName, ...externalMixins]
+        : [...externalMixins];
+
+    if (externalApis.isNotEmpty) {
+      fixMeBuffer..write('''
+        //   ${extendsFromCustomNonReservedClass ? '3' : '1'}. You should notice that ${externalApis.join(', ')} ${externalApis.length == 1 ? 'is' : 'are'} deprecated.  
+        //      Follow the deprecation instructions to consume the replacement by either updating your usage to
+        //      the new class/mixin name and/or updating to a different entrypoint that exports the ${externalApis.length == 1 ? 'version' : 'versions'} of 
+        //      ${externalApis.join(', ')} that ${externalApis.length == 1 ? 'is' : 'are'} compatible with the new over_react boilerplate.
+        //
+        //      If ${externalApis.length == 1 ? 'it is' : 'they are'} not deprecated, something most likely went wrong during the migration of the 
+        //      library that contains ${externalApis.length == 1 ? 'it' : 'them'}.        
+        ''');
+    }
+  }
+
+  return fixMeBuffer.toString();
+}

--- a/lib/src/boilerplate_suggestors/migration_decision.dart
+++ b/lib/src/boilerplate_suggestors/migration_decision.dart
@@ -35,7 +35,7 @@ class MigrationDecision {
     if (reason != null) {
       final firstLineOfReasonComment = reason.split('\n').first.trim();
       final firstLineOfNodeComment =
-          node.beginToken.precedingComments.toString();
+          node.beginToken.precedingComments.toString().trim();
       fixmeCommentAlreadyAdded =
           firstLineOfReasonComment == firstLineOfNodeComment;
     }

--- a/lib/src/boilerplate_suggestors/migration_decision.dart
+++ b/lib/src/boilerplate_suggestors/migration_decision.dart
@@ -14,6 +14,7 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:meta/meta.dart';
+import 'package:over_react_codemod/src/util.dart';
 
 import 'boilerplate_utilities.dart';
 

--- a/lib/src/boilerplate_suggestors/migration_decision.dart
+++ b/lib/src/boilerplate_suggestors/migration_decision.dart
@@ -118,7 +118,7 @@ String getFixMeCommentForConvertedClassDeclaration({
   final extendsFromCustomNonReservedClass =
       !isReservedBaseClass(parentClassName);
   final usesExternalMixins = !mixinNames.every(converter.wasVisited);
-  if (!extendsFromCustomNonReservedClass && !usesExternalMixins) return null;
+  if (!extendsFromCustomNonReservedClass && !usesExternalMixins) return '';
 
   final fixMeBuffer = StringBuffer()..writeln('// FIXME:');
 

--- a/lib/src/boilerplate_suggestors/migration_decision.dart
+++ b/lib/src/boilerplate_suggestors/migration_decision.dart
@@ -120,7 +120,9 @@ String getFixMeCommentForConvertedClassDeclaration({
 }) {
   final extendsFromCustomNonReservedClass =
       !isReservedBaseClass(parentClassName);
-  final usesExternalMixins = !mixinNames.every(converter.wasVisited);
+  final usesExternalMixins = !mixinNames
+      .where((name) => !isReservedBaseClass(name))
+      .every(converter.wasVisited);
   if (!extendsFromCustomNonReservedClass && !usesExternalMixins) return '';
 
   final fixMeBuffer = StringBuffer()..writeln('// FIXME:');

--- a/lib/src/boilerplate_suggestors/migration_decision.dart
+++ b/lib/src/boilerplate_suggestors/migration_decision.dart
@@ -14,7 +14,6 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:meta/meta.dart';
-import 'package:over_react_codemod/src/util.dart';
 
 import 'boilerplate_utilities.dart';
 

--- a/lib/src/boilerplate_suggestors/migration_decision.dart
+++ b/lib/src/boilerplate_suggestors/migration_decision.dart
@@ -34,8 +34,10 @@ class MigrationDecision {
     var fixmeCommentAlreadyAdded = false;
     if (reason != null) {
       final firstLineOfReasonComment = reason.split('\n').first.trim();
-      final firstLineOfNodeComment =
-          node.beginToken.precedingComments.toString().trim();
+      final firstLineOfNodeComment = node
+          .firstTokenAfterCommentAndMetadata.precedingComments
+          .toString()
+          .trim();
       fixmeCommentAlreadyAdded =
           firstLineOfReasonComment == firstLineOfNodeComment;
     }
@@ -44,7 +46,8 @@ class MigrationDecision {
       return;
     }
 
-    yieldPatch(node.offset, node.offset, reason);
+    yieldPatch(node.firstTokenAfterCommentAndMetadata.offset,
+        node.firstTokenAfterCommentAndMetadata.offset, reason);
   }
 }
 

--- a/lib/src/boilerplate_suggestors/props_meta_migrator.dart
+++ b/lib/src/boilerplate_suggestors/props_meta_migrator.dart
@@ -20,7 +20,7 @@ import 'package:over_react_codemod/src/component2_suggestors/component2_utilitie
 import 'package:over_react_codemod/src/util.dart';
 
 /// Suggestor that looks for `meta` getter access on props classes found within
-/// [convertedClassNames] as a result of being converted to the new
+/// [visitedClassNames] as a result of being converted to the new
 /// boilerplate via `SimplePropsAndStateClassMigrator` or `AdvancedPropsAndStateClassMigrator`, and converts
 /// them to the way meta is accessed using the new boilerplate.
 ///
@@ -53,7 +53,7 @@ class PropsMetaMigrator extends GeneralizingAstVisitor
 
     if (node.identifier.name == 'meta') {
       final propsClassWithMetaWasConverted =
-          converter.convertedClassNames.containsKey(node.prefix.name);
+          converter.classWasMigrated(node.prefix.name);
       // If the component we're visiting does not extend from `UiComponent2`, then `propsMeta` will not exist.
       final componentWithMetaUsageIsComponent2 =
           extendsComponent2(getContainingClass(node));
@@ -63,7 +63,7 @@ class PropsMetaMigrator extends GeneralizingAstVisitor
         yieldPatch(
           node.prefix.offset,
           node.identifier.end,
-          'propsMeta.forMixin(${converter.convertedClassNames[node.prefix.name]})',
+          'propsMeta.forMixin(${converter.visitedClassNames[node.prefix.name]})',
         );
 
         if (node.parent is TypedLiteral) {

--- a/lib/src/boilerplate_suggestors/props_meta_migrator.dart
+++ b/lib/src/boilerplate_suggestors/props_meta_migrator.dart
@@ -20,7 +20,7 @@ import 'package:over_react_codemod/src/component2_suggestors/component2_utilitie
 import 'package:over_react_codemod/src/util.dart';
 
 /// Suggestor that looks for `meta` getter access on props classes found within
-/// [visitedClassNames] as a result of being converted to the new
+/// [visitedNames] as a result of being converted to the new
 /// boilerplate via `SimplePropsAndStateClassMigrator` or `AdvancedPropsAndStateClassMigrator`, and converts
 /// them to the way meta is accessed using the new boilerplate.
 ///
@@ -53,7 +53,7 @@ class PropsMetaMigrator extends GeneralizingAstVisitor
 
     if (node.identifier.name == 'meta') {
       final propsClassWithMetaWasConverted =
-          converter.classWasMigrated(node.prefix.name);
+          converter.wasMigrated(node.prefix.name);
       // If the component we're visiting does not extend from `UiComponent2`, then `propsMeta` will not exist.
       final componentWithMetaUsageIsComponent2 =
           extendsComponent2(getContainingClass(node));
@@ -63,7 +63,7 @@ class PropsMetaMigrator extends GeneralizingAstVisitor
         yieldPatch(
           node.prefix.offset,
           node.identifier.end,
-          'propsMeta.forMixin(${converter.visitedClassNames[node.prefix.name]})',
+          'propsMeta.forMixin(${converter.visitedNames[node.prefix.name]})',
         );
 
         if (node.parent is TypedLiteral) {

--- a/lib/src/boilerplate_suggestors/props_mixins_migrator.dart
+++ b/lib/src/boilerplate_suggestors/props_mixins_migrator.dart
@@ -31,6 +31,7 @@ class PropsMixinMigrator extends GeneralizingAstVisitor
   @override
   visitClassDeclaration(ClassDeclaration node) {
     super.visitClassDeclaration(node);
+    converter.recordVisit(node);
 
     if (!shouldMigratePropsAndStateMixin(node)) return;
 

--- a/lib/src/boilerplate_suggestors/simple_props_and_state_class_migrator.dart
+++ b/lib/src/boilerplate_suggestors/simple_props_and_state_class_migrator.dart
@@ -15,6 +15,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:codemod/codemod.dart';
+import 'package:over_react_codemod/src/boilerplate_suggestors/migration_decision.dart';
 
 import 'boilerplate_utilities.dart';
 
@@ -35,12 +36,26 @@ class SimplePropsAndStateClassMigrator extends GeneralizingAstVisitor
   @override
   visitClassDeclaration(ClassDeclaration node) {
     super.visitClassDeclaration(node);
+    converter.recordVisit(node);
 
-    if (!shouldMigrateSimplePropsAndStateClass(node)) return;
+    final _shouldMigrateSimplePropsAndStateClass =
+        shouldMigrateSimplePropsAndStateClass(node);
+    if (!_shouldMigrateSimplePropsAndStateClass.yee) {
+      _shouldMigrateSimplePropsAndStateClass.patchWithReasonComment(
+          node, yieldPatch);
+      return;
+    }
 
     converter.migrate(node, yieldPatch, sourceFile: sourceFile);
   }
 }
 
-bool shouldMigrateSimplePropsAndStateClass(ClassDeclaration node) =>
-    shouldMigratePropsAndStateClass(node) && isSimplePropsOrStateClass(node);
+MigrationDecision shouldMigrateSimplePropsAndStateClass(ClassDeclaration node) {
+  final _shouldMigratePropsAndStateClass =
+      shouldMigratePropsAndStateClass(node);
+  if (!_shouldMigratePropsAndStateClass.yee) {
+    return _shouldMigratePropsAndStateClass;
+  }
+
+  return MigrationDecision(isSimplePropsOrStateClass(node));
+}

--- a/lib/src/boilerplate_suggestors/simple_props_and_state_class_migrator.dart
+++ b/lib/src/boilerplate_suggestors/simple_props_and_state_class_migrator.dart
@@ -52,7 +52,7 @@ class SimplePropsAndStateClassMigrator extends GeneralizingAstVisitor
 
 MigrationDecision shouldMigrateSimplePropsAndStateClass(ClassDeclaration node) {
   final _shouldMigratePropsAndStateClass =
-      shouldMigratePropsAndStateClass(node);
+      getPropsAndStateClassMigrationDecision(node);
   if (!_shouldMigratePropsAndStateClass.yee) {
     return _shouldMigratePropsAndStateClass;
   }

--- a/lib/src/boilerplate_suggestors/stubbed_props_and_state_class_remover.dart
+++ b/lib/src/boilerplate_suggestors/stubbed_props_and_state_class_remover.dart
@@ -29,6 +29,6 @@ class StubbedPropsAndStateClassRemover
   bool shouldRemoveCompanionClassFor(
       NamedCompilationUnitMember candidate, CompilationUnit node) {
     return super.shouldRemoveCompanionClassFor(candidate, node) &&
-        converter.classWasMigrated(candidate.name.name);
+        converter.wasMigrated(candidate.name.name);
   }
 }

--- a/lib/src/boilerplate_suggestors/stubbed_props_and_state_class_remover.dart
+++ b/lib/src/boilerplate_suggestors/stubbed_props_and_state_class_remover.dart
@@ -15,6 +15,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:codemod/codemod.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart';
+import 'package:over_react_codemod/src/boilerplate_suggestors/boilerplate_utilities.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/simple_props_and_state_class_migrator.dart';
 import 'package:over_react_codemod/src/dart2_suggestors/props_and_state_companion_class_remover.dart';
 
@@ -22,11 +23,15 @@ import 'package:over_react_codemod/src/dart2_suggestors/props_and_state_companio
 /// they were only temporarily required for backwards-compatibility with Dart 1.
 class StubbedPropsAndStateClassRemover
     extends PropsAndStateCompanionClassRemover implements Suggestor {
+  final ClassToMixinConverter converter;
+
+  StubbedPropsAndStateClassRemover(this.converter);
+
   @override
   bool shouldRemoveCompanionClassFor(
       ClassDeclaration candidate, CompilationUnit node) {
     return super.shouldRemoveCompanionClassFor(candidate, node) &&
-        (shouldMigrateSimplePropsAndStateClass(candidate) ||
-            shouldMigrateAdvancedPropsAndStateClass(candidate));
+        (shouldMigrateSimplePropsAndStateClass(candidate).yee ||
+            shouldMigrateAdvancedPropsAndStateClass(candidate, converter).yee);
   }
 }

--- a/lib/src/boilerplate_suggestors/stubbed_props_and_state_class_remover.dart
+++ b/lib/src/boilerplate_suggestors/stubbed_props_and_state_class_remover.dart
@@ -14,9 +14,7 @@
 
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:codemod/codemod.dart';
-import 'package:over_react_codemod/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/boilerplate_utilities.dart';
-import 'package:over_react_codemod/src/boilerplate_suggestors/simple_props_and_state_class_migrator.dart';
 import 'package:over_react_codemod/src/dart2_suggestors/props_and_state_companion_class_remover.dart';
 
 /// Suggestor that removes every companion class for props and state classes, as
@@ -29,9 +27,8 @@ class StubbedPropsAndStateClassRemover
 
   @override
   bool shouldRemoveCompanionClassFor(
-      ClassDeclaration candidate, CompilationUnit node) {
+      NamedCompilationUnitMember candidate, CompilationUnit node) {
     return super.shouldRemoveCompanionClassFor(candidate, node) &&
-        (shouldMigrateSimplePropsAndStateClass(candidate).yee ||
-            shouldMigrateAdvancedPropsAndStateClass(candidate, converter).yee);
+        converter.classWasMigrated(candidate.name.name);
   }
 }

--- a/lib/src/executables/boilerplate_upgrade.dart
+++ b/lib/src/executables/boilerplate_upgrade.dart
@@ -24,6 +24,8 @@ import 'package:over_react_codemod/src/boilerplate_suggestors/props_mixins_migra
 import 'package:over_react_codemod/src/boilerplate_suggestors/stubbed_props_and_state_class_remover.dart';
 import 'package:over_react_codemod/src/ignoreable.dart';
 
+const _convertedClassesWithExternalSuperclassFlag =
+    '--convert-classes-with-external-superclasses';
 const _changesRequiredOutput = '''
   To update your code, run the following commands in your repository:
   pub global activate over_react_codemod
@@ -33,6 +35,10 @@ const _changesRequiredOutput = '''
 ''';
 
 void main(List<String> args) {
+  final convertClassesWithExternalSuperclass =
+      args.contains(_convertedClassesWithExternalSuperclassFlag);
+  args.removeWhere((arg) => arg == _convertedClassesWithExternalSuperclassFlag);
+
   final query = FileQuery.dir(
     pathFilter: (path) {
       return isDartFile(path) && !isGeneratedDartFile(path);
@@ -84,9 +90,26 @@ void main(List<String> args) {
       // We need this to run first so that the AdvancedPropsAndStateClassMigrator
       // can check for duplicate mixin names before creating one.
       PropsMixinMigrator(classToMixinConverter),
-      StubbedPropsAndStateClassRemover(),
+      StubbedPropsAndStateClassRemover(classToMixinConverter),
       SimplePropsAndStateClassMigrator(classToMixinConverter),
-      AdvancedPropsAndStateClassMigrator(classToMixinConverter),
+      AdvancedPropsAndStateClassMigrator(
+        classToMixinConverter,
+        // When we visit these nodes the first time around, we can't assume that
+        // they come from an external lib just because they do not
+        // appear within `ClassToMixinConverter.visitedClassNames`
+        treatUnvisitedClassesAsExternal: false,
+      ),
+      // NOTE: The convertClassesWithExternalSuperclass is intentionally only set
+      // based on the CLI flag value the second time around.
+      AdvancedPropsAndStateClassMigrator(
+        classToMixinConverter,
+        convertClassesWithExternalSuperclass:
+            convertClassesWithExternalSuperclass,
+        // Now that we have visited all of the nodes once, we can assume that
+        // they come from an external lib if they do not
+        // appear within `ClassToMixinConverter.visitedClassNames`
+        treatUnvisitedClassesAsExternal: true,
+      ),
       PropsMetaMigrator(classToMixinConverter),
       AnnotationsRemover(classToMixinConverter),
     ].map((s) => Ignoreable(s)),

--- a/lib/src/executables/boilerplate_upgrade.dart
+++ b/lib/src/executables/boilerplate_upgrade.dart
@@ -90,7 +90,6 @@ void main(List<String> args) {
       // We need this to run first so that the AdvancedPropsAndStateClassMigrator
       // can check for duplicate mixin names before creating one.
       PropsMixinMigrator(classToMixinConverter),
-      StubbedPropsAndStateClassRemover(classToMixinConverter),
       SimplePropsAndStateClassMigrator(classToMixinConverter),
       AdvancedPropsAndStateClassMigrator(
         classToMixinConverter,
@@ -111,6 +110,10 @@ void main(List<String> args) {
         treatUnvisitedClassesAsExternal: true,
       ),
       PropsMetaMigrator(classToMixinConverter),
+      // Run this last so that the decision about whether to migrate the class is based on
+      // the final migrated / un-migrated state of the class after the simple/advanced class
+      // migrators have finished, but before the annotations are removed.
+      StubbedPropsAndStateClassRemover(classToMixinConverter),
       AnnotationsRemover(classToMixinConverter),
     ].map((s) => Ignoreable(s)),
     args: args,

--- a/lib/src/react16_suggestors/react16_utilities.dart
+++ b/lib/src/react16_suggestors/react16_utilities.dart
@@ -15,12 +15,14 @@
 import 'dart:io';
 
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/dart/ast/token.dart';
 import 'package:codemod/codemod.dart';
 import 'package:logging/logging.dart';
+import 'package:over_react_codemod/src/util.dart';
 import 'package:source_span/source_span.dart';
 
 import 'constants.dart';
+
+export 'package:over_react_codemod/src/util.dart' show allComments;
 
 /// Returns whether or not the source file contains the React 16 validation
 /// required comment.
@@ -93,24 +95,6 @@ SourceSpan nodeCommentSpan(AnnotatedNode node, SourceFile sourceFile) {
       node.beginToken.offset,
       node.metadata?.beginToken?.offset ??
           node.firstTokenAfterCommentAndMetadata.offset);
-}
-
-/// Returns an iterable of all the comments from [beginToken] to the end of the
-/// file.
-///
-/// Comments are part of the normal stream, and need to be accessed via
-/// [Token.precedingComments], so it's difficult to iterate over them without
-/// this method.
-Iterable<Token> allComments(Token beginToken) sync* {
-  var currentToken = beginToken;
-  while (!currentToken.isEof) {
-    var currentComment = currentToken.precedingComments;
-    while (currentComment != null) {
-      yield currentComment;
-      currentComment = currentComment.next;
-    }
-    currentToken = currentToken.next;
-  }
 }
 
 /// Returns whether or not there is a React 16 upgrade comment within a

--- a/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
@@ -1504,6 +1504,117 @@ void main() {
             });
           });
 
+          group('that is abstract based on annotation only (edge case)', () {
+            test('with members of its own', () {
+              const input = r'''
+                  @PropsMixin()
+                  abstract class BreadcrumbPathPropsMixin {}
+                  
+                  @AbstractProps()
+                  class _$AbstractBreadcrumbPathProps extends AbstractGraphFormProps
+                      with
+                          BreadcrumbPathPropsMixin,
+                          // ignore: mixin_of_non_class, undefined_class
+                          $BreadcrumbPathPropsMixin {
+                    String foo;
+                    int bar;
+                  }
+                  
+                  @AbstractComponent2()
+                  class AbstractBreadcrumbPathComponent<T extends AbstractBreadcrumbPathProps> 
+                      extends UiComponent2<T> {}
+                ''';
+
+              testSuggestor(visitedClassNames: {
+                'BreadcrumbPathPropsMixin': 'BreadcrumbPathPropsMixin',
+                'AbstractGraphFormProps': 'AbstractGraphFormProps',
+              })(
+                expectedPatchCount: 7,
+                input: input,
+                expectedOutput: r'''
+                @PropsMixin()
+                abstract class BreadcrumbPathPropsMixin {}
+              
+                @AbstractProps()
+                mixin AbstractBreadcrumbPathPropsMixin on UiProps {
+                  String foo;
+                  int bar;
+                }
+
+                // FIXME:
+                //   1. Ensure that all mixins used by AbstractGraphFormProps are also mixed into this class.
+                //   2. Fix any analyzer warnings on this class about missing mixins.
+                @AbstractProps()
+                abstract class AbstractBreadcrumbPathProps 
+                    implements
+                        AbstractGraphFormProps,
+                        AbstractBreadcrumbPathPropsMixin,
+                        BreadcrumbPathPropsMixin {}
+
+                @AbstractComponent2()
+                class AbstractBreadcrumbPathComponent<T extends AbstractBreadcrumbPathProps> 
+                    extends UiComponent2<T> {}
+              ''',
+              );
+
+              expect(converter.visitedNames, {
+                'BreadcrumbPathPropsMixin': 'BreadcrumbPathPropsMixin',
+                'AbstractGraphFormProps': 'AbstractGraphFormProps',
+                'AbstractBreadcrumbPathProps':
+                    'AbstractBreadcrumbPathPropsMixin',
+              });
+            });
+
+            test('with no members', () {
+              const input = r'''
+                  @PropsMixin()
+                  abstract class BreadcrumbPathPropsMixin {}
+                  
+                  @AbstractProps()
+                  class _$AbstractBreadcrumbPathProps extends AbstractGraphFormProps
+                      with
+                          BreadcrumbPathPropsMixin,
+                          // ignore: mixin_of_non_class, undefined_class
+                          $BreadcrumbPathPropsMixin {}
+                  
+                  @AbstractComponent2()
+                  class AbstractBreadcrumbPathComponent<T extends AbstractBreadcrumbPathProps> 
+                      extends UiComponent2<T> {}
+                ''';
+
+              testSuggestor(visitedClassNames: {
+                'BreadcrumbPathPropsMixin': 'BreadcrumbPathPropsMixin',
+                'AbstractGraphFormProps': 'AbstractGraphFormProps',
+              })(
+                expectedPatchCount: 2,
+                input: input,
+                expectedOutput: r'''
+                @PropsMixin()
+                abstract class BreadcrumbPathPropsMixin {}
+                  
+                // FIXME:
+                //   1. Ensure that all mixins used by AbstractGraphFormProps are also mixed into this class.
+                //   2. Fix any analyzer warnings on this class about missing mixins.
+                @AbstractProps()
+                abstract class AbstractBreadcrumbPathProps 
+                    implements 
+                        AbstractGraphFormProps, 
+                        BreadcrumbPathPropsMixin {}
+
+                @AbstractComponent2()
+                class AbstractBreadcrumbPathComponent<T extends AbstractBreadcrumbPathProps> 
+                    extends UiComponent2<T> {}
+              ''',
+              );
+
+              expect(converter.visitedNames, {
+                'BreadcrumbPathPropsMixin': 'BreadcrumbPathPropsMixin',
+                'AbstractGraphFormProps': 'AbstractGraphFormProps',
+                'AbstractBreadcrumbPathProps': 'AbstractBreadcrumbPathProps',
+              });
+            });
+          });
+
           group('that has an analagous abstract component class', () {
             test('and members of its own', () {
               testSuggestor(visitedClassNames: {
@@ -1818,6 +1929,104 @@ void main() {
                 'LayoutPropsMixin': 'LayoutPropsMixin',
                 'BlockPropsMixin': null,
                 'AbstractBlockProps': 'AbstractBlockProps',
+              });
+            });
+          });
+
+          group('and is abstract based on annotation only (edge case)', () {
+            test('with members of its own', () {
+              const input = r'''
+                  @PropsMixin()
+                  abstract class BreadcrumbPathPropsMixin {}
+                  
+                  @AbstractProps()
+                  class _$AbstractBreadcrumbPathProps extends UiProps
+                      with
+                          BreadcrumbPathPropsMixin,
+                          // ignore: mixin_of_non_class, undefined_class
+                          $BreadcrumbPathPropsMixin {
+                    String foo;
+                    int bar;
+                  }
+                  
+                  @AbstractComponent2()
+                  class AbstractBreadcrumbPathComponent<T extends AbstractBreadcrumbPathProps> 
+                      extends UiComponent2<T> {}
+                ''';
+
+              testSuggestor(visitedClassNames: {
+                'BreadcrumbPathPropsMixin': 'BreadcrumbPathPropsMixin',
+              })(
+                expectedPatchCount: 6,
+                input: input,
+                expectedOutput: r'''
+                @PropsMixin()
+                abstract class BreadcrumbPathPropsMixin {}
+              
+                @AbstractProps()
+                mixin AbstractBreadcrumbPathPropsMixin on UiProps {
+                  String foo;
+                  int bar;
+                }
+
+                @AbstractProps()
+                abstract class AbstractBreadcrumbPathProps 
+                    implements
+                        AbstractBreadcrumbPathPropsMixin,
+                        BreadcrumbPathPropsMixin {}
+
+                @AbstractComponent2()
+                class AbstractBreadcrumbPathComponent<T extends AbstractBreadcrumbPathProps> 
+                    extends UiComponent2<T> {}
+              ''',
+              );
+
+              expect(converter.visitedNames, {
+                'BreadcrumbPathPropsMixin': 'BreadcrumbPathPropsMixin',
+                'AbstractBreadcrumbPathProps':
+                    'AbstractBreadcrumbPathPropsMixin',
+              });
+            });
+
+            test('with no members', () {
+              const input = r'''
+                  @PropsMixin()
+                  abstract class BreadcrumbPathPropsMixin {}
+                  
+                  @AbstractProps()
+                  class _$AbstractBreadcrumbPathProps extends UiProps
+                      with
+                          BreadcrumbPathPropsMixin,
+                          // ignore: mixin_of_non_class, undefined_class
+                          $BreadcrumbPathPropsMixin {}
+                  
+                  @AbstractComponent2()
+                  class AbstractBreadcrumbPathComponent<T extends AbstractBreadcrumbPathProps> 
+                      extends UiComponent2<T> {}
+                ''';
+
+              testSuggestor(visitedClassNames: {
+                'BreadcrumbPathPropsMixin': 'BreadcrumbPathPropsMixin',
+              })(
+                expectedPatchCount: 2,
+                input: input,
+                expectedOutput: r'''
+                @PropsMixin()
+                abstract class BreadcrumbPathPropsMixin {}
+                  
+                @AbstractProps()
+                abstract class AbstractBreadcrumbPathProps 
+                    implements BreadcrumbPathPropsMixin {}
+
+                @AbstractComponent2()
+                class AbstractBreadcrumbPathComponent<T extends AbstractBreadcrumbPathProps> 
+                    extends UiComponent2<T> {}
+              ''',
+              );
+
+              expect(converter.visitedNames, {
+                'BreadcrumbPathPropsMixin': 'BreadcrumbPathPropsMixin',
+                'AbstractBreadcrumbPathProps': 'AbstractBreadcrumbPathProps',
               });
             });
           });

--- a/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
@@ -132,7 +132,7 @@ void main() {
           /// might get in the way of fix me comment removal
           @Props()
           // FIXME: `$publicPropsClassName` could not be auto-migrated to the new over_react boilerplate 
-          // because `FooComponent` does not extend from `react.Component2`.
+          // because `FooComponent` does not extend from `UiComponent2`.
           // 
           // Once you have upgraded the component, you can remove this FIXME comment and 
           // re-run the boilerplate migration script:

--- a/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
@@ -58,8 +58,8 @@ void main() {
       // If visitedClassNames is set, append the value of `converter.visitedClassNames`.
       // This is done to ensure that those custom classNames are not treated as members of an external library API.
       if (visitedClassNames.isNotEmpty) {
-        converter.setVisitedClassNames(
-            {...converter.visitedClassNames, ...visitedClassNames});
+        converter
+            .setVisitedNames({...converter.visitedNames, ...visitedClassNames});
       }
 
       return tester;
@@ -71,14 +71,14 @@ void main() {
 
     tearDown(() {
       runCount = 0;
-      converter.setVisitedClassNames({});
+      converter.setVisitedNames({});
     });
 
     group('does not perform a migration when', () {
       test('it\'s an empty file', () {
         testSuggestor()(expectedPatchCount: 0, input: '');
 
-        expect(converter.visitedClassNames, isEmpty);
+        expect(converter.visitedNames, isEmpty);
       });
 
       test('the class is simple', () {
@@ -97,7 +97,7 @@ void main() {
         ''',
         );
 
-        expect(converter.classWasMigrated(publicPropsClassName), isFalse);
+        expect(converter.wasMigrated(publicPropsClassName), isFalse);
       });
 
       test('the class is not Component2, but does add a FIXME comment', () {
@@ -151,7 +151,7 @@ void main() {
       ''',
         );
 
-        expect(converter.classWasMigrated(publicPropsClassName), isFalse);
+        expect(converter.wasMigrated(publicPropsClassName), isFalse);
       });
 
       test('the class is publicly exported, but does add a FIXME comment', () {
@@ -251,8 +251,8 @@ void main() {
         ''',
         );
 
-        expect(converter.classWasMigrated('BarProps'), isFalse);
-        expect(converter.classWasMigrated('BarState'), isFalse);
+        expect(converter.wasMigrated('BarProps'), isFalse);
+        expect(converter.wasMigrated('BarState'), isFalse);
       });
 
       group(
@@ -311,7 +311,7 @@ void main() {
 
           test('', () {
             expect(
-                converter.visitedClassNames,
+                converter.visitedNames,
                 {
                   publicPropsClassName: null,
                 },
@@ -356,7 +356,7 @@ void main() {
             );
 
             expect(
-                converter.visitedClassNames,
+                converter.visitedNames,
                 {
                   publicPropsClassName: '${publicPropsClassName}Mixin',
                 },
@@ -413,7 +413,7 @@ void main() {
           );
 
           expect(
-              converter.visitedClassNames,
+              converter.visitedNames,
               {
                 publicPropsClassName: '${publicPropsClassName}Mixin',
               },
@@ -494,7 +494,7 @@ void main() {
 
           test('', () {
             expect(
-                converter.visitedClassNames,
+                converter.visitedNames,
                 {
                   publicPropsClassName: null,
                 },
@@ -540,7 +540,7 @@ void main() {
             );
 
             expect(
-                converter.visitedClassNames,
+                converter.visitedNames,
                 {
                   publicPropsClassName: '${publicPropsClassName}Mixin',
                 },
@@ -587,7 +587,7 @@ void main() {
           );
 
           expect(
-              converter.visitedClassNames,
+              converter.visitedNames,
               {
                 publicPropsClassName: '${publicPropsClassName}Mixin',
               },
@@ -647,7 +647,7 @@ void main() {
             expectedOutput: expectedOutputWithUnMigratedSuperclassReasonComment,
           );
 
-          expect(converter.visitedClassNames, {
+          expect(converter.visitedNames, {
             'ADifferentPropsClass': null,
             publicPropsClassName: null,
           });
@@ -687,7 +687,7 @@ void main() {
           ''',
           );
 
-          expect(converter.visitedClassNames, {
+          expect(converter.visitedNames, {
             'ADifferentPropsClass': 'ADifferentPropsClassMixin',
             publicPropsClassName: '${publicPropsClassName}Mixin',
           });
@@ -751,7 +751,7 @@ void main() {
 
             test('', () {
               expect(
-                  converter.visitedClassNames,
+                  converter.visitedNames,
                   {
                     publicPropsClassName: null,
                   },
@@ -794,7 +794,7 @@ void main() {
               );
 
               expect(
-                  converter.visitedClassNames,
+                  converter.visitedNames,
                   {
                     publicPropsClassName: '${publicPropsClassName}Mixin',
                   },
@@ -859,7 +859,7 @@ void main() {
 
             test('', () {
               expect(
-                  converter.visitedClassNames,
+                  converter.visitedNames,
                   {
                     publicPropsClassName: null,
                   },
@@ -902,7 +902,7 @@ void main() {
               );
 
               expect(
-                  converter.visitedClassNames,
+                  converter.visitedNames,
                   {
                     publicPropsClassName: '${publicPropsClassName}Mixin',
                   },
@@ -978,7 +978,7 @@ void main() {
             expectedOutput: expectedOutput,
           );
 
-          expect(converter.visitedClassNames, {
+          expect(converter.visitedNames, {
             'ADifferentPropsClass': 'ADifferentPropsClassMixin',
             'ADifferentStateClass': 'ADifferentStateClassMixin',
             publicPropsClassName: '${publicPropsClassName}Mixin',
@@ -1006,7 +1006,7 @@ void main() {
             expectedOutput: expectedOutput,
           );
 
-          expect(converter.visitedClassNames, {
+          expect(converter.visitedNames, {
             'ADifferentPropsClass': 'ADifferentPropsClassMixin',
             'ADifferentStateClass': 'ADifferentStateClassMixin',
             publicPropsClassName: '${publicPropsClassName}Mixin',
@@ -1073,7 +1073,7 @@ void main() {
             expectedOutput: expectedOutput,
           );
 
-          expect(converter.visitedClassNames, {
+          expect(converter.visitedNames, {
             'AMixin': 'AMixin',
             'AnotherMixin': 'AnotherMixin',
             'AStateMixin': 'AStateMixin',
@@ -1100,7 +1100,7 @@ void main() {
             expectedOutput: expectedOutput,
           );
 
-          expect(converter.visitedClassNames, {
+          expect(converter.visitedNames, {
             'AMixin': 'AMixin',
             'AnotherMixin': 'AnotherMixin',
             'AStateMixin': 'AStateMixin',
@@ -1163,7 +1163,7 @@ void main() {
             ''',
             );
 
-            expect(converter.visitedClassNames, {
+            expect(converter.visitedNames, {
               publicPropsClassName: '${publicPropsClassName}Mixin',
             });
           });
@@ -1226,7 +1226,7 @@ void main() {
                 expectedOutput: expectedOutput,
               );
 
-              expect(converter.visitedClassNames, {
+              expect(converter.visitedNames, {
                 'SomePropsMixin': 'SomePropsMixin',
                 publicPropsClassName: '${publicPropsClassName}Mixin',
               });
@@ -1244,7 +1244,7 @@ void main() {
                 expectedOutput: expectedOutput,
               );
 
-              expect(converter.visitedClassNames, {
+              expect(converter.visitedNames, {
                 'SomePropsMixin': 'SomePropsMixin',
                 publicPropsClassName: '${publicPropsClassName}Mixin',
               });
@@ -1287,7 +1287,7 @@ void main() {
             ''',
             );
 
-            expect(converter.visitedClassNames, {
+            expect(converter.visitedNames, {
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
               publicPropsClassName: '${publicPropsClassName}Mixin',
             });
@@ -1350,7 +1350,7 @@ void main() {
               ''',
               );
 
-              expect(converter.visitedClassNames, {
+              expect(converter.visitedNames, {
                 'SomeAbstractPropsClass': 'SomeAbstractPropsClass',
                 'LayoutPropsMixin': 'LayoutPropsMixin',
                 'BlockPropsMixin': null,
@@ -1405,7 +1405,7 @@ void main() {
               ''',
               );
 
-              expect(converter.visitedClassNames, {
+              expect(converter.visitedNames, {
                 'SomeAbstractPropsClass': 'SomeAbstractPropsClass',
                 'LayoutPropsMixin': 'LayoutPropsMixin',
                 'BlockPropsMixin': null,
@@ -1469,7 +1469,7 @@ void main() {
               ''',
               );
 
-              expect(converter.visitedClassNames, {
+              expect(converter.visitedNames, {
                 'SomeAbstractPropsClass': 'SomeAbstractPropsClassMixin',
                 publicPropsClassName: '${publicPropsClassName}Mixin',
               });
@@ -1519,7 +1519,7 @@ void main() {
               ''',
               );
 
-              expect(converter.visitedClassNames, {
+              expect(converter.visitedNames, {
                 'SomeAbstractPropsClass': 'SomeAbstractPropsClass',
                 publicPropsClassName: publicPropsClassName,
               });
@@ -1572,7 +1572,7 @@ void main() {
           ''',
           );
 
-          expect(converter.visitedClassNames, {
+          expect(converter.visitedNames, {
             'ConvertedMixin': 'ConvertedMixin',
             'UnconvertedMixin': null,
             publicPropsClassName: '${publicPropsClassName}Mixin',
@@ -1613,7 +1613,7 @@ void main() {
             ''',
             );
 
-            expect(converter.visitedClassNames, {
+            expect(converter.visitedNames, {
               'ConvertedMixin': 'ConvertedMixin',
               publicPropsClassName: '${publicPropsClassName}Mixin',
             });
@@ -1671,7 +1671,7 @@ void main() {
               ''',
               );
 
-              expect(converter.visitedClassNames, {
+              expect(converter.visitedNames, {
                 'LayoutPropsMixin': 'LayoutPropsMixin',
                 'BlockPropsMixin': null,
                 'AbstractBlockProps': 'AbstractBlockPropsMixin',
@@ -1720,7 +1720,7 @@ void main() {
               ''',
               );
 
-              expect(converter.visitedClassNames, {
+              expect(converter.visitedNames, {
                 'LayoutPropsMixin': 'LayoutPropsMixin',
                 'BlockPropsMixin': null,
                 'AbstractBlockProps': 'AbstractBlockProps',
@@ -1767,7 +1767,7 @@ void main() {
             ''',
             );
 
-            expect(converter.visitedClassNames, {
+            expect(converter.visitedNames, {
               '${publicPropsClassName}Mixin': '${publicPropsClassName}Mixin',
               publicPropsClassName: publicPropsClassName,
             });
@@ -1811,7 +1811,7 @@ void main() {
             ''',
             );
 
-            expect(converter.visitedClassNames, {
+            expect(converter.visitedNames, {
               '${publicPropsClassName}Mixin': '${publicPropsClassName}Mixin',
               publicPropsClassName: publicPropsClassName,
             });
@@ -1884,7 +1884,7 @@ void main() {
         ''',
         );
 
-        expect(converter.visitedClassNames, {
+        expect(converter.visitedNames, {
           'AMixin': 'AMixin',
           'AnotherMixin': 'AnotherMixin',
           'ADifferentPropsClass': 'ADifferentPropsClassMixin',
@@ -1902,7 +1902,7 @@ void main() {
           () {
         group('and that mixin exists in the same root', () {
           setUp(() {
-            converter.setVisitedClassNames({
+            converter.setVisitedNames({
               '${publicPropsClassName}Mixin': '${publicPropsClassName}Mixin',
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
             });
@@ -1944,7 +1944,7 @@ void main() {
             ''',
             );
 
-            expect(converter.visitedClassNames, {
+            expect(converter.visitedNames, {
               '${publicPropsClassName}Mixin': '${publicPropsClassName}Mixin',
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
               publicPropsClassName: publicPropsClassName,
@@ -1990,7 +1990,7 @@ void main() {
             ''',
             );
 
-            expect(converter.visitedClassNames, {
+            expect(converter.visitedNames, {
               '${publicPropsClassName}Mixin': '${publicPropsClassName}Mixin',
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
               publicPropsClassName: publicPropsClassName,
@@ -2002,7 +2002,7 @@ void main() {
             'and that mixin does not exist in the same root, but has already been converted',
             () {
           setUp(() {
-            converter.setVisitedClassNames({
+            converter.setVisitedNames({
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
               '${publicPropsClassName}Mixin': '${publicPropsClassName}Mixin',
             });
@@ -2032,7 +2032,7 @@ void main() {
             ''',
             );
 
-            expect(converter.visitedClassNames, {
+            expect(converter.visitedNames, {
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
               '${publicPropsClassName}Mixin': '${publicPropsClassName}Mixin',
               publicPropsClassName: publicPropsClassName,
@@ -2069,7 +2069,7 @@ void main() {
             ''',
             );
 
-            expect(converter.visitedClassNames, {
+            expect(converter.visitedNames, {
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
               '${publicPropsClassName}Mixin': '${publicPropsClassName}Mixin',
               publicPropsClassName: publicPropsClassName,

--- a/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
@@ -20,23 +20,44 @@ import '../util.dart';
 
 void main() {
   group('AdvancedPropsAndStateClassMigrator', () {
+    var runCount = 0;
     final converter = ClassToMixinConverter();
-    final testSuggestor =
-        getSuggestorTester(AdvancedPropsAndStateClassMigrator(converter));
+    SuggestorTester testSuggestor({
+      bool convertClassesWithExternalSuperclass = false,
+      Map<String, String> visitedClassNames = const {},
+    }) {
+      runCount++;
+      final tester = getSuggestorTester(AdvancedPropsAndStateClassMigrator(
+          converter,
+          treatUnvisitedClassesAsExternal: runCount > 1,
+          convertClassesWithExternalSuperclass:
+              convertClassesWithExternalSuperclass));
+
+      // If customVisitedClassNameKeys is set, append the value of `converter.visitedClassNames`.
+      // This is done to ensure that those custom classNames are not treated as members of an external library API.
+      if (visitedClassNames.isNotEmpty) {
+        converter.setVisitedClassNames(
+            {...converter.visitedClassNames, ...visitedClassNames});
+      }
+
+      return tester;
+    }
 
     tearDown(() {
-      converter.setConvertedClassNames({});
+      runCount = 0;
+      converter.setVisitedClassNames({});
+      isPublicForTest = false;
     });
 
-    group('does not operate when', () {
+    group('does not perform a migration when', () {
       test('it\'s an empty file', () {
-        testSuggestor(expectedPatchCount: 0, input: '');
+        testSuggestor()(expectedPatchCount: 0, input: '');
 
-        expect(converter.convertedClassNames, isEmpty);
+        expect(converter.visitedClassNames, isEmpty);
       });
 
       test('the class is simple', () {
-        testSuggestor(
+        testSuggestor()(
           expectedPatchCount: 0,
           input: r'''
           @Factory()
@@ -63,37 +84,161 @@ void main() {
         ''',
         );
 
-        expect(converter.convertedClassNames, isEmpty);
+        expect(converter.classWasMigrated('FooProps'), isFalse);
       });
-    });
 
-    group('operates when the classes are advanced', () {
-      group('and there are both a props and a state class', () {
-        test(
-            'and the classes extend from custom classes that have not been converted to the new boilerplate yet',
-            () {
-          testSuggestor(
-            expectedPatchCount: 12,
-            input: r'''
+      test('the class is not Component2, but does add a FIXME comment', () {
+        testSuggestor()(
+          expectedPatchCount: 1,
+          input: r'''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              $Foo;
+  
+          @Props()
+          class _$FooProps extends UiProps with SomePropsMixin {
+            String foo;
+            int bar;
+          }
+  
+          @Component()
+          class FooComponent extends UiComponent<FooProps> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+      ''',
+          expectedOutput: '''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              \$Foo;
+  
+          // FIXME: `FooProps` could not be auto-migrated to the new over_react boilerplate 
+          // because `FooComponent` does not extend from `react.Component2`.
+          // 
+          // Once you have upgraded the component, you can remove this FIXME comment and 
+          // re-run the boilerplate migration script:
+          // pub run over_react_codemod:boilerplate_upgrade
+          @Props()
+          class _\$FooProps extends UiProps with SomePropsMixin {
+            String foo;
+            int bar;
+          }
+  
+          @Component()
+          class FooComponent extends UiComponent<FooProps> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+      ''',
+        );
+
+        expect(converter.classWasMigrated('FooProps'), isFalse);
+      });
+
+      test('the class is publicly exported, but does add a FIXME comment', () {
+        isPublicForTest = true;
+
+        testSuggestor()(
+          expectedPatchCount: 1,
+          input: r'''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              $Foo;
+  
+          @Props()
+          class _$FooProps extends UiProps with SomePropsMixin {
+            String foo;
+            int bar;
+          }
+  
+          @Component2()
+          class FooComponent extends UiComponent2<FooProps> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+      ''',
+          expectedOutput: '''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              \$Foo;
+  
+          // FIXME: `FooProps` could not be auto-migrated to the new over_react boilerplate 
+          // because doing so would be a breaking change since `FooProps` is exported from a 
+          // library in this repo.
+          //
+          // To complete the migration, you should: 
+          //   1. Deprecate `FooProps`.
+          //   2. Make a copy of it, renaming it something like `FooPropsV2`.
+          //   3. Replace all your current usage of the deprecated `FooProps` with `FooPropsV2`.
+          //   4. Add a `hide FooPropsV2` clause to all places where it is exported, and then run:
+          //        pub run over_react_codemod:boilerplate_upgrade
+          //   5a. If `FooProps` had consumers outside this repo, and it was intentionally made public,
+          //       remove the `hide` clause you added in step 4 so that the new mixin created from `FooPropsV2` 
+          //       will be a viable replacement for `FooProps`.
+          //   5b. If `FooProps` had no consumers outside this repo, and you have no reason to make the new
+          //       "V2" class / mixin public, update the `hide` clause you added in step 4 to include both the 
+          //       concrete class and the newly created mixin.
+          //   6. Remove this FIXME comment.
+          @Props()
+          class _\$FooProps extends UiProps with SomePropsMixin {
+            String foo;
+            int bar;
+          }
+  
+          @Component2()
+          class FooComponent extends UiComponent2<FooProps> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+      ''',
+        );
+
+        expect(converter.classWasMigrated('FooProps'), isFalse);
+      });
+
+      group(
+          'the class extends from a class not found within ClassToMixinConverter.visitedClassNames',
+          () {
+        const externalSuperclassName = 'SomeExternalPropsClass';
+
+        final input = '''
             @Factory()
             UiFactory<FooProps> Foo =
                 // ignore: undefined_identifier
-                $Foo;
-    
+                \$Foo;
+            
             @Props()
-            class _$FooProps extends ADifferentPropsClass {
+            class _\$FooProps extends $externalSuperclassName {
               String foo;
               int bar;
             }
-    
-            @State()
-            class _$FooState extends ADifferentStateClass {
-              String foo;
-              int bar;
-            }
-    
+            
             @Component2()
-            class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+            class FooComponent extends UiComponent2<FooProps> {
               @override
               render() {
                 return Dom.ul()(
@@ -102,37 +247,103 @@ void main() {
                 );
               }
             }
-          ''',
-            expectedOutput: r'''
-            @Factory()
+            ''';
+
+        final expectedOutputWithExternalSuperclassReasonComment = '''
+        @Factory()
+        UiFactory<FooProps> Foo =
+            // ignore: undefined_identifier
+            \$Foo;
+        
+        // FIXME: `FooProps` could not be auto-migrated to the new over_react boilerplate 
+        // because it extends from: $externalSuperclassName - which comes from an external library.
+        //
+        // To complete the migration, you should:
+        //   1. Check on the boilerplate migration status of the library it comes from.
+        //   2. Once the library has released a version that includes updated boilerplate,
+        //      bump the lower bound of your dependency to that version in your `pubspec.yaml`, and run `pub get`.
+        //   3. Re-run the migration script with the following flag:
+        //      pub run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
+        //   4. Once the migration is complete, you should notice that $externalSuperclassName has been deprecated. 
+        //      Follow the deprecation instructions to consume the replacement by either updating your usage to
+        //      the new class name and/or updating to a different entrypoint that exports the version(s) of 
+        //      $externalSuperclassName that is compatible with the new over_react boilerplate.
+        @Props()
+        class _\$FooProps extends $externalSuperclassName {
+          String foo;
+          int bar;
+        }
+        
+        @Component2()
+        class FooComponent extends UiComponent2<FooProps> {
+          @override
+          render() {
+            return Dom.ul()(
+              Dom.li()('Foo: ', props.foo),
+              Dom.li()('Bar: ', props.bar),
+            );
+          }
+        }
+      ''';
+
+        group('but does add a FIXME comment', () {
+          setUp(() {
+            // When it is run the first time, nothing should happen since
+            // we don't know if the custom classes are external or not.
+            testSuggestor()(expectedPatchCount: 0, input: input);
+            testSuggestor()(
+              expectedPatchCount: 1,
+              input: input,
+              expectedOutput: expectedOutputWithExternalSuperclassReasonComment,
+            );
+          });
+
+          test('', () {
+            expect(
+                converter.visitedClassNames,
+                {
+                  'FooProps': null,
+                },
+                reason:
+                    'FooProps should not be converted since $externalSuperclassName is external, and the --convert-classes-with-external-superclasses flag is not set');
+          });
+
+          test(
+              'which then gets removed from the declaration that is converted to a mixin, and replaced '
+              'with updated instructions on the new concrete class declaration when the script '
+              'is re-ran with the --convert-classes-with-external-superclasses flag set',
+              () {
+            // Run it a third time - this time simulating `--convert-classes-with-external-superclasses`
+            // being set - which allows conversion of external superclasses
+            testSuggestor(convertClassesWithExternalSuperclass: true)(
+              expectedPatchCount: 7,
+              input: expectedOutputWithExternalSuperclassReasonComment,
+              expectedOutput: '''
+              @Factory()
               UiFactory<FooProps> Foo =
                   // ignore: undefined_identifier
-                  $Foo;
-      
+                  \$Foo;
+  
               @Props()
               mixin FooPropsMixin on UiProps {
                 String foo;
                 int bar;
               }
-      
+  
               // FIXME:
-              //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
-              //   2. Fix any analyzer warnings on this class about missing mixins
-              class FooProps = UiProps with ADifferentPropsClass, FooPropsMixin;
-      
-              @State()
-              mixin FooStateMixin on UiState {
-                String foo;
-                int bar;
-              }
-              
-              // FIXME:
-              //   1. Ensure that all mixins used by ADifferentStateClass are also mixed into this class.
-              //   2. Fix any analyzer warnings on this class about missing mixins
-              class FooState = UiState with ADifferentStateClass, FooStateMixin;
-      
+              //   1. Ensure that all mixins used by $externalSuperclassName are also mixed into this class.
+              //   2. Fix any analyzer warnings on this class about missing mixins.
+              //   3. You should notice that $externalSuperclassName is deprecated.  
+              //      Follow the deprecation instructions to consume the replacement by either updating your usage to
+              //      the new class/mixin name and/or updating to a different entrypoint that exports the version of 
+              //      $externalSuperclassName that is compatible with the new over_react boilerplate.
+              //
+              //      If it is not deprecated, something most likely went wrong during the migration of the 
+              //      library that contains it. 
+              class FooProps = UiProps with $externalSuperclassName, FooPropsMixin;
+  
               @Component2()
-              class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+              class FooComponent extends UiComponent2<FooProps> {
                 @override
                 render() {
                   return Dom.ul()(
@@ -141,45 +352,43 @@ void main() {
                   );
                 }
               }
-          ''',
-          );
+            ''',
+            );
 
-          expect(converter.convertedClassNames, {
-            'FooProps': 'FooPropsMixin',
-            'FooState': 'FooStateMixin',
+            expect(
+                converter.visitedClassNames,
+                {
+                  'FooProps': 'FooPropsMixin',
+                },
+                reason:
+                    'FooProps should be converted to a mixin since the --convert-classes-with-external-superclasses flag is set');
           });
         });
 
         test(
-            'and the classes extend from custom classes that have been converted to the new boilerplate',
+            'unless the --convert-classes-with-external-superclasses flag is set',
             () {
-          converter.setConvertedClassNames({
-            'ADifferentPropsClass': 'ADifferentPropsClassMixin',
-            'ADifferentStateClass': 'ADifferentStateClassMixin',
-          });
-
-          testSuggestor(
-            expectedPatchCount: 12,
-            input: r'''
+          // When it is run the first time, nothing should happen since
+          // we don't know if the custom classes are external or not.
+          testSuggestor()(expectedPatchCount: 0, input: input);
+          // Run it a second time - this time simulating `--convert-classes-with-external-superclasses`
+          // being set - which allows conversion of external superclasses
+          testSuggestor(convertClassesWithExternalSuperclass: true)(
+            expectedPatchCount: 6,
+            input: '''
             @Factory()
             UiFactory<FooProps> Foo =
                 // ignore: undefined_identifier
-                $Foo;
-    
+                \$Foo;
+
             @Props()
-            class _$FooProps extends ADifferentPropsClass {
+            class _\$FooProps extends $externalSuperclassName {
               String foo;
               int bar;
             }
-    
-            @State()
-            class _$FooState extends ADifferentStateClass {
-              String foo;
-              int bar;
-            }
-    
+
             @Component2()
-            class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+            class FooComponent extends UiComponent2<FooProps> {
               @override
               render() {
                 return Dom.ul()(
@@ -189,36 +398,32 @@ void main() {
               }
             }
           ''',
-            expectedOutput: r'''
-            @Factory()
+            expectedOutput: '''
+              @Factory()
               UiFactory<FooProps> Foo =
                   // ignore: undefined_identifier
-                  $Foo;
-      
+                  \$Foo;
+  
               @Props()
               mixin FooPropsMixin on UiProps {
                 String foo;
                 int bar;
               }
-      
+  
               // FIXME:
-              //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
-              //   2. Fix any analyzer warnings on this class about missing mixins
-              class FooProps = UiProps with ADifferentPropsClassMixin, FooPropsMixin;
-      
-              @State()
-              mixin FooStateMixin on UiState {
-                String foo;
-                int bar;
-              }
-              
-              // FIXME:
-              //   1. Ensure that all mixins used by ADifferentStateClass are also mixed into this class.
-              //   2. Fix any analyzer warnings on this class about missing mixins
-              class FooState = UiState with ADifferentStateClassMixin, FooStateMixin;
-      
+              //   1. Ensure that all mixins used by $externalSuperclassName are also mixed into this class.
+              //   2. Fix any analyzer warnings on this class about missing mixins.
+              //   3. You should notice that $externalSuperclassName is deprecated.  
+              //      Follow the deprecation instructions to consume the replacement by either updating your usage to
+              //      the new class/mixin name and/or updating to a different entrypoint that exports the version of 
+              //      $externalSuperclassName that is compatible with the new over_react boilerplate.
+              //
+              //      If it is not deprecated, something most likely went wrong during the migration of the 
+              //      library that contains it. 
+              class FooProps = UiProps with $externalSuperclassName, FooPropsMixin;
+  
               @Component2()
-              class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+              class FooComponent extends UiComponent2<FooProps> {
                 @override
                 render() {
                   return Dom.ul()(
@@ -227,40 +432,39 @@ void main() {
                   );
                 }
               }
-          ''',
+            ''',
           );
 
-          expect(converter.convertedClassNames, {
-            'ADifferentPropsClass': 'ADifferentPropsClassMixin',
-            'ADifferentStateClass': 'ADifferentStateClassMixin',
-            'FooProps': 'FooPropsMixin',
-            'FooState': 'FooStateMixin',
-          });
+          expect(
+              converter.visitedClassNames,
+              {
+                'FooProps': 'FooPropsMixin',
+              },
+              reason:
+                  'FooProps should be converted to a mixin since the --convert-classes-with-external-superclasses flag is set');
         });
+      });
 
-        test('and the class uses mixins', () {
-          testSuggestor(
-            expectedPatchCount: 12,
-            input: r'''
+      group(
+          'the class mixes in and extends from classes not found within ClassToMixinConverter.visitedClassNames',
+          () {
+        const externalSuperclassName = 'SomeExternalPropsClass';
+        const externalMixinName = 'SomeExternalMixin';
+
+        final input = '''
             @Factory()
             UiFactory<FooProps> Foo =
                 // ignore: undefined_identifier
-                $Foo;
-      
+                \$Foo;
+            
             @Props()
-            class _$FooProps extends UiProps with AMixin, AnotherMixin {
+            class _\$FooProps extends $externalSuperclassName with $externalMixinName {
               String foo;
               int bar;
             }
-      
-            @State()
-            class _$FooState extends UiState with AStateMixin, AnotherStateMixin {
-              String foo;
-              int bar;
-            }
-      
+            
             @Component2()
-            class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+            class FooComponent extends UiComponent2<FooProps> {
               @override
               render() {
                 return Dom.ul()(
@@ -269,31 +473,311 @@ void main() {
                 );
               }
             }
-          ''',
-            expectedOutput: r'''
+            ''';
+
+        final expectedOutputWithExternalSuperclassReasonComment = '''
+        @Factory()
+        UiFactory<FooProps> Foo =
+            // ignore: undefined_identifier
+            \$Foo;
+        
+        // FIXME: `FooProps` could not be auto-migrated to the new over_react boilerplate 
+        // because it mixes in: $externalMixinName - which comes from an external library.
+        //
+        // To complete the migration, you should:
+        //   1. Check on the boilerplate migration status of the library it comes from.
+        //   2. Once the library has released a version that includes updated boilerplate,
+        //      bump the lower bound of your dependency to that version in your `pubspec.yaml`, and run `pub get`.
+        //   3. Re-run the migration script with the following flag:
+        //      pub run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
+        //   4. Once the migration is complete, you should notice that $externalMixinName has been deprecated. 
+        //      Follow the deprecation instructions to consume the replacement by either updating your usage to
+        //      the new mixin name and/or updating to a different entrypoint that exports the version(s) of 
+        //      $externalMixinName that is compatible with the new over_react boilerplate.
+        //
+        // FIXME: `FooProps` could not be auto-migrated to the new over_react boilerplate 
+        // because it extends from: $externalSuperclassName - which comes from an external library.
+        //
+        // To complete the migration, you should:
+        //   1. Check on the boilerplate migration status of the library it comes from.
+        //   2. Once the library has released a version that includes updated boilerplate,
+        //      bump the lower bound of your dependency to that version in your `pubspec.yaml`, and run `pub get`.
+        //   3. Re-run the migration script with the following flag:
+        //      pub run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
+        //   4. Once the migration is complete, you should notice that $externalSuperclassName has been deprecated. 
+        //      Follow the deprecation instructions to consume the replacement by either updating your usage to
+        //      the new class name and/or updating to a different entrypoint that exports the version(s) of 
+        //      $externalSuperclassName that is compatible with the new over_react boilerplate.
+        @Props()
+        class _\$FooProps extends $externalSuperclassName with $externalMixinName {
+          String foo;
+          int bar;
+        }
+        
+        @Component2()
+        class FooComponent extends UiComponent2<FooProps> {
+          @override
+          render() {
+            return Dom.ul()(
+              Dom.li()('Foo: ', props.foo),
+              Dom.li()('Bar: ', props.bar),
+            );
+          }
+        }
+      ''';
+
+        group('but does add a FIXME comment', () {
+          setUp(() {
+            // When it is run the first time, nothing should happen since
+            // we don't know if the custom classes are external or not.
+            testSuggestor()(expectedPatchCount: 0, input: input);
+            testSuggestor()(
+              expectedPatchCount: 1,
+              input: input,
+              expectedOutput: expectedOutputWithExternalSuperclassReasonComment,
+            );
+          });
+
+          test('', () {
+            expect(
+                converter.visitedClassNames,
+                {
+                  'FooProps': null,
+                },
+                reason:
+                    'FooProps should not be converted since $externalSuperclassName and $externalMixinName are external, and the --convert-classes-with-external-superclasses flag is not set');
+          });
+
+          test(
+              'which then gets removed from the declaration that is converted to a mixin, and replaced '
+              'with updated instructions on the new concrete class declaration when the script '
+              'is re-ran with the --convert-classes-with-external-superclasses flag set',
+              () {
+            // Run it a third time - this time simulating `--convert-classes-with-external-superclasses`
+            // being set - which allows conversion of external superclasses
+            testSuggestor(convertClassesWithExternalSuperclass: true)(
+              expectedPatchCount: 8,
+              input: expectedOutputWithExternalSuperclassReasonComment,
+              expectedOutput: '''
+              @Factory()
+              UiFactory<FooProps> Foo =
+                  // ignore: undefined_identifier
+                  \$Foo;
+  
+              @Props()
+              mixin FooPropsMixin on UiProps {
+                String foo;
+                int bar;
+              }
+  
+              // FIXME:
+              //   1. Ensure that all mixins used by $externalSuperclassName are also mixed into this class.
+              //   2. Fix any analyzer warnings on this class about missing mixins.
+              //   3. You should notice that $externalSuperclassName, $externalMixinName are deprecated.  
+              //      Follow the deprecation instructions to consume the replacement by either updating your usage to
+              //      the new class/mixin name and/or updating to a different entrypoint that exports the versions of 
+              //      $externalSuperclassName, $externalMixinName that are compatible with the new over_react boilerplate.
+              //
+              //      If they are not deprecated, something most likely went wrong during the migration of the 
+              //      library that contains them. 
+              class FooProps = UiProps with $externalSuperclassName, FooPropsMixin, $externalMixinName;
+  
+              @Component2()
+              class FooComponent extends UiComponent2<FooProps> {
+                @override
+                render() {
+                  return Dom.ul()(
+                    Dom.li()('Foo: ', props.foo),
+                    Dom.li()('Bar: ', props.bar),
+                  );
+                }
+              }
+            ''',
+            );
+
+            expect(
+                converter.visitedClassNames,
+                {
+                  'FooProps': 'FooPropsMixin',
+                },
+                reason:
+                    'FooProps should be converted to a mixin since the --convert-classes-with-external-superclasses flag is set');
+          });
+        });
+
+        test(
+            'unless the --convert-classes-with-external-superclasses flag is set',
+            () {
+          // When it is run the first time, nothing should happen since
+          // we don't know if the custom classes are external or not.
+          testSuggestor()(expectedPatchCount: 0, input: input);
+          // Run it a second time - this time simulating `--convert-classes-with-external-superclasses`
+          // being set - which allows conversion of external superclasses
+          testSuggestor(convertClassesWithExternalSuperclass: true)(
+            expectedPatchCount: 7,
+            input: input,
+            expectedOutput: '''
+              @Factory()
+              UiFactory<FooProps> Foo =
+                  // ignore: undefined_identifier
+                  \$Foo;
+  
+              @Props()
+              mixin FooPropsMixin on UiProps {
+                String foo;
+                int bar;
+              }
+  
+              // FIXME:
+              //   1. Ensure that all mixins used by $externalSuperclassName are also mixed into this class.
+              //   2. Fix any analyzer warnings on this class about missing mixins.
+              //   3. You should notice that $externalSuperclassName, $externalMixinName are deprecated.  
+              //      Follow the deprecation instructions to consume the replacement by either updating your usage to
+              //      the new class/mixin name and/or updating to a different entrypoint that exports the versions of 
+              //      $externalSuperclassName, $externalMixinName that are compatible with the new over_react boilerplate.
+              //
+              //      If they are not deprecated, something most likely went wrong during the migration of the 
+              //      library that contains them. 
+              class FooProps = UiProps with $externalSuperclassName, FooPropsMixin, $externalMixinName;
+  
+              @Component2()
+              class FooComponent extends UiComponent2<FooProps> {
+                @override
+                render() {
+                  return Dom.ul()(
+                    Dom.li()('Foo: ', props.foo),
+                    Dom.li()('Bar: ', props.bar),
+                  );
+                }
+              }
+            ''',
+          );
+
+          expect(
+              converter.visitedClassNames,
+              {
+                'FooProps': 'FooPropsMixin',
+              },
+              reason:
+                  'FooProps should be converted to a mixin since the --convert-classes-with-external-superclasses flag is set');
+        });
+      });
+
+      group(
+          'the class extends from a custom class that has been visited, '
+          'but not yet converted to the new boilerplate after two runs '
+          'but does add a FIXME comment', () {
+        final expectedOutputWithUnMigratedSuperclassReasonComment = '''
+        @Factory()
+        UiFactory<FooProps> Foo =
+            // ignore: undefined_identifier
+            \$Foo;
+        
+        // FIXME: `FooProps` could not be auto-migrated to the new over_react boilerplate 
+        // because it extends from `ADifferentPropsClass`, which was not able to be migrated.
+        //
+        // To complete the migration, you should:
+        //   1. Look at the "FIXME" comment that has been added to `ADifferentPropsClass` - 
+        //      and follow the steps outlined there to complete the migration.
+        //   2. Re-run the migration script:
+        //      pub run over_react_codemod:boilerplate_upgrade
+        @Props()
+        class _\$FooProps extends ADifferentPropsClass {
+          String foo;
+          int bar;
+        }
+
+        @Component2()
+        class FooComponent extends UiComponent2<FooProps> {
+          @override
+          render() {
+            return Dom.ul()(
+              Dom.li()('Foo: ', props.foo),
+              Dom.li()('Bar: ', props.bar),
+            );
+          }
+        }
+        ''';
+
+        test('', () {
+          const input = r'''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              $Foo;
+  
+          @Props()
+          class _$FooProps extends ADifferentPropsClass {
+            String foo;
+            int bar;
+          }
+  
+          @Component2()
+          class FooComponent extends UiComponent2<FooProps> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+        ''';
+
+          // When it is run the first time, nothing should happen since
+          // we don't know if the custom classes are "migratable" or not.
+          testSuggestor()(expectedPatchCount: 0, input: input);
+          testSuggestor(
+            visitedClassNames: {
+              'ADifferentPropsClass': null,
+            },
+          )(
+            expectedPatchCount: 1,
+            input: input,
+            expectedOutput: expectedOutputWithUnMigratedSuperclassReasonComment,
+          );
+
+          expect(converter.visitedClassNames, {
+            'ADifferentPropsClass': null,
+            'FooProps': null,
+          });
+        });
+
+        test(
+            'which then gets removed and replaced with updated instructions '
+            'when the script is re-ran after the consumer makes the class "migratable"',
+            () {
+          // When it is run the first time, nothing should happen since
+          // we don't know if the custom classes are "migratable" or not.
+          testSuggestor()(
+              expectedPatchCount: 0,
+              input: expectedOutputWithUnMigratedSuperclassReasonComment);
+          testSuggestor(
+            visitedClassNames: {
+              'ADifferentPropsClass': 'ADifferentPropsClassMixin',
+            },
+          )(
+            expectedPatchCount: 7,
+            input: expectedOutputWithUnMigratedSuperclassReasonComment,
+            expectedOutput: '''
             @Factory()
             UiFactory<FooProps> Foo =
                 // ignore: undefined_identifier
-                $Foo;
-      
+                \$Foo;
+            
             @Props()
             mixin FooPropsMixin on UiProps {
               String foo;
               int bar;
             }
-            
-            class FooProps = UiProps with FooPropsMixin, AMixin, AnotherMixin;
-      
-            @State()
-            mixin FooStateMixin on UiState {
-              String foo;
-              int bar;
-            }
-            
-            class FooState = UiState with FooStateMixin, AStateMixin, AnotherStateMixin;
-      
+
+            // FIXME:
+            //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
+            //   2. Fix any analyzer warnings on this class about missing mixins.
+            class FooProps = UiProps with ADifferentPropsClassMixin, FooPropsMixin;
+    
             @Component2()
-            class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+            class FooComponent extends UiComponent2<FooProps> {
               @override
               render() {
                 return Dom.ul()(
@@ -305,7 +789,540 @@ void main() {
           ''',
           );
 
-          expect(converter.convertedClassNames, {
+          expect(converter.visitedClassNames, {
+            'ADifferentPropsClass': 'ADifferentPropsClassMixin',
+            'FooProps': 'FooPropsMixin',
+          });
+        });
+      });
+
+      group(
+          'the class uses one or more mixins not found within ClassToMixinConverter.visitedClassNames:',
+          () {
+        group('single external mixin:', () {
+          const externalMixinName = 'SomeExternalMixin';
+
+          final input = '''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              \$Foo;
+
+          @Props()
+          class _\$FooProps extends UiProps with $externalMixinName {
+            String foo;
+            int bar;
+          }
+
+          @Component2()
+          class FooComponent extends UiComponent2<FooProps> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+          ''';
+
+          final expectedOutputWithExternalMixinReasonComment = '''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              \$Foo;
+
+          // FIXME: `FooProps` could not be auto-migrated to the new over_react boilerplate 
+          // because it mixes in: $externalMixinName - which comes from an external library.
+          //
+          // To complete the migration, you should:
+          //   1. Check on the boilerplate migration status of the library it comes from.
+          //   2. Once the library has released a version that includes updated boilerplate,
+          //      bump the lower bound of your dependency to that version in your `pubspec.yaml`, and run `pub get`.
+          //   3. Re-run the migration script with the following flag:
+          //      pub run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
+          //   4. Once the migration is complete, you should notice that $externalMixinName has been deprecated. 
+          //      Follow the deprecation instructions to consume the replacement by either updating your usage to
+          //      the new mixin name and/or updating to a different entrypoint that exports the version(s) of 
+          //      $externalMixinName that is compatible with the new over_react boilerplate.
+          @Props()
+          class _\$FooProps extends UiProps with $externalMixinName {
+            String foo;
+            int bar;
+          }
+
+          @Component2()
+          class FooComponent extends UiComponent2<FooProps> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+        ''';
+
+          group('but does add a FIXME comment', () {
+            setUp(() {
+              // When it is run the first time, nothing should happen since
+              // we don't know if the custom classes are external or not.
+              testSuggestor()(expectedPatchCount: 0, input: input);
+              testSuggestor()(
+                expectedPatchCount: 1,
+                input: input,
+                expectedOutput: expectedOutputWithExternalMixinReasonComment,
+              );
+            });
+
+            test('', () {
+              expect(
+                  converter.visitedClassNames,
+                  {
+                    'FooProps': null,
+                  },
+                  reason:
+                      'FooProps should not be converted since $externalMixinName is external, and the --convert-classes-with-external-superclasses flag is not set');
+            });
+
+            test(
+                'which then gets removed from the declaration that is converted to a mixin, and replaced '
+                'with updated instructions on the new concrete class declaration when the script '
+                'is re-ran with the --convert-classes-with-external-superclasses flag set',
+                () {
+              // Run it a third time - this time simulating `--convert-classes-with-external-superclasses`
+              // being set - which allows conversion of external mixins
+              testSuggestor(convertClassesWithExternalSuperclass: true)(
+                expectedPatchCount: 7,
+                input: expectedOutputWithExternalMixinReasonComment,
+                expectedOutput: '''
+                @Factory()
+                UiFactory<FooProps> Foo =
+                    // ignore: undefined_identifier
+                    \$Foo;
+    
+                @Props()
+                mixin FooPropsMixin on UiProps {
+                  String foo;
+                  int bar;
+                }
+    
+                // FIXME:
+                //   1. You should notice that $externalMixinName is deprecated.  
+                //      Follow the deprecation instructions to consume the replacement by either updating your usage to
+                //      the new class/mixin name and/or updating to a different entrypoint that exports the version of 
+                //      $externalMixinName that is compatible with the new over_react boilerplate.
+                //
+                //      If it is not deprecated, something most likely went wrong during the migration of the 
+                //      library that contains it. 
+                class FooProps = UiProps with FooPropsMixin, $externalMixinName;
+    
+                @Component2()
+                class FooComponent extends UiComponent2<FooProps> {
+                  @override
+                  render() {
+                    return Dom.ul()(
+                      Dom.li()('Foo: ', props.foo),
+                      Dom.li()('Bar: ', props.bar),
+                    );
+                  }
+                }
+              ''',
+              );
+
+              expect(
+                  converter.visitedClassNames,
+                  {
+                    'FooProps': 'FooPropsMixin',
+                  },
+                  reason:
+                      'FooProps should be converted to a mixin since the --convert-classes-with-external-superclasses flag is set');
+            });
+          });
+        });
+
+        group('multiple external mixins:', () {
+          const externalMixinNames = 'SomeExternalMixin, AnotherExternalMixin';
+
+          final input = '''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              \$Foo;
+
+          @Props()
+          class _\$FooProps extends UiProps with $externalMixinNames {
+            String foo;
+            int bar;
+          }
+
+          @Component2()
+          class FooComponent extends UiComponent2<FooProps> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+          ''';
+
+          final expectedOutputWithExternalMixinReasonComment = '''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              \$Foo;
+
+          // FIXME: `FooProps` could not be auto-migrated to the new over_react boilerplate 
+          // because it mixes in: $externalMixinNames - which come from an external library.
+          //
+          // To complete the migration, you should:
+          //   1. Check on the boilerplate migration status of the library they come from.
+          //   2. Once the library has released a version that includes updated boilerplate,
+          //      bump the lower bound of your dependency to that version in your `pubspec.yaml`, and run `pub get`.
+          //   3. Re-run the migration script with the following flag:
+          //      pub run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
+          //   4. Once the migration is complete, you should notice that $externalMixinNames have been deprecated. 
+          //      Follow the deprecation instructions to consume the replacements by either updating your usage to
+          //      the new mixin names and/or updating to a different entrypoint that exports the version(s) of 
+          //      $externalMixinNames that are compatible with the new over_react boilerplate.
+          @Props()
+          class _\$FooProps extends UiProps with $externalMixinNames {
+            String foo;
+            int bar;
+          }
+
+          @Component2()
+          class FooComponent extends UiComponent2<FooProps> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+        ''';
+
+          group('but does add a FIXME comment', () {
+            setUp(() {
+              // When it is run the first time, nothing should happen since
+              // we don't know if the custom classes are external or not.
+              testSuggestor()(expectedPatchCount: 0, input: input);
+              testSuggestor()(
+                expectedPatchCount: 1,
+                input: input,
+                expectedOutput: expectedOutputWithExternalMixinReasonComment,
+              );
+            });
+
+            test('', () {
+              expect(
+                  converter.visitedClassNames,
+                  {
+                    'FooProps': null,
+                  },
+                  reason:
+                      'FooProps should not be converted since $externalMixinNames are external, and the --convert-classes-with-external-superclasses flag is not set');
+            });
+
+            test(
+                'which then gets removed from the declaration that is converted to a mixin, and replaced '
+                'with updated instructions on the new concrete class declaration when the script '
+                'is re-ran with the --convert-classes-with-external-superclasses flag set',
+                () {
+              // Run it a third time - this time simulating `--convert-classes-with-external-superclasses`
+              // being set - which allows conversion of external mixins
+              testSuggestor(convertClassesWithExternalSuperclass: true)(
+                expectedPatchCount: 7,
+                input: expectedOutputWithExternalMixinReasonComment,
+                expectedOutput: '''
+                @Factory()
+                UiFactory<FooProps> Foo =
+                    // ignore: undefined_identifier
+                    \$Foo;
+    
+                @Props()
+                mixin FooPropsMixin on UiProps {
+                  String foo;
+                  int bar;
+                }
+    
+                // FIXME:
+                //   1. You should notice that $externalMixinNames are deprecated.  
+                //      Follow the deprecation instructions to consume the replacement by either updating your usage to
+                //      the new class/mixin name and/or updating to a different entrypoint that exports the versions of 
+                //      $externalMixinNames that are compatible with the new over_react boilerplate.
+                //
+                //      If they are not deprecated, something most likely went wrong during the migration of the 
+                //      library that contains them. 
+                class FooProps = UiProps with FooPropsMixin, $externalMixinNames;
+    
+                @Component2()
+                class FooComponent extends UiComponent2<FooProps> {
+                  @override
+                  render() {
+                    return Dom.ul()(
+                      Dom.li()('Foo: ', props.foo),
+                      Dom.li()('Bar: ', props.bar),
+                    );
+                  }
+                }
+              ''',
+              );
+
+              expect(
+                  converter.visitedClassNames,
+                  {
+                    'FooProps': 'FooPropsMixin',
+                  },
+                  reason:
+                      'FooProps should be converted to a mixin since the --convert-classes-with-external-superclasses flag is set');
+            });
+          });
+        });
+      });
+    });
+
+    group('performs a migration when the class(es) are advanced', () {
+      group(
+          'and there are both a props and a state class that extend '
+          'from custom classes that were converted to the new boilerplate', () {
+        const input = r'''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              $Foo;
+  
+          @Props()
+          class _$FooProps extends ADifferentPropsClass {
+            String foo;
+            int bar;
+          }
+  
+          @State()
+          class _$FooState extends ADifferentStateClass {
+            String foo;
+            int bar;
+          }
+  
+          @Component2()
+          class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+        ''';
+
+        final expectedOutput = '''
+        @Factory()
+        UiFactory<FooProps> Foo =
+            // ignore: undefined_identifier
+            \$Foo;
+
+        @Props()
+        mixin FooPropsMixin on UiProps {
+          String foo;
+          int bar;
+        }
+
+        // FIXME:
+        //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
+        //   2. Fix any analyzer warnings on this class about missing mixins.
+        class FooProps = UiProps with ADifferentPropsClassMixin, FooPropsMixin;
+
+        @State()
+        mixin FooStateMixin on UiState {
+          String foo;
+          int bar;
+        }
+        
+        // FIXME:
+        //   1. Ensure that all mixins used by ADifferentStateClass are also mixed into this class.
+        //   2. Fix any analyzer warnings on this class about missing mixins.
+        class FooState = UiState with ADifferentStateClassMixin, FooStateMixin;
+
+        @Component2()
+        class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+          @override
+          render() {
+            return Dom.ul()(
+              Dom.li()('Foo: ', props.foo),
+              Dom.li()('Bar: ', props.bar),
+            );
+          }
+        }
+      ''';
+
+        test('on the first run', () {
+          // Simulates the case where the superclasses were visited first and successfully converted
+          testSuggestor(
+            visitedClassNames: {
+              'ADifferentPropsClass': 'ADifferentPropsClassMixin',
+              'ADifferentStateClass': 'ADifferentStateClassMixin',
+            },
+          )(
+            expectedPatchCount: 12,
+            input: input,
+            expectedOutput: expectedOutput,
+          );
+
+          expect(converter.visitedClassNames, {
+            'ADifferentPropsClass': 'ADifferentPropsClassMixin',
+            'ADifferentStateClass': 'ADifferentStateClassMixin',
+            'FooProps': 'FooPropsMixin',
+            'FooState': 'FooStateMixin',
+          });
+        });
+
+        test('on the second run', () {
+          // When it is run the first time, nothing should happen since
+          // we don't know if the custom classes are external or not.
+          testSuggestor(
+            visitedClassNames: {
+              'ADifferentPropsClass': null,
+              'ADifferentStateClass': null,
+            },
+          )(expectedPatchCount: 0, input: input);
+          testSuggestor(
+            visitedClassNames: {
+              'ADifferentPropsClass': 'ADifferentPropsClassMixin',
+              'ADifferentStateClass': 'ADifferentStateClassMixin',
+            },
+          )(
+            expectedPatchCount: 12,
+            input: input,
+            expectedOutput: expectedOutput,
+          );
+
+          expect(converter.visitedClassNames, {
+            'ADifferentPropsClass': 'ADifferentPropsClassMixin',
+            'ADifferentStateClass': 'ADifferentStateClassMixin',
+            'FooProps': 'FooPropsMixin',
+            'FooState': 'FooStateMixin',
+          });
+        });
+      });
+
+      group(
+          'and there are both a props and state class that use mixins that were converted to the new boilerplate',
+          () {
+        const input = r'''
+        @Factory()
+        UiFactory<FooProps> Foo =
+            // ignore: undefined_identifier
+            $Foo;
+
+        @Props()
+        class _$FooProps extends UiProps with AMixin, AnotherMixin {
+          String foo;
+          int bar;
+        }
+
+        @State()
+        class _$FooState extends UiState with AStateMixin, AnotherStateMixin {
+          String foo;
+          int bar;
+        }
+
+        @Component2()
+        class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+          @override
+          render() {
+            return Dom.ul()(
+              Dom.li()('Foo: ', props.foo),
+              Dom.li()('Bar: ', props.bar),
+            );
+          }
+        }
+        ''';
+
+        const expectedOutput = r'''
+        @Factory()
+        UiFactory<FooProps> Foo =
+            // ignore: undefined_identifier
+            $Foo;
+
+        @Props()
+        mixin FooPropsMixin on UiProps {
+          String foo;
+          int bar;
+        }
+
+        class FooProps = UiProps with FooPropsMixin, AMixin, AnotherMixin;
+
+        @State()
+        mixin FooStateMixin on UiState {
+          String foo;
+          int bar;
+        }
+
+        class FooState = UiState with FooStateMixin, AStateMixin, AnotherStateMixin;
+
+        @Component2()
+        class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+          @override
+          render() {
+            return Dom.ul()(
+              Dom.li()('Foo: ', props.foo),
+              Dom.li()('Bar: ', props.bar),
+            );
+          }
+        }
+      ''';
+
+        test('on the first run', () {
+          // Simulates the case where the superclasses were visited first and successfully converted
+          testSuggestor(
+            visitedClassNames: {
+              'AMixin': 'AMixin',
+              'AnotherMixin': 'AnotherMixin',
+              'AStateMixin': 'AStateMixin',
+              'AnotherStateMixin': 'AnotherStateMixin',
+            },
+          )(
+            expectedPatchCount: 12,
+            input: input,
+            expectedOutput: expectedOutput,
+          );
+
+          expect(converter.visitedClassNames, {
+            'AMixin': 'AMixin',
+            'AnotherMixin': 'AnotherMixin',
+            'AStateMixin': 'AStateMixin',
+            'AnotherStateMixin': 'AnotherStateMixin',
+            'FooProps': 'FooPropsMixin',
+            'FooState': 'FooStateMixin',
+          });
+        });
+
+        test('on the second run', () {
+          // When it is run the first time, nothing should happen since
+          // we don't know if the custom mixins are external or not.
+          testSuggestor()(expectedPatchCount: 0, input: input);
+          testSuggestor(
+            visitedClassNames: {
+              'AMixin': 'AMixin',
+              'AnotherMixin': 'AnotherMixin',
+              'AStateMixin': 'AStateMixin',
+              'AnotherStateMixin': 'AnotherStateMixin',
+            },
+          )(
+            expectedPatchCount: 12,
+            input: input,
+            expectedOutput: expectedOutput,
+          );
+
+          expect(converter.visitedClassNames, {
+            'AMixin': 'AMixin',
+            'AnotherMixin': 'AnotherMixin',
+            'AStateMixin': 'AStateMixin',
+            'AnotherStateMixin': 'AnotherStateMixin',
             'FooProps': 'FooPropsMixin',
             'FooState': 'FooStateMixin',
           });
@@ -313,21 +1330,20 @@ void main() {
       });
 
       group('and there is just a props class', () {
-        test('that extends from the reserved FluxUiProps class', () {
-          testSuggestor(
-            expectedPatchCount: 6,
-            input: r'''
+        group('that extends from the reserved FluxUiProps class', () {
+          test('and uses no mixins', () {
+            final input = r'''
             @Factory()
             UiFactory<FooProps> Foo =
                 // ignore: undefined_identifier
                 $Foo;
-    
+  
             @Props()
             class _$FooProps extends FluxUiProps<SomeActions, SomeStore> {
               String foo;
               int bar;
             }
-    
+  
             @Component2()
             class FooComponent extends FluxUiComponent2<FooProps> {
               @override
@@ -338,59 +1354,58 @@ void main() {
                 );
               }
             }
-          ''',
-            expectedOutput: r'''
-            @Factory()
-            UiFactory<FooProps> Foo =
-                // ignore: undefined_identifier
-                $Foo;
-    
-            @Props()
-            mixin FooPropsMixin on UiProps {
-              String foo;
-              int bar;
-            }
-    
-            // FIXME:
-            //   1. Ensure that all mixins used by FluxUiProps are also mixed into this class.
-            //   2. Fix any analyzer warnings on this class about missing mixins
-            class FooProps = UiProps with FluxUiPropsMixin<SomeActions, SomeStore>, FooPropsMixin;
-    
-            @Component2()
-            class FooComponent extends FluxUiComponent2<FooProps> {
-              @override
-              render() {
-                return Dom.ul()(
-                  Dom.li()('Foo: ', props.foo),
-                  Dom.li()('Bar: ', props.bar),
-                );
-              }
-            }
-          ''',
-          );
+            ''';
 
-          expect(converter.convertedClassNames, {
-            'FooProps': 'FooPropsMixin',
+            testSuggestor()(
+              expectedPatchCount: 6,
+              input: input,
+              expectedOutput: r'''
+              @Factory()
+              UiFactory<FooProps> Foo =
+                  // ignore: undefined_identifier
+                  $Foo;
+  
+              @Props()
+              mixin FooPropsMixin on UiProps {
+                String foo;
+                int bar;
+              }
+  
+              class FooProps = UiProps with FluxUiPropsMixin<SomeActions, SomeStore>, FooPropsMixin;
+  
+              @Component2()
+              class FooComponent extends FluxUiComponent2<FooProps> {
+                @override
+                render() {
+                  return Dom.ul()(
+                    Dom.li()('Foo: ', props.foo),
+                    Dom.li()('Bar: ', props.bar),
+                  );
+                }
+              }
+            ''',
+            );
+
+            expect(converter.visitedClassNames, {
+              'FooProps': 'FooPropsMixin',
+            });
           });
-        });
 
-        test('that extends from the reserved BuiltReduxUiProps class', () {
-          testSuggestor(
-            expectedPatchCount: 6,
-            input: r'''
+          group('and uses a mixin', () {
+            const input = r'''
             @Factory()
             UiFactory<FooProps> Foo =
                 // ignore: undefined_identifier
                 $Foo;
-    
+  
             @Props()
-            class _$FooProps extends BuiltReduxUiProps<_, __, ___> {
+            class _$FooProps extends FluxUiProps<SomeActions, SomeStore> with SomePropsMixin<SomeStore> {
               String foo;
               int bar;
             }
-    
+  
             @Component2()
-            class FooComponent extends BuiltReduxUiComponent2<_, __, ___, FooProps, _____> {
+            class FooComponent extends FluxUiComponent2<FooProps> {
               @override
               render() {
                 return Dom.ul()(
@@ -399,26 +1414,28 @@ void main() {
                 );
               }
             }
-          ''',
-            expectedOutput: r'''
+            ''';
+
+            const expectedOutput = r'''
             @Factory()
             UiFactory<FooProps> Foo =
                 // ignore: undefined_identifier
                 $Foo;
-    
+
             @Props()
             mixin FooPropsMixin on UiProps {
               String foo;
               int bar;
             }
-    
-            // FIXME:
-            //   1. Ensure that all mixins used by BuiltReduxUiProps are also mixed into this class.
-            //   2. Fix any analyzer warnings on this class about missing mixins
-            class FooProps = UiProps with BuiltReduxUiPropsMixin<_, __, ___>, FooPropsMixin;
-    
+
+            class FooProps = UiProps 
+                with 
+                    FluxUiPropsMixin<SomeActions, SomeStore>, 
+                    FooPropsMixin, 
+                    SomePropsMixin<SomeStore>;
+
             @Component2()
-            class FooComponent extends BuiltReduxUiComponent2<_, __, ___, FooProps, _____> {
+            class FooComponent extends FluxUiComponent2<FooProps> {
               @override
               render() {
                 return Dom.ul()(
@@ -427,34 +1444,61 @@ void main() {
                 );
               }
             }
-          ''',
-          );
+          ''';
 
-          expect(converter.convertedClassNames, {
-            'FooProps': 'FooPropsMixin',
+            test('that has already been converted', () {
+              testSuggestor(visitedClassNames: {
+                'SomePropsMixin': 'SomePropsMixin',
+              })(
+                expectedPatchCount: 7,
+                input: input,
+                expectedOutput: expectedOutput,
+              );
+
+              expect(converter.visitedClassNames, {
+                'SomePropsMixin': 'SomePropsMixin',
+                'FooProps': 'FooPropsMixin',
+              });
+            });
+
+            test('that has not been converted the first time around', () {
+              // When it is run the first time, nothing should happen since
+              // we don't know if the mixin(s) are external or not.
+              testSuggestor()(expectedPatchCount: 0, input: input);
+              testSuggestor(visitedClassNames: {
+                'SomePropsMixin': 'SomePropsMixin',
+              })(
+                expectedPatchCount: 7,
+                input: input,
+                expectedOutput: expectedOutput,
+              );
+
+              expect(converter.visitedClassNames, {
+                'SomePropsMixin': 'SomePropsMixin',
+                'FooProps': 'FooPropsMixin',
+              });
+            });
           });
         });
 
         group('that extends from an arbitrary custom class', () {
-          test('', () {
-            converter.setConvertedClassNames({
+          test('that is not abstract', () {
+            testSuggestor(visitedClassNames: {
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
-            });
-
-            testSuggestor(
+            })(
               expectedPatchCount: 6,
               input: r'''
               @Factory()
               UiFactory<FooProps> Foo =
                   // ignore: undefined_identifier
                   $Foo;
-        
+
               @Props()
               class _$FooProps extends ADifferentPropsClass {
                 String foo;
                 int bar;
               }
-        
+
               @Component2()
               class FooComponent extends UiComponent2<FooProps> {
                 @override
@@ -471,18 +1515,18 @@ void main() {
               UiFactory<FooProps> Foo =
                   // ignore: undefined_identifier
                   $Foo;
-        
+
               @Props()
               mixin FooPropsMixin on UiProps {
                 String foo;
                 int bar;
               }
-              
+
               // FIXME:
               //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
-              //   2. Fix any analyzer warnings on this class about missing mixins
+              //   2. Fix any analyzer warnings on this class about missing mixins.
               class FooProps = UiProps with ADifferentPropsClassMixin, FooPropsMixin;
-        
+
               @Component2()
               class FooComponent extends UiComponent2<FooProps> {
                 @override
@@ -496,50 +1540,55 @@ void main() {
             ''',
             );
 
-            expect(converter.convertedClassNames, {
+            expect(converter.visitedClassNames, {
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
               'FooProps': 'FooPropsMixin',
             });
           });
 
-          group('and is abstract', () {
+          group('that is abstract', () {
             test('with members of its own', () {
-              converter.setConvertedClassNames({
-                'LayoutPropsMixin': 'LayoutPropsMixin',
-              });
+              const input = r'''
+              @AbstractProps()
+              abstract class _$AbstractBlockProps extends SomeAbstractPropsClass
+                  with
+                      LayoutPropsMixin,
+                      // ignore: mixin_of_non_class, undefined_class
+                      $LayoutPropsMixin,
+                      BlockPropsMixin,
+                      // ignore: mixin_of_non_class, undefined_class
+                      $BlockPropsMixin
+                  implements
+                      BlockClassHelperMapView {
+                String foo;
+                int bar;
+              }
 
-              testSuggestor(
+              @AbstractComponent2()
+              abstract class AbstractBlockComponent<T extends AbstractBlockProps> extends UiComponent2<T>
+                  with LayoutMixin<T>, BlockMixin<T> {}
+            ''';
+
+              // When it is run the first time, nothing should happen since
+              // we don't know if the mixin(s) are external or not.
+              testSuggestor()(expectedPatchCount: 0, input: input);
+              testSuggestor(visitedClassNames: {
+                'SomeAbstractPropsClass': 'SomeAbstractPropsClass',
+                'LayoutPropsMixin': 'LayoutPropsMixin',
+                'BlockPropsMixin': null,
+              })(
                 expectedPatchCount: 8,
-                input: r'''
-                @AbstractProps()
-                abstract class _$AbstractBlockProps extends SomeAbstractPropsClass
-                    with
-                        LayoutPropsMixin,
-                        // ignore: mixin_of_non_class, undefined_class
-                        $LayoutPropsMixin,
-                        BlockPropsMixin,
-                        // ignore: mixin_of_non_class, undefined_class
-                        $BlockPropsMixin
-                    implements
-                        BlockClassHelperMapView {
-                  String foo;
-                  int bar;
-                }
-                
-                @AbstractComponent2()
-                abstract class AbstractBlockComponent<T extends AbstractBlockProps> extends UiComponent2<T>
-                    with LayoutMixin<T>, BlockMixin<T> {}
-              ''',
+                input: input,
                 expectedOutput: r'''
                 @AbstractProps()
                 mixin AbstractBlockPropsMixin on UiProps implements BlockClassHelperMapView {
                   String foo;
                   int bar;
-                } 
-                
+                }
+
                 // FIXME:
                 //   1. Ensure that all mixins used by SomeAbstractPropsClass are also mixed into this class.
-                //   2. Fix any analyzer warnings on this class about missing mixins
+                //   2. Fix any analyzer warnings on this class about missing mixins.
                 abstract class AbstractBlockProps implements
                         SomeAbstractPropsClass,
                         AbstractBlockPropsMixin,
@@ -547,87 +1596,94 @@ void main() {
                         BlockPropsMixin, // ignore: mixin_of_non_class, undefined_class
                         $BlockPropsMixin,
                         BlockClassHelperMapView {}
-                        
+
                 @AbstractComponent2()
                 abstract class AbstractBlockComponent<T extends AbstractBlockProps> extends UiComponent2<T>
                     with LayoutMixin<T>, BlockMixin<T> {}
               ''',
               );
 
-              expect(converter.convertedClassNames, {
+              expect(converter.visitedClassNames, {
+                'SomeAbstractPropsClass': 'SomeAbstractPropsClass',
                 'LayoutPropsMixin': 'LayoutPropsMixin',
+                'BlockPropsMixin': null,
                 'AbstractBlockProps': 'AbstractBlockPropsMixin',
               });
             });
 
             test('with no members', () {
-              converter.setConvertedClassNames({
-                'LayoutPropsMixin': 'LayoutPropsMixin',
-              });
+              const input = r'''
+              @AbstractProps()
+              abstract class _$AbstractBlockProps extends SomeAbstractPropsClass
+                  with
+                      LayoutPropsMixin,
+                      // ignore: mixin_of_non_class, undefined_class
+                      $LayoutPropsMixin,
+                      BlockPropsMixin,
+                      // ignore: mixin_of_non_class, undefined_class
+                      $BlockPropsMixin
+                  implements
+                      BlockClassHelperMapView {}
 
-              testSuggestor(
+              @AbstractComponent2()
+              abstract class AbstractBlockComponent<T extends AbstractBlockProps> extends UiComponent2<T>
+                  with LayoutMixin<T>, BlockMixin<T> {}
+            ''';
+
+              // When it is run the first time, nothing should happen since
+              // we don't know if the mixin(s) are external or not.
+              testSuggestor()(expectedPatchCount: 0, input: input);
+              testSuggestor(visitedClassNames: {
+                'SomeAbstractPropsClass': 'SomeAbstractPropsClass',
+                'LayoutPropsMixin': 'LayoutPropsMixin',
+                'BlockPropsMixin': null,
+              })(
                 expectedPatchCount: 2,
-                input: r'''
-                @AbstractProps()
-                abstract class _$AbstractBlockProps extends SomeAbstractPropsClass
-                    with
-                        LayoutPropsMixin,
-                        // ignore: mixin_of_non_class, undefined_class
-                        $LayoutPropsMixin,
-                        BlockPropsMixin,
-                        // ignore: mixin_of_non_class, undefined_class
-                        $BlockPropsMixin
-                    implements
-                        BlockClassHelperMapView {}
-                
-                @AbstractComponent2()
-                abstract class AbstractBlockComponent<T extends AbstractBlockProps> extends UiComponent2<T>
-                    with LayoutMixin<T>, BlockMixin<T> {}
-              ''',
+                input: input,
                 expectedOutput: r'''
                 // FIXME:
                 //   1. Ensure that all mixins used by SomeAbstractPropsClass are also mixed into this class.
-                //   2. Fix any analyzer warnings on this class about missing mixins
+                //   2. Fix any analyzer warnings on this class about missing mixins.
                 abstract class AbstractBlockProps implements
                         SomeAbstractPropsClass,
                         LayoutPropsMixin,
                         BlockPropsMixin, // ignore: mixin_of_non_class, undefined_class
                         $BlockPropsMixin,
                         BlockClassHelperMapView {}
-                        
+
                 @AbstractComponent2()
                 abstract class AbstractBlockComponent<T extends AbstractBlockProps> extends UiComponent2<T>
                     with LayoutMixin<T>, BlockMixin<T> {}
               ''',
               );
 
-              expect(converter.convertedClassNames, {
+              expect(converter.visitedClassNames, {
+                'SomeAbstractPropsClass': 'SomeAbstractPropsClass',
                 'LayoutPropsMixin': 'LayoutPropsMixin',
+                'BlockPropsMixin': null,
                 'AbstractBlockProps': 'AbstractBlockProps',
               });
             });
           });
 
           group('that has an analagous abstract component class', () {
-            test('', () {
-              converter.setConvertedClassNames({
+            test('and members of its own', () {
+              testSuggestor(visitedClassNames: {
                 'SomeAbstractPropsClass': 'SomeAbstractPropsClassMixin',
-              });
-
-              testSuggestor(
+              })(
                 expectedPatchCount: 6,
                 input: r'''
                 @Factory()
                 UiFactory<FooProps> Foo =
                     // ignore: undefined_identifier
                     $Foo;
-          
+
                 @Props()
                 class _$FooProps extends SomeAbstractPropsClass implements SomeInterface {
                   String foo;
                   int bar;
                 }
-          
+
                 @Component2()
                 class FooComponent extends AbstractComponentClass<FooProps> {
                   @override
@@ -644,19 +1700,19 @@ void main() {
                 UiFactory<FooProps> Foo =
                     // ignore: undefined_identifier
                     $Foo;
-          
+
                 @Props()
                 mixin FooPropsMixin on UiProps implements SomeInterface {
                   String foo;
                   int bar;
                 }
-                
+
                 // FIXME:
                 //   1. Ensure that all mixins used by SomeAbstractPropsClass are also mixed into this class.
-                //   2. Fix any analyzer warnings on this class about missing mixins
-                class FooProps = UiProps with SomeAbstractPropsClassMixin, FooPropsMixin 
+                //   2. Fix any analyzer warnings on this class about missing mixins.
+                class FooProps = UiProps with SomeAbstractPropsClassMixin, FooPropsMixin
                     implements SomeAbstractPropsClass, SomeInterface;
-          
+
                 @Component2()
                 class FooComponent extends AbstractComponentClass<FooProps> {
                   @override
@@ -670,24 +1726,26 @@ void main() {
               ''',
               );
 
-              expect(converter.convertedClassNames, {
+              expect(converter.visitedClassNames, {
                 'SomeAbstractPropsClass': 'SomeAbstractPropsClassMixin',
                 'FooProps': 'FooPropsMixin',
               });
             });
 
             test('but no members of its own', () {
-              testSuggestor(
+              testSuggestor(visitedClassNames: {
+                'SomeAbstractPropsClass': 'SomeAbstractPropsClass',
+              })(
                 expectedPatchCount: 2,
                 input: r'''
                 @Factory()
                 UiFactory<FooProps> Foo =
                     // ignore: undefined_identifier
                     $Foo;
-          
+
                 @Props()
                 class _$FooProps extends SomeAbstractPropsClass implements SomeInterface {}
-          
+
                 @Component2()
                 class FooComponent extends AbstractComponentClass<FooProps> {
                   @override
@@ -704,12 +1762,12 @@ void main() {
                 UiFactory<FooProps> Foo =
                     // ignore: undefined_identifier
                     $Foo;
-                
+
                 // FIXME:
                 //   1. Ensure that all mixins used by SomeAbstractPropsClass are also mixed into this class.
-                //   2. Fix any analyzer warnings on this class about missing mixins
+                //   2. Fix any analyzer warnings on this class about missing mixins.
                 class FooProps extends UiProps implements SomeAbstractPropsClass, SomeInterface {}
-          
+
                 @Component2()
                 class FooComponent extends AbstractComponentClass<FooProps> {
                   @override
@@ -723,7 +1781,8 @@ void main() {
               ''',
               );
 
-              expect(converter.convertedClassNames, {
+              expect(converter.visitedClassNames, {
+                'SomeAbstractPropsClass': 'SomeAbstractPropsClass',
                 'FooProps': 'FooProps',
               });
             });
@@ -731,57 +1790,61 @@ void main() {
         });
 
         test('that extends from UiProps, but uses mixins', () {
-          converter.setConvertedClassNames({
-            'ConvertedMixin': 'ConvertedMixin',
-          });
+          const input = r'''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              $Foo;
 
-          testSuggestor(
+          @Props()
+          class _$FooProps extends UiProps
+              with ConvertedMixin,
+                   // ignore: mixin_of_non_class, undefined_class
+                   $ConvertedMixin,
+                   UnconvertedMixin,
+                   // ignore: mixin_of_non_class, undefined_class
+                   $UnconvertedMixin {
+            String foo;
+            int bar;
+          }
+
+          @Component2()
+          class FooComponent extends UiComponent2<FooProps> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+        ''';
+
+          // When it is run the first time, nothing should happen since
+          // we don't know for sure if UnconvertedMixin can be converted yet.
+          testSuggestor()(expectedPatchCount: 0, input: input);
+          testSuggestor(visitedClassNames: {
+            'ConvertedMixin': 'ConvertedMixin',
+            'UnconvertedMixin': null,
+          })(
             expectedPatchCount: 6,
-            input: r'''
-            @Factory()
-            UiFactory<FooProps> Foo =
-                // ignore: undefined_identifier
-                $Foo;
-      
-            @Props()
-            class _$FooProps extends UiProps 
-                with ConvertedMixin, 
-                     // ignore: mixin_of_non_class, undefined_class
-                     $ConvertedMixin,
-                     UnconvertedMixin,
-                     // ignore: mixin_of_non_class, undefined_class
-                     $UnconvertedMixin {
-              String foo;
-              int bar;
-            }
-      
-            @Component2()
-            class FooComponent extends UiComponent2<FooProps> {
-              @override
-              render() {
-                return Dom.ul()(
-                  Dom.li()('Foo: ', props.foo),
-                  Dom.li()('Bar: ', props.bar),
-                );
-              }
-            }
-          ''',
+            input: input,
             expectedOutput: r'''
             @Factory()
             UiFactory<FooProps> Foo =
                 // ignore: undefined_identifier
                 $Foo;
-      
+
             @Props()
             mixin FooPropsMixin on UiProps {
               String foo;
               int bar;
             }
-            
-            class FooProps = UiProps 
-                with FooPropsMixin, ConvertedMixin, UnconvertedMixin, // ignore: mixin_of_non_class, undefined_class 
+
+            class FooProps = UiProps
+                with FooPropsMixin, ConvertedMixin, UnconvertedMixin, // ignore: mixin_of_non_class, undefined_class
                 $UnconvertedMixin;
-      
+
             @Component2()
             class FooComponent extends UiComponent2<FooProps> {
               @override
@@ -795,29 +1858,32 @@ void main() {
           ''',
           );
 
-          expect(converter.convertedClassNames, {
+          expect(converter.visitedClassNames, {
             'ConvertedMixin': 'ConvertedMixin',
+            'UnconvertedMixin': null,
             'FooProps': 'FooPropsMixin',
           });
         });
 
         group('that extends from UiProps, uses mixins, implements interfaces',
             () {
-          test('', () {
-            testSuggestor(
+          test('and is not abstract', () {
+            testSuggestor(visitedClassNames: {
+              'ConvertedMixin': 'ConvertedMixin',
+            })(
               expectedPatchCount: 6,
               input: r'''
               @Factory()
               UiFactory<FooProps> Foo =
                   // ignore: undefined_identifier
                   $Foo;
-                
+
               @Props()
               class _$FooProps extends UiProps with ConvertedMixin implements SomeInterface, SomeOtherInterface {
                 String foo;
                 int bar;
               }
-              
+
               @Component2()
               class FooComponent extends UiComponent2<FooProps> {
                 @override
@@ -840,9 +1906,9 @@ void main() {
                 String foo;
                 int bar;
               }
-              
+
               class FooProps = UiProps with FooPropsMixin, ConvertedMixin implements SomeInterface, SomeOtherInterface;
-              
+
               @Component2()
               class FooComponent extends UiComponent2<FooProps> {
                 @override
@@ -856,104 +1922,115 @@ void main() {
             ''',
             );
 
-            expect(converter.convertedClassNames, {
+            expect(converter.visitedClassNames, {
+              'ConvertedMixin': 'ConvertedMixin',
               'FooProps': 'FooPropsMixin',
             });
           });
 
           group('and is abstract', () {
             test('with members of its own', () {
-              converter.setConvertedClassNames({
-                'LayoutPropsMixin': 'LayoutPropsMixin',
-              });
+              const input = r'''
+              @AbstractProps()
+              abstract class _$AbstractBlockProps extends UiProps
+                  with
+                      LayoutPropsMixin,
+                      // ignore: mixin_of_non_class, undefined_class
+                      $LayoutPropsMixin,
+                      BlockPropsMixin,
+                      // ignore: mixin_of_non_class, undefined_class
+                      $BlockPropsMixin
+                  implements
+                      BlockClassHelperMapView {
+                String foo;
+                int bar;
+              }
 
-              testSuggestor(
+              @AbstractComponent2()
+              abstract class AbstractBlockComponent<T extends AbstractBlockProps> extends UiComponent2<T>
+                  with LayoutMixin<T>, BlockMixin<T> {}
+            ''';
+
+              // When it is run the first time, nothing should happen since
+              // we don't know if the mixin(s) are external or not.
+              testSuggestor()(expectedPatchCount: 0, input: input);
+              testSuggestor(visitedClassNames: {
+                'LayoutPropsMixin': 'LayoutPropsMixin',
+                'BlockPropsMixin': null,
+              })(
                 expectedPatchCount: 7,
-                input: r'''
-                @AbstractProps()
-                abstract class _$AbstractBlockProps extends UiProps
-                    with
-                        LayoutPropsMixin,
-                        // ignore: mixin_of_non_class, undefined_class
-                        $LayoutPropsMixin,
-                        BlockPropsMixin,
-                        // ignore: mixin_of_non_class, undefined_class
-                        $BlockPropsMixin
-                    implements
-                        BlockClassHelperMapView {
-                  String foo;
-                  int bar;
-                }
-                
-                @AbstractComponent2()
-                abstract class AbstractBlockComponent<T extends AbstractBlockProps> extends UiComponent2<T>
-                    with LayoutMixin<T>, BlockMixin<T> {}
-              ''',
+                input: input,
                 expectedOutput: r'''
                 @AbstractProps()
                 mixin AbstractBlockPropsMixin on UiProps implements BlockClassHelperMapView {
                   String foo;
                   int bar;
-                } 
-                
+                }
+
                 abstract class AbstractBlockProps implements
                         AbstractBlockPropsMixin,
                         LayoutPropsMixin,
                         BlockPropsMixin, // ignore: mixin_of_non_class, undefined_class
                         $BlockPropsMixin,
                         BlockClassHelperMapView {}
-                        
+
                 @AbstractComponent2()
                 abstract class AbstractBlockComponent<T extends AbstractBlockProps> extends UiComponent2<T>
                     with LayoutMixin<T>, BlockMixin<T> {}
               ''',
               );
 
-              expect(converter.convertedClassNames, {
+              expect(converter.visitedClassNames, {
                 'LayoutPropsMixin': 'LayoutPropsMixin',
+                'BlockPropsMixin': null,
                 'AbstractBlockProps': 'AbstractBlockPropsMixin',
               });
             });
 
             test('with no members', () {
-              converter.setConvertedClassNames({
-                'LayoutPropsMixin': 'LayoutPropsMixin',
-              });
+              const input = r'''
+              @AbstractProps()
+              abstract class _$AbstractBlockProps extends UiProps
+                  with
+                      LayoutPropsMixin,
+                      // ignore: mixin_of_non_class, undefined_class
+                      $LayoutPropsMixin,
+                      BlockPropsMixin,
+                      // ignore: mixin_of_non_class, undefined_class
+                      $BlockPropsMixin
+                  implements
+                      BlockClassHelperMapView {}
 
-              testSuggestor(
+              @AbstractComponent2()
+              abstract class AbstractBlockComponent<T extends AbstractBlockProps> extends UiComponent2<T>
+                  with LayoutMixin<T>, BlockMixin<T> {}
+            ''';
+
+              // When it is run the first time, nothing should happen since
+              // we don't know if the mixin(s) are external or not.
+              testSuggestor()(expectedPatchCount: 0, input: input);
+              testSuggestor(visitedClassNames: {
+                'LayoutPropsMixin': 'LayoutPropsMixin',
+                'BlockPropsMixin': null,
+              })(
                 expectedPatchCount: 2,
-                input: r'''
-                @AbstractProps()
-                abstract class _$AbstractBlockProps extends UiProps
-                    with
-                        LayoutPropsMixin,
-                        // ignore: mixin_of_non_class, undefined_class
-                        $LayoutPropsMixin,
-                        BlockPropsMixin,
-                        // ignore: mixin_of_non_class, undefined_class
-                        $BlockPropsMixin
-                    implements
-                        BlockClassHelperMapView {}
-                
-                @AbstractComponent2()
-                abstract class AbstractBlockComponent<T extends AbstractBlockProps> extends UiComponent2<T>
-                    with LayoutMixin<T>, BlockMixin<T> {}
-              ''',
+                input: input,
                 expectedOutput: r'''
                 abstract class AbstractBlockProps implements
                         LayoutPropsMixin,
                         BlockPropsMixin, // ignore: mixin_of_non_class, undefined_class
                         $BlockPropsMixin,
                         BlockClassHelperMapView {}
-                        
+
                 @AbstractComponent2()
                 abstract class AbstractBlockComponent<T extends AbstractBlockProps> extends UiComponent2<T>
                     with LayoutMixin<T>, BlockMixin<T> {}
               ''',
               );
 
-              expect(converter.convertedClassNames, {
+              expect(converter.visitedClassNames, {
                 'LayoutPropsMixin': 'LayoutPropsMixin',
+                'BlockPropsMixin': null,
                 'AbstractBlockProps': 'AbstractBlockProps',
               });
             });
@@ -964,27 +2041,25 @@ void main() {
             'and there is already a mixin that matches the name of the class appended with "Mixin"',
             () {
           test('and the class has no members of its own', () {
-            converter.setConvertedClassNames({
+            testSuggestor(visitedClassNames: {
               'FooPropsMixin': 'FooPropsMixin',
-            });
-
-            testSuggestor(
+            })(
               expectedPatchCount: 2,
               input: r'''
               @Factory()
               UiFactory<FooProps> Foo =
                   // ignore: undefined_identifier
                   $Foo;
-                
+
               @PropsMixin()
               mixin FooPropsMixin on UiProps {
                 String foo;
                 int bar;
               }
-      
+
               @Props()
               class _$FooProps extends UiProps with FooPropsMixin {}
-      
+
               @Component2()
               class FooComponent extends UiComponent2<FooProps, FooState> {
                 @override
@@ -1001,15 +2076,15 @@ void main() {
               UiFactory<FooProps> Foo =
                   // ignore: undefined_identifier
                   $Foo;
-      
+
               @PropsMixin()
               mixin FooPropsMixin on UiProps {
                 String foo;
                 int bar;
               }
-              
+
               class FooProps = UiProps with FooPropsMixin;
-      
+
               @Component2()
               class FooComponent extends UiComponent2<FooProps, FooState> {
                 @override
@@ -1023,36 +2098,34 @@ void main() {
             ''',
             );
 
-            expect(converter.convertedClassNames, {
+            expect(converter.visitedClassNames, {
               'FooPropsMixin': 'FooPropsMixin',
               'FooProps': 'FooProps',
             });
           });
 
           test('and the class has members', () {
-            converter.setConvertedClassNames({
+            testSuggestor(visitedClassNames: {
               'FooPropsMixin': 'FooPropsMixin',
-            });
-
-            testSuggestor(
+            })(
               expectedPatchCount: 3,
               input: r'''
               @Factory()
               UiFactory<FooProps> Foo =
                   // ignore: undefined_identifier
                   $Foo;
-                
+
               @PropsMixin()
               mixin FooPropsMixin on UiProps {
                 String foo;
                 int bar;
               }
-      
+
               @Props()
               class _$FooProps extends UiProps with FooPropsMixin {
                 String baz;
               }
-      
+
               @Component2()
               class FooComponent extends UiComponent2<FooProps, FooState> {
                 @override
@@ -1069,16 +2142,16 @@ void main() {
               UiFactory<FooProps> Foo =
                   // ignore: undefined_identifier
                   $Foo;
-      
+
               @PropsMixin()
               mixin FooPropsMixin on UiProps {
                 String foo;
                 int bar;
                 String baz;
               }
-              
+
               class FooProps = UiProps with FooPropsMixin;
-      
+
               @Component2()
               class FooComponent extends UiComponent2<FooProps, FooState> {
                 @override
@@ -1092,7 +2165,7 @@ void main() {
             ''',
             );
 
-            expect(converter.convertedClassNames, {
+            expect(converter.visitedClassNames, {
               'FooPropsMixin': 'FooPropsMixin',
               'FooProps': 'FooProps',
             });
@@ -1103,71 +2176,77 @@ void main() {
       test(
           'and there are classes that extend from arbitrary custom classes, along with mixins',
           () {
-        // Omit the state class intentionally to verify that the boilerplate
-        // is not updated to point at a mixin name that is not "known" as a previously converted class.
-        converter.setConvertedClassNames({
-          'ADifferentPropsClass': 'ADifferentPropsClassMixin',
-        });
+        const input = r'''
+        @Factory()
+        UiFactory<FooProps> Foo =
+            // ignore: undefined_identifier
+            $Foo;
 
-        testSuggestor(
+        @Props()
+        class _$FooProps extends ADifferentPropsClass with AMixin, AnotherMixin {
+          String foo;
+          int bar;
+        }
+
+        @State()
+        class _$FooState extends ADifferentStateClass with AStateMixin, AnotherStateMixin {
+          String foo;
+          int bar;
+        }
+
+        @Component2()
+        class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+          @override
+          render() {
+            return Dom.ul()(
+              Dom.li()('Foo: ', props.foo),
+              Dom.li()('Bar: ', props.bar),
+            );
+          }
+        }
+      ''';
+
+        // When it is run the first time, nothing should happen since
+        // we don't know if the mixin(s) are external or not.
+        testSuggestor()(expectedPatchCount: 0, input: input);
+        testSuggestor(visitedClassNames: {
+          'AMixin': 'AMixin',
+          'AnotherMixin': 'AnotherMixin',
+          'ADifferentPropsClass': 'ADifferentPropsClassMixin',
+          'AStateMixin': 'AStateMixin',
+          'AnotherStateMixin': 'AnotherStateMixin',
+          'ADifferentStateClass': 'ADifferentStateClass',
+        })(
           expectedPatchCount: 14,
-          input: r'''
-          @Factory()
-          UiFactory<FooProps> Foo =
-              // ignore: undefined_identifier
-              $Foo;
-  
-          @Props()
-          class _$FooProps extends ADifferentPropsClass with AMixin, AnotherMixin {
-            String foo;
-            int bar;
-          }
-  
-          @State()
-          class _$FooState extends ADifferentStateClass with AStateMixin, AnotherStateMixin {
-            String foo;
-            int bar;
-          }
-  
-          @Component2()
-          class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
-            @override
-            render() {
-              return Dom.ul()(
-                Dom.li()('Foo: ', props.foo),
-                Dom.li()('Bar: ', props.bar),
-              );
-            }
-          }
-        ''',
+          input: input,
           expectedOutput: r'''
           @Factory()
           UiFactory<FooProps> Foo =
               // ignore: undefined_identifier
               $Foo;
-  
+
           @Props()
           mixin FooPropsMixin on UiProps {
             String foo;
             int bar;
           }
-          
+
           // FIXME:
           //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
-          //   2. Fix any analyzer warnings on this class about missing mixins        
+          //   2. Fix any analyzer warnings on this class about missing mixins.
           class FooProps = UiProps with ADifferentPropsClassMixin, FooPropsMixin, AMixin, AnotherMixin;
-  
+
           @State()
           mixin FooStateMixin on UiState {
             String foo;
             int bar;
           }
-          
+
           // FIXME:
           //   1. Ensure that all mixins used by ADifferentStateClass are also mixed into this class.
-          //   2. Fix any analyzer warnings on this class about missing mixins
+          //   2. Fix any analyzer warnings on this class about missing mixins.
           class FooState = UiState with ADifferentStateClass, FooStateMixin, AStateMixin, AnotherStateMixin;
-  
+
           @Component2()
           class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
             @override
@@ -1181,8 +2260,13 @@ void main() {
         ''',
         );
 
-        expect(converter.convertedClassNames, {
+        expect(converter.visitedClassNames, {
+          'AMixin': 'AMixin',
+          'AnotherMixin': 'AnotherMixin',
           'ADifferentPropsClass': 'ADifferentPropsClassMixin',
+          'AStateMixin': 'AStateMixin',
+          'AnotherStateMixin': 'AnotherStateMixin',
+          'ADifferentStateClass': 'ADifferentStateClass',
           'FooProps': 'FooPropsMixin',
           'FooState': 'FooStateMixin',
         });
@@ -1194,29 +2278,30 @@ void main() {
           () {
         group('and that mixin exists in the same root', () {
           setUp(() {
-            converter.setConvertedClassNames({
+            converter.setVisitedClassNames({
+              'FooPropsMixin': 'FooPropsMixin',
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
             });
           });
 
           test('and the class has no members', () {
-            testSuggestor(
+            testSuggestor()(
               expectedPatchCount: 2,
               input: r'''
               @Factory()
               UiFactory<FooProps> Foo =
                   // ignore: undefined_identifier
                   $Foo;
-                
+
               @PropsMixin()
               mixin FooPropsMixin on UiProps {
                 String foo;
                 int bar;
               }
-      
+
               @Props()
               class _$FooProps extends ADifferentPropsClass with FooPropsMixin {}
-      
+
               @Component2()
               class FooComponent extends UiComponent2<FooProps, FooState> {
                 @override
@@ -1233,18 +2318,18 @@ void main() {
               UiFactory<FooProps> Foo =
                   // ignore: undefined_identifier
                   $Foo;
-      
+
               @PropsMixin()
               mixin FooPropsMixin on UiProps {
                 String foo;
                 int bar;
               }
-              
+
               // FIXME:
               //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
-              //   2. Fix any analyzer warnings on this class about missing mixins        
+              //   2. Fix any analyzer warnings on this class about missing mixins.
               class FooProps = UiProps with ADifferentPropsClassMixin, FooPropsMixin;
-      
+
               @Component2()
               class FooComponent extends UiComponent2<FooProps, FooState> {
                 @override
@@ -1258,32 +2343,33 @@ void main() {
             ''',
             );
 
-            expect(converter.convertedClassNames, {
+            expect(converter.visitedClassNames, {
+              'FooPropsMixin': 'FooPropsMixin',
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
               'FooProps': 'FooProps',
             });
           });
 
           test('and the class has members', () {
-            testSuggestor(
+            testSuggestor()(
               expectedPatchCount: 3,
               input: r'''
               @Factory()
               UiFactory<FooProps> Foo =
                   // ignore: undefined_identifier
                   $Foo;
-                
+
               @PropsMixin()
               mixin FooPropsMixin on UiProps {
                 String foo;
                 int bar;
               }
-      
+
               @Props()
               class _$FooProps extends ADifferentPropsClass with FooPropsMixin {
                 String baz;
               }
-      
+
               @Component2()
               class FooComponent extends UiComponent2<FooProps, FooState> {
                 @override
@@ -1300,19 +2386,19 @@ void main() {
               UiFactory<FooProps> Foo =
                   // ignore: undefined_identifier
                   $Foo;
-      
+
               @PropsMixin()
               mixin FooPropsMixin on UiProps {
                 String foo;
                 int bar;
                 String baz;
               }
-              
+
               // FIXME:
               //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
-              //   2. Fix any analyzer warnings on this class about missing mixins        
+              //   2. Fix any analyzer warnings on this class about missing mixins.
               class FooProps = UiProps with ADifferentPropsClassMixin, FooPropsMixin;
-      
+
               @Component2()
               class FooComponent extends UiComponent2<FooProps, FooState> {
                 @override
@@ -1326,7 +2412,8 @@ void main() {
             ''',
             );
 
-            expect(converter.convertedClassNames, {
+            expect(converter.visitedClassNames, {
+              'FooPropsMixin': 'FooPropsMixin',
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
               'FooProps': 'FooProps',
             });
@@ -1337,24 +2424,24 @@ void main() {
             'and that mixin does not exist in the same root, but has already been converted',
             () {
           setUp(() {
-            converter.setConvertedClassNames({
+            converter.setVisitedClassNames({
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
               'FooPropsMixin': 'FooPropsMixin',
             });
           });
 
           test('and the class has no members', () {
-            testSuggestor(
+            testSuggestor()(
               expectedPatchCount: 2,
               input: r'''
               @Factory()
               UiFactory<FooProps> Foo =
                   // ignore: undefined_identifier
                   $Foo;
-      
+
               @Props()
               class _$FooProps extends ADifferentPropsClass with FooPropsMixin {}
-      
+
               @Component2()
               class FooComponent extends UiComponent2<FooProps, FooState> {
                 @override
@@ -1371,12 +2458,12 @@ void main() {
               UiFactory<FooProps> Foo =
                   // ignore: undefined_identifier
                   $Foo;
-              
+
               // FIXME:
               //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
-              //   2. Fix any analyzer warnings on this class about missing mixins        
+              //   2. Fix any analyzer warnings on this class about missing mixins.
               class FooProps = UiProps with ADifferentPropsClassMixin, FooPropsMixin;
-      
+
               @Component2()
               class FooComponent extends UiComponent2<FooProps, FooState> {
                 @override
@@ -1390,7 +2477,7 @@ void main() {
             ''',
             );
 
-            expect(converter.convertedClassNames, {
+            expect(converter.visitedClassNames, {
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
               'FooPropsMixin': 'FooPropsMixin',
               'FooProps': 'FooProps',
@@ -1398,19 +2485,19 @@ void main() {
           });
 
           test('and the class has members', () {
-            testSuggestor(
+            testSuggestor()(
               expectedPatchCount: 2,
               input: r'''
               @Factory()
               UiFactory<FooProps> Foo =
                   // ignore: undefined_identifier
                   $Foo;
-      
+
               @Props()
-              class _$FooProps extends ADifferentPropsClass with FooPropsMixin { 
+              class _$FooProps extends ADifferentPropsClass with FooPropsMixin {
                 String baz;
               }
-      
+
               @Component2()
               class FooComponent extends UiComponent2<FooProps, FooState> {
                 @override
@@ -1427,16 +2514,16 @@ void main() {
               UiFactory<FooProps> Foo =
                   // ignore: undefined_identifier
                   $Foo;
-              
+
               // FIXME:
               //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
-              //   2. Fix any analyzer warnings on this class about missing mixins        
+              //   2. Fix any analyzer warnings on this class about missing mixins.
               class FooProps extends UiProps with ADifferentPropsClassMixin, FooPropsMixin {
                 // FIXME: Everything in this body needs to be moved to the body of FooPropsMixin.
                 // Once that is done, the body can be removed, and `extends` can be replaced with `=`.
                 String baz;
               }
-      
+
               @Component2()
               class FooComponent extends UiComponent2<FooProps, FooState> {
                 @override
@@ -1450,7 +2537,7 @@ void main() {
             ''',
             );
 
-            expect(converter.convertedClassNames, {
+            expect(converter.visitedClassNames, {
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
               'FooPropsMixin': 'FooPropsMixin',
               'FooProps': 'FooProps',

--- a/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
@@ -106,6 +106,8 @@ void main() {
           input: '''
           $factoryDecl
   
+          /// Some documentation comment 
+          /// might get in the way of fix me comment removal
           @Props()
           class $propsClassName extends UiProps with SomePropsMixin {
             String foo;
@@ -126,13 +128,15 @@ void main() {
           expectedOutput: '''
           $factoryDecl
   
+          /// Some documentation comment 
+          /// might get in the way of fix me comment removal
+          @Props()
           // FIXME: `$publicPropsClassName` could not be auto-migrated to the new over_react boilerplate 
           // because `FooComponent` does not extend from `react.Component2`.
           // 
           // Once you have upgraded the component, you can remove this FIXME comment and 
           // re-run the boilerplate migration script:
           // pub run over_react_codemod:boilerplate_upgrade
-          @Props()
           class $propsClassName extends UiProps with SomePropsMixin {
             String foo;
             int bar;
@@ -192,6 +196,7 @@ void main() {
               // ignore: undefined_identifier
               $Bar;
   
+          @Props()
           // FIXME: `BarProps` could not be auto-migrated to the new over_react boilerplate 
           // because doing so would be a breaking change since `BarProps` is exported from a 
           // library in this repo.
@@ -209,12 +214,12 @@ void main() {
           //       "V2" class / mixin public, update the `hide` clause you added in step 4 to include both the 
           //       concrete class and the newly created mixin.
           //   6. Remove this FIXME comment.
-          @Props()
           class _$BarProps extends ADifferentPropsClass {
             String foo;
             int bar;
           }
-  
+
+          @State()
           // FIXME: `BarState` could not be auto-migrated to the new over_react boilerplate 
           // because doing so would be a breaking change since `BarState` is exported from a 
           // library in this repo.
@@ -232,7 +237,6 @@ void main() {
           //       "V2" class / mixin public, update the `hide` clause you added in step 4 to include both the 
           //       concrete class and the newly created mixin.
           //   6. Remove this FIXME comment.
-          @State()
           class _$BarState extends ADifferentStateClass {
             String foo;
             int bar;
@@ -275,6 +279,7 @@ void main() {
         const expectedOutputWithExternalSuperclassReasonComment = '''
             $factoryDecl
             
+            @Props()
             // FIXME: `$publicPropsClassName` could not be auto-migrated to the new over_react boilerplate 
             // because it extends from: $externalSuperclassName - which comes from an external library.
             //
@@ -288,7 +293,6 @@ void main() {
             //      Follow the deprecation instructions to consume the replacement by either updating your usage to
             //      the new class name and/or updating to a different entrypoint that exports the version(s) of 
             //      $externalSuperclassName that is compatible with the new over_react boilerplate.
-            @Props()
             class $propsClassName extends $externalSuperclassName {
               String foo;
               int bar;
@@ -339,6 +343,7 @@ void main() {
                 int bar;
               }
   
+              @Props()
               // FIXME:
               //   1. Ensure that all mixins used by $externalSuperclassName are also mixed into this class.
               //   2. Fix any analyzer warnings on this class about missing mixins.
@@ -349,7 +354,6 @@ void main() {
               //
               //      If it is not deprecated, something most likely went wrong during the migration of the 
               //      library that contains it. 
-              @Props()
               class $publicPropsClassName = UiProps with $externalSuperclassName, ${publicPropsClassName}Mixin;
   
               $componentDecl
@@ -397,6 +401,7 @@ void main() {
                 int bar;
               }
   
+              @Props()
               // FIXME:
               //   1. Ensure that all mixins used by $externalSuperclassName are also mixed into this class.
               //   2. Fix any analyzer warnings on this class about missing mixins.
@@ -406,8 +411,7 @@ void main() {
               //      $externalSuperclassName that is compatible with the new over_react boilerplate.
               //
               //      If it is not deprecated, something most likely went wrong during the migration of the 
-              //      library that contains it. 
-              @Props()
+              //      library that contains it.
               class $publicPropsClassName = UiProps with $externalSuperclassName, ${publicPropsClassName}Mixin;
   
               $componentDecl
@@ -446,6 +450,7 @@ void main() {
         const expectedOutputWithExternalSuperclassReasonComment = '''
             $factoryDecl
             
+            @Props()
             // FIXME: `$publicPropsClassName` could not be auto-migrated to the new over_react boilerplate 
             // because it mixes in: $externalMixinName - which comes from an external library.
             //
@@ -473,7 +478,6 @@ void main() {
             //      Follow the deprecation instructions to consume the replacement by either updating your usage to
             //      the new class name and/or updating to a different entrypoint that exports the version(s) of 
             //      $externalSuperclassName that is compatible with the new over_react boilerplate.
-            @Props()
             class $propsClassName extends $externalSuperclassName with $externalMixinName {
               String foo;
               int bar;
@@ -524,7 +528,8 @@ void main() {
                 String foo;
                 int bar;
               }
-  
+
+              @Props()
               // FIXME:
               //   1. Ensure that all mixins used by $externalSuperclassName are also mixed into this class.
               //   2. Fix any analyzer warnings on this class about missing mixins.
@@ -535,7 +540,6 @@ void main() {
               //
               //      If they are not deprecated, something most likely went wrong during the migration of the 
               //      library that contains them. 
-              @Props()
               class $publicPropsClassName = UiProps with $externalSuperclassName, ${publicPropsClassName}Mixin, $externalMixinName;
   
               $componentDecl
@@ -572,7 +576,8 @@ void main() {
                 String foo;
                 int bar;
               }
-  
+
+              @Props()
               // FIXME:
               //   1. Ensure that all mixins used by $externalSuperclassName are also mixed into this class.
               //   2. Fix any analyzer warnings on this class about missing mixins.
@@ -583,7 +588,6 @@ void main() {
               //
               //      If they are not deprecated, something most likely went wrong during the migration of the 
               //      library that contains them. 
-              @Props()
               class $publicPropsClassName = UiProps with $externalSuperclassName, ${publicPropsClassName}Mixin, $externalMixinName;
   
               $componentDecl
@@ -608,6 +612,7 @@ void main() {
         const expectedOutputWithUnMigratedSuperclassReasonComment = '''
             $factoryDecl
             
+            @Props()
             // FIXME: `$publicPropsClassName` could not be auto-migrated to the new over_react boilerplate 
             // because it extends from `ADifferentPropsClass`, which was not able to be migrated.
             //
@@ -616,7 +621,6 @@ void main() {
             //      and follow the steps outlined there to complete the migration.
             //   2. Re-run the migration script:
             //      pub run over_react_codemod:boilerplate_upgrade
-            @Props()
             class $propsClassName extends ADifferentPropsClass {
               String foo;
               int bar;
@@ -682,10 +686,10 @@ void main() {
               int bar;
             }
 
+            @Props()
             // FIXME:
             //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
             //   2. Fix any analyzer warnings on this class about missing mixins.
-            @Props()
             class $publicPropsClassName = UiProps with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin;
     
             $componentDecl
@@ -719,7 +723,8 @@ void main() {
 
           const expectedOutputWithExternalMixinReasonComment = '''
               $factoryDecl
-    
+
+              @Props()
               // FIXME: `$publicPropsClassName` could not be auto-migrated to the new over_react boilerplate 
               // because it mixes in: $externalMixinName - which comes from an external library.
               //
@@ -733,7 +738,6 @@ void main() {
               //      Follow the deprecation instructions to consume the replacement by either updating your usage to
               //      the new mixin name and/or updating to a different entrypoint that exports the version(s) of 
               //      $externalMixinName that is compatible with the new over_react boilerplate.
-              @Props()
               class $propsClassName extends UiProps with $externalMixinName {
                 String foo;
                 int bar;
@@ -783,7 +787,8 @@ void main() {
                   String foo;
                   int bar;
                 }
-    
+
+                @Props()
                 // FIXME:
                 //   1. You should notice that $externalMixinName is deprecated.  
                 //      Follow the deprecation instructions to consume the replacement by either updating your usage to
@@ -792,7 +797,6 @@ void main() {
                 //
                 //      If it is not deprecated, something most likely went wrong during the migration of the 
                 //      library that contains it. 
-                @Props()
                 class $publicPropsClassName = UiProps with ${publicPropsClassName}Mixin, $externalMixinName;
     
                 $componentDecl
@@ -828,7 +832,8 @@ void main() {
 
           const expectedOutputWithExternalMixinReasonComment = '''
               $factoryDecl
-    
+
+              @Props()
               // FIXME: `$publicPropsClassName` could not be auto-migrated to the new over_react boilerplate 
               // because it mixes in: $externalMixinNames - which come from an external library.
               //
@@ -842,7 +847,6 @@ void main() {
               //      Follow the deprecation instructions to consume the replacements by either updating your usage to
               //      the new mixin names and/or updating to a different entrypoint that exports the version(s) of 
               //      $externalMixinNames that are compatible with the new over_react boilerplate.
-              @Props()
               class $propsClassName extends UiProps with $externalMixinNames {
                 String foo;
                 int bar;
@@ -892,7 +896,8 @@ void main() {
                   String foo;
                   int bar;
                 }
-    
+
+                @Props()
                 // FIXME:
                 //   1. You should notice that $externalMixinNames are deprecated.  
                 //      Follow the deprecation instructions to consume the replacement by either updating your usage to
@@ -901,7 +906,6 @@ void main() {
                 //
                 //      If they are not deprecated, something most likely went wrong during the migration of the 
                 //      library that contains them. 
-                @Props()
                 class $publicPropsClassName = UiProps with ${publicPropsClassName}Mixin, $externalMixinNames;
     
                 $componentDecl
@@ -952,11 +956,11 @@ void main() {
               String foo;
               int bar;
             }
-    
+
+            @Props()
             // FIXME:
             //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
             //   2. Fix any analyzer warnings on this class about missing mixins.
-            @Props()
             class $publicPropsClassName = UiProps with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin;
     
             @State()
@@ -964,11 +968,11 @@ void main() {
               String foo;
               int bar;
             }
-            
+
+            @State()
             // FIXME:
             //   1. Ensure that all mixins used by ADifferentStateClass are also mixed into this class.
             //   2. Fix any analyzer warnings on this class about missing mixins.
-            @State()
             class $publicStateClassName = UiState with ADifferentStateClassMixin, ${publicStateClassName}Mixin;
     
             $statefulComponentDecl
@@ -1366,10 +1370,10 @@ void main() {
                 int bar;
               }
 
+              @Props()
               // FIXME:
               //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
               //   2. Fix any analyzer warnings on this class about missing mixins.
-              @Props()
               class $publicPropsClassName = UiProps with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin;
 
               $componentDecl
@@ -1422,10 +1426,10 @@ void main() {
                   int bar;
                 }
 
+                @AbstractProps()
                 // FIXME:
                 //   1. Ensure that all mixins used by SomeAbstractPropsClass are also mixed into this class.
                 //   2. Fix any analyzer warnings on this class about missing mixins.
-                @AbstractProps()
                 abstract class AbstractBlockProps<A extends Something> implements
                         SomeAbstractPropsClass<A>,
                         AbstractBlockPropsMixin<A>,
@@ -1478,10 +1482,10 @@ void main() {
                 expectedPatchCount: 2,
                 input: input,
                 expectedOutput: r'''
+                @AbstractProps()
                 // FIXME:
                 //   1. Ensure that all mixins used by SomeAbstractPropsClass are also mixed into this class.
                 //   2. Fix any analyzer warnings on this class about missing mixins.
-                @AbstractProps()
                 abstract class AbstractBlockProps<A extends Something> implements
                         SomeAbstractPropsClass<A>,
                         LayoutPropsMixin,
@@ -1541,10 +1545,10 @@ void main() {
                   int bar;
                 }
 
+                @AbstractProps()
                 // FIXME:
                 //   1. Ensure that all mixins used by AbstractGraphFormProps are also mixed into this class.
                 //   2. Fix any analyzer warnings on this class about missing mixins.
-                @AbstractProps()
                 abstract class AbstractBreadcrumbPathProps 
                     implements
                         AbstractGraphFormProps,
@@ -1591,11 +1595,11 @@ void main() {
                 expectedOutput: r'''
                 @PropsMixin()
                 abstract class BreadcrumbPathPropsMixin {}
-                  
+
+                @AbstractProps()
                 // FIXME:
                 //   1. Ensure that all mixins used by AbstractGraphFormProps are also mixed into this class.
                 //   2. Fix any analyzer warnings on this class about missing mixins.
-                @AbstractProps()
                 abstract class AbstractBreadcrumbPathProps 
                     implements 
                         AbstractGraphFormProps, 
@@ -1650,10 +1654,10 @@ void main() {
                   int bar;
                 }
 
+                @Props()
                 // FIXME:
                 //   1. Ensure that all mixins used by SomeAbstractPropsClass are also mixed into this class.
                 //   2. Fix any analyzer warnings on this class about missing mixins.
-                @Props()
                 class $publicPropsClassName = UiProps 
                     with SomeAbstractPropsClassMixin, ${publicPropsClassName}Mixin
                     implements SomeAbstractPropsClass, SomeInterface;
@@ -1702,10 +1706,10 @@ void main() {
                 expectedOutput: '''
                 $factoryDecl
 
+                @Props()
                 // FIXME:
                 //   1. Ensure that all mixins used by SomeAbstractPropsClass are also mixed into this class.
                 //   2. Fix any analyzer warnings on this class about missing mixins.
-                @Props()
                 class $publicPropsClassName extends UiProps implements SomeAbstractPropsClass, SomeInterface {}
 
                 @Component2()
@@ -2165,10 +2169,10 @@ void main() {
             int bar;
           }
 
+          @Props()
           // FIXME:
           //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
           //   2. Fix any analyzer warnings on this class about missing mixins.
-          @Props()
           class $publicPropsClassName = UiProps 
               with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin, AMixin, AnotherMixin;
 
@@ -2178,10 +2182,10 @@ void main() {
             int bar;
           }
 
+          @State()
           // FIXME:
           //   1. Ensure that all mixins used by ADifferentStateClass are also mixed into this class.
           //   2. Fix any analyzer warnings on this class about missing mixins.
-          @State()
           class $publicStateClassName = UiState 
               with ADifferentStateClass, ${publicStateClassName}Mixin, AStateMixin, AnotherStateMixin;
 
@@ -2239,10 +2243,10 @@ void main() {
                 int bar;
               }
 
+              @Props()
               // FIXME:
               //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
               //   2. Fix any analyzer warnings on this class about missing mixins.
-              @Props()
               class $publicPropsClassName = UiProps with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin;
 
               $componentDecl
@@ -2285,10 +2289,10 @@ void main() {
                 String baz;
               }
 
+              @Props()
               // FIXME:
               //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
               //   2. Fix any analyzer warnings on this class about missing mixins.
-              @Props()
               class $publicPropsClassName = UiProps with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin;
 
               $componentDecl
@@ -2327,10 +2331,10 @@ void main() {
               expectedOutput: '''
               $factoryDecl
 
+              @Props()
               // FIXME:
               //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
               //   2. Fix any analyzer warnings on this class about missing mixins.
-              @Props()
               class $publicPropsClassName = UiProps with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin;
 
               $componentDecl
@@ -2360,10 +2364,10 @@ void main() {
               expectedOutput: '''
               $factoryDecl
 
+              @Props()
               // FIXME:
               //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
               //   2. Fix any analyzer warnings on this class about missing mixins.
-              @Props()
               class $publicPropsClassName extends UiProps with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin {
                 // FIXME: Everything in this body needs to be moved to the body of ${publicPropsClassName}Mixin.
                 // Once that is done, the body can be removed, and `extends` can be replaced with `=`.

--- a/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
@@ -1310,25 +1310,25 @@ void main() {
           group('that is abstract', () {
             test('with members of its own', () {
               const input = r'''
-              @AbstractProps()
-              abstract class _$AbstractBlockProps extends SomeAbstractPropsClass
-                  with
-                      LayoutPropsMixin,
-                      // ignore: mixin_of_non_class, undefined_class
-                      $LayoutPropsMixin,
-                      BlockPropsMixin,
-                      // ignore: mixin_of_non_class, undefined_class
-                      $BlockPropsMixin
-                  implements
-                      BlockClassHelperMapView {
-                String foo;
-                int bar;
-              }
-
-              @AbstractComponent2()
-              abstract class AbstractBlockComponent<T extends AbstractBlockProps> extends UiComponent2<T>
-                  with LayoutMixin<T>, BlockMixin<T> {}
-            ''';
+                  @AbstractProps()
+                  abstract class _$AbstractBlockProps extends SomeAbstractPropsClass
+                      with
+                          LayoutPropsMixin,
+                          // ignore: mixin_of_non_class, undefined_class
+                          $LayoutPropsMixin,
+                          BlockPropsMixin,
+                          // ignore: mixin_of_non_class, undefined_class
+                          $BlockPropsMixin
+                      implements
+                          BlockClassHelperMapView {
+                    String foo;
+                    int bar;
+                  }
+    
+                  @AbstractComponent2()
+                  abstract class AbstractBlockComponent<T extends AbstractBlockProps> extends UiComponent2<T>
+                      with LayoutMixin<T>, BlockMixin<T> {}
+                ''';
 
               // When it is run the first time, nothing should happen since
               // we don't know if the mixin(s) are external or not.
@@ -1375,22 +1375,22 @@ void main() {
 
             test('with no members', () {
               const input = r'''
-              @AbstractProps()
-              abstract class _$AbstractBlockProps extends SomeAbstractPropsClass
-                  with
-                      LayoutPropsMixin,
-                      // ignore: mixin_of_non_class, undefined_class
-                      $LayoutPropsMixin,
-                      BlockPropsMixin,
-                      // ignore: mixin_of_non_class, undefined_class
-                      $BlockPropsMixin
-                  implements
-                      BlockClassHelperMapView {}
-
-              @AbstractComponent2()
-              abstract class AbstractBlockComponent<T extends AbstractBlockProps> extends UiComponent2<T>
-                  with LayoutMixin<T>, BlockMixin<T> {}
-            ''';
+                  @AbstractProps()
+                  abstract class _$AbstractBlockProps extends SomeAbstractPropsClass
+                      with
+                          LayoutPropsMixin,
+                          // ignore: mixin_of_non_class, undefined_class
+                          $LayoutPropsMixin,
+                          BlockPropsMixin,
+                          // ignore: mixin_of_non_class, undefined_class
+                          $BlockPropsMixin
+                      implements
+                          BlockClassHelperMapView {}
+    
+                  @AbstractComponent2()
+                  abstract class AbstractBlockComponent<T extends AbstractBlockProps> extends UiComponent2<T>
+                      with LayoutMixin<T>, BlockMixin<T> {}
+                ''';
 
               // When it is run the first time, nothing should happen since
               // we don't know if the mixin(s) are external or not.

--- a/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
@@ -1786,6 +1786,47 @@ void main() {
           });
         });
 
+        test('that extends from UiProps, but uses a "reserved" mixin', () {
+          const input = '''
+              $factoryDecl
+    
+              @Props()
+              class $propsClassName extends UiProps
+                  with DomPropsMixin,
+                       // ignore: mixin_of_non_class, undefined_class
+                       \$DomPropsMixin {
+                String foo;
+                int bar;
+              }
+    
+              $componentDecl
+            ''';
+
+          testSuggestor()(
+            expectedPatchCount: 6,
+            input: input,
+            expectedOutput: '''
+            $factoryDecl
+
+            @Props()
+            mixin ${publicPropsClassName}Mixin on UiProps {
+              String foo;
+              int bar;
+            }
+
+            @Props()
+            class $publicPropsClassName = UiProps
+                with ${publicPropsClassName}Mixin, DomPropsMixin;
+
+            $componentDecl
+          ''',
+          );
+
+          expect(converter.visitedNames, {
+            publicPropsClassName: '${publicPropsClassName}Mixin',
+          });
+        });
+
         group('that extends from UiProps, uses mixins, implements interfaces',
             () {
           test('and is not abstract', () {

--- a/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
@@ -1427,9 +1427,6 @@ void main() {
                 }
 
                 @AbstractProps()
-                // FIXME:
-                //   1. Ensure that all mixins used by SomeAbstractPropsClass are also mixed into this class.
-                //   2. Fix any analyzer warnings on this class about missing mixins.
                 abstract class AbstractBlockProps<A extends Something> implements
                         SomeAbstractPropsClass<A>,
                         AbstractBlockPropsMixin<A>,
@@ -1483,9 +1480,6 @@ void main() {
                 input: input,
                 expectedOutput: r'''
                 @AbstractProps()
-                // FIXME:
-                //   1. Ensure that all mixins used by SomeAbstractPropsClass are also mixed into this class.
-                //   2. Fix any analyzer warnings on this class about missing mixins.
                 abstract class AbstractBlockProps<A extends Something> implements
                         SomeAbstractPropsClass<A>,
                         LayoutPropsMixin,
@@ -1546,9 +1540,6 @@ void main() {
                 }
 
                 @AbstractProps()
-                // FIXME:
-                //   1. Ensure that all mixins used by AbstractGraphFormProps are also mixed into this class.
-                //   2. Fix any analyzer warnings on this class about missing mixins.
                 abstract class AbstractBreadcrumbPathProps 
                     implements
                         AbstractGraphFormProps,
@@ -1597,9 +1588,6 @@ void main() {
                 abstract class BreadcrumbPathPropsMixin {}
 
                 @AbstractProps()
-                // FIXME:
-                //   1. Ensure that all mixins used by AbstractGraphFormProps are also mixed into this class.
-                //   2. Fix any analyzer warnings on this class about missing mixins.
                 abstract class AbstractBreadcrumbPathProps 
                     implements 
                         AbstractGraphFormProps, 

--- a/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
@@ -328,11 +328,12 @@ void main() {
             // Run it a third time - this time simulating `--convert-classes-with-external-superclasses`
             // being set - which allows conversion of external superclasses
             testSuggestor(convertClassesWithExternalSuperclass: true)(
-              expectedPatchCount: 8,
+              expectedPatchCount: 7,
               input: expectedOutputWithExternalSuperclassReasonComment,
               expectedOutput: '''
               $factoryDecl
   
+              @Props()
               mixin ${publicPropsClassName}Mixin on UiProps {
                 String foo;
                 int bar;
@@ -375,7 +376,7 @@ void main() {
           // Run it a second time - this time simulating `--convert-classes-with-external-superclasses`
           // being set - which allows conversion of external superclasses
           testSuggestor(convertClassesWithExternalSuperclass: true)(
-            expectedPatchCount: 7,
+            expectedPatchCount: 6,
             input: '''
             $factoryDecl
 
@@ -390,6 +391,7 @@ void main() {
             expectedOutput: '''
               $factoryDecl
   
+              @Props()
               mixin ${publicPropsClassName}Mixin on UiProps {
                 String foo;
                 int bar;
@@ -512,11 +514,12 @@ void main() {
             // Run it a third time - this time simulating `--convert-classes-with-external-superclasses`
             // being set - which allows conversion of external superclasses
             testSuggestor(convertClassesWithExternalSuperclass: true)(
-              expectedPatchCount: 9,
+              expectedPatchCount: 8,
               input: expectedOutputWithExternalSuperclassReasonComment,
               expectedOutput: '''
               $factoryDecl
   
+              @Props()
               mixin ${publicPropsClassName}Mixin on UiProps {
                 String foo;
                 int bar;
@@ -559,11 +562,12 @@ void main() {
           // Run it a second time - this time simulating `--convert-classes-with-external-superclasses`
           // being set - which allows conversion of external superclasses
           testSuggestor(convertClassesWithExternalSuperclass: true)(
-            expectedPatchCount: 8,
+            expectedPatchCount: 7,
             input: input,
             expectedOutput: '''
               $factoryDecl
   
+              @Props()
               mixin ${publicPropsClassName}Mixin on UiProps {
                 String foo;
                 int bar;
@@ -667,11 +671,12 @@ void main() {
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
             },
           )(
-            expectedPatchCount: 8,
+            expectedPatchCount: 7,
             input: expectedOutputWithUnMigratedSuperclassReasonComment,
             expectedOutput: '''
             $factoryDecl
             
+            @Props()
             mixin ${publicPropsClassName}Mixin on UiProps {
               String foo;
               int bar;
@@ -768,11 +773,12 @@ void main() {
               // Run it a third time - this time simulating `--convert-classes-with-external-superclasses`
               // being set - which allows conversion of external mixins
               testSuggestor(convertClassesWithExternalSuperclass: true)(
-                expectedPatchCount: 8,
+                expectedPatchCount: 7,
                 input: expectedOutputWithExternalMixinReasonComment,
                 expectedOutput: '''
                 $factoryDecl
     
+                @Props()
                 mixin ${publicPropsClassName}Mixin on UiProps {
                   String foo;
                   int bar;
@@ -876,11 +882,12 @@ void main() {
               // Run it a third time - this time simulating `--convert-classes-with-external-superclasses`
               // being set - which allows conversion of external mixins
               testSuggestor(convertClassesWithExternalSuperclass: true)(
-                expectedPatchCount: 8,
+                expectedPatchCount: 7,
                 input: expectedOutputWithExternalMixinReasonComment,
                 expectedOutput: '''
                 $factoryDecl
     
+                @Props()
                 mixin ${publicPropsClassName}Mixin on UiProps {
                   String foo;
                   int bar;
@@ -940,6 +947,7 @@ void main() {
         const expectedOutput = '''
             $factoryDecl
     
+            @Props()
             mixin ${publicPropsClassName}Mixin on UiProps {
               String foo;
               int bar;
@@ -951,6 +959,7 @@ void main() {
             @Props()
             class $publicPropsClassName = UiProps with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin;
     
+            @State()
             mixin ${publicStateClassName}Mixin on UiState {
               String foo;
               int bar;
@@ -973,7 +982,7 @@ void main() {
               'ADifferentStateClass': 'ADifferentStateClassMixin',
             },
           )(
-            expectedPatchCount: 14,
+            expectedPatchCount: 12,
             input: input,
             expectedOutput: expectedOutput,
           );
@@ -1001,7 +1010,7 @@ void main() {
               'ADifferentStateClass': 'ADifferentStateClassMixin',
             },
           )(
-            expectedPatchCount: 14,
+            expectedPatchCount: 12,
             input: input,
             expectedOutput: expectedOutput,
           );
@@ -1039,6 +1048,7 @@ void main() {
         const expectedOutput = '''
             $factoryDecl
     
+            @Props()
             mixin ${publicPropsClassName}Mixin on UiProps {
               String foo;
               int bar;
@@ -1047,6 +1057,7 @@ void main() {
             @Props()
             class $publicPropsClassName = UiProps with ${publicPropsClassName}Mixin, AMixin, AnotherMixin;
 
+            @State()
             mixin ${publicStateClassName}Mixin on UiState {
               String foo;
               int bar;
@@ -1068,7 +1079,7 @@ void main() {
               'AnotherStateMixin': 'AnotherStateMixin',
             },
           )(
-            expectedPatchCount: 14,
+            expectedPatchCount: 12,
             input: input,
             expectedOutput: expectedOutput,
           );
@@ -1095,7 +1106,7 @@ void main() {
               'AnotherStateMixin': 'AnotherStateMixin',
             },
           )(
-            expectedPatchCount: 14,
+            expectedPatchCount: 12,
             input: input,
             expectedOutput: expectedOutput,
           );
@@ -1136,11 +1147,12 @@ void main() {
                 ''';
 
             testSuggestor()(
-              expectedPatchCount: 7,
+              expectedPatchCount: 6,
               input: input,
               expectedOutput: '''
               $factoryDecl
   
+              @Props()
               mixin ${publicPropsClassName}Mixin on UiProps {
                 String foo;
                 int bar;
@@ -1193,6 +1205,7 @@ void main() {
             const expectedOutput = '''
                 $factoryDecl
     
+                @Props()
                 mixin ${publicPropsClassName}Mixin on UiProps {
                   String foo;
                   int bar;
@@ -1221,7 +1234,7 @@ void main() {
               testSuggestor(visitedClassNames: {
                 'SomePropsMixin': 'SomePropsMixin',
               })(
-                expectedPatchCount: 8,
+                expectedPatchCount: 7,
                 input: input,
                 expectedOutput: expectedOutput,
               );
@@ -1239,7 +1252,7 @@ void main() {
               testSuggestor(visitedClassNames: {
                 'SomePropsMixin': 'SomePropsMixin',
               })(
-                expectedPatchCount: 8,
+                expectedPatchCount: 7,
                 input: input,
                 expectedOutput: expectedOutput,
               );
@@ -1257,7 +1270,7 @@ void main() {
             testSuggestor(visitedClassNames: {
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
             })(
-              expectedPatchCount: 7,
+              expectedPatchCount: 6,
               input: '''
               $factoryDecl
 
@@ -1272,6 +1285,7 @@ void main() {
               expectedOutput: '''
               $factoryDecl
 
+              @Props()
               mixin ${publicPropsClassName}Mixin on UiProps {
                 String foo;
                 int bar;
@@ -1324,9 +1338,10 @@ void main() {
                 'LayoutPropsMixin': 'LayoutPropsMixin',
                 'BlockPropsMixin': null,
               })(
-                expectedPatchCount: 9,
+                expectedPatchCount: 8,
                 input: input,
                 expectedOutput: r'''
+                @AbstractProps()
                 mixin AbstractBlockPropsMixin on UiProps implements BlockClassHelperMapView {
                   String foo;
                   int bar;
@@ -1419,7 +1434,7 @@ void main() {
               testSuggestor(visitedClassNames: {
                 'SomeAbstractPropsClass': 'SomeAbstractPropsClassMixin',
               })(
-                expectedPatchCount: 7,
+                expectedPatchCount: 6,
                 input: '''
                 $factoryDecl
 
@@ -1443,6 +1458,7 @@ void main() {
                 expectedOutput: '''
                 $factoryDecl
 
+                @Props()
                 mixin ${publicPropsClassName}Mixin on UiProps implements SomeInterface {
                   String foo;
                   int bar;
@@ -1553,11 +1569,12 @@ void main() {
             'ConvertedMixin': 'ConvertedMixin',
             'UnconvertedMixin': null,
           })(
-            expectedPatchCount: 7,
+            expectedPatchCount: 6,
             input: input,
             expectedOutput: '''
             $factoryDecl
 
+            @Props()
             mixin ${publicPropsClassName}Mixin on UiProps {
               String foo;
               int bar;
@@ -1585,7 +1602,7 @@ void main() {
             testSuggestor(visitedClassNames: {
               'ConvertedMixin': 'ConvertedMixin',
             })(
-              expectedPatchCount: 7,
+              expectedPatchCount: 6,
               input: '''
               $factoryDecl
 
@@ -1600,6 +1617,7 @@ void main() {
               expectedOutput: '''
               $factoryDecl
 
+              @Props()
               mixin ${publicPropsClassName}Mixin on UiProps implements SomeInterface, SomeOtherInterface {
                 String foo;
                 int bar;
@@ -1649,9 +1667,10 @@ void main() {
                 'LayoutPropsMixin': 'LayoutPropsMixin',
                 'BlockPropsMixin': null,
               })(
-                expectedPatchCount: 8,
+                expectedPatchCount: 7,
                 input: input,
                 expectedOutput: r'''
+                @AbstractProps()
                 mixin AbstractBlockPropsMixin on UiProps implements BlockClassHelperMapView {
                   String foo;
                   int bar;
@@ -1851,11 +1870,12 @@ void main() {
           'AnotherStateMixin': 'AnotherStateMixin',
           'ADifferentStateClass': 'ADifferentStateClass',
         })(
-          expectedPatchCount: 16,
+          expectedPatchCount: 14,
           input: input,
           expectedOutput: '''
           $factoryDecl
 
+          @Props()
           mixin ${publicPropsClassName}Mixin on UiProps {
             String foo;
             int bar;
@@ -1868,6 +1888,7 @@ void main() {
           class $publicPropsClassName = UiProps 
               with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin, AMixin, AnotherMixin;
 
+          @State()
           mixin ${publicStateClassName}Mixin on UiState {
             String foo;
             int bar;

--- a/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
@@ -270,12 +270,11 @@ void main() {
             // Run it a third time - this time simulating `--convert-classes-with-external-superclasses`
             // being set - which allows conversion of external superclasses
             testSuggestor(convertClassesWithExternalSuperclass: true)(
-              expectedPatchCount: 7,
+              expectedPatchCount: 8,
               input: expectedOutputWithExternalSuperclassReasonComment,
               expectedOutput: '''
               $factoryDecl
   
-              @Props()
               mixin ${publicPropsClassName}Mixin on UiProps {
                 String foo;
                 int bar;
@@ -291,6 +290,7 @@ void main() {
               //
               //      If it is not deprecated, something most likely went wrong during the migration of the 
               //      library that contains it. 
+              @Props()
               class $publicPropsClassName = UiProps with $externalSuperclassName, ${publicPropsClassName}Mixin;
   
               $componentDecl
@@ -317,7 +317,7 @@ void main() {
           // Run it a second time - this time simulating `--convert-classes-with-external-superclasses`
           // being set - which allows conversion of external superclasses
           testSuggestor(convertClassesWithExternalSuperclass: true)(
-            expectedPatchCount: 6,
+            expectedPatchCount: 7,
             input: '''
             $factoryDecl
 
@@ -332,7 +332,6 @@ void main() {
             expectedOutput: '''
               $factoryDecl
   
-              @Props()
               mixin ${publicPropsClassName}Mixin on UiProps {
                 String foo;
                 int bar;
@@ -348,6 +347,7 @@ void main() {
               //
               //      If it is not deprecated, something most likely went wrong during the migration of the 
               //      library that contains it. 
+              @Props()
               class $publicPropsClassName = UiProps with $externalSuperclassName, ${publicPropsClassName}Mixin;
   
               $componentDecl
@@ -454,12 +454,11 @@ void main() {
             // Run it a third time - this time simulating `--convert-classes-with-external-superclasses`
             // being set - which allows conversion of external superclasses
             testSuggestor(convertClassesWithExternalSuperclass: true)(
-              expectedPatchCount: 8,
+              expectedPatchCount: 9,
               input: expectedOutputWithExternalSuperclassReasonComment,
               expectedOutput: '''
               $factoryDecl
   
-              @Props()
               mixin ${publicPropsClassName}Mixin on UiProps {
                 String foo;
                 int bar;
@@ -475,6 +474,7 @@ void main() {
               //
               //      If they are not deprecated, something most likely went wrong during the migration of the 
               //      library that contains them. 
+              @Props()
               class $publicPropsClassName = UiProps with $externalSuperclassName, ${publicPropsClassName}Mixin, $externalMixinName;
   
               $componentDecl
@@ -501,12 +501,11 @@ void main() {
           // Run it a second time - this time simulating `--convert-classes-with-external-superclasses`
           // being set - which allows conversion of external superclasses
           testSuggestor(convertClassesWithExternalSuperclass: true)(
-            expectedPatchCount: 7,
+            expectedPatchCount: 8,
             input: input,
             expectedOutput: '''
               $factoryDecl
   
-              @Props()
               mixin ${publicPropsClassName}Mixin on UiProps {
                 String foo;
                 int bar;
@@ -522,6 +521,7 @@ void main() {
               //
               //      If they are not deprecated, something most likely went wrong during the migration of the 
               //      library that contains them. 
+              @Props()
               class $publicPropsClassName = UiProps with $externalSuperclassName, ${publicPropsClassName}Mixin, $externalMixinName;
   
               $componentDecl
@@ -609,12 +609,11 @@ void main() {
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
             },
           )(
-            expectedPatchCount: 7,
+            expectedPatchCount: 8,
             input: expectedOutputWithUnMigratedSuperclassReasonComment,
             expectedOutput: '''
             $factoryDecl
             
-            @Props()
             mixin ${publicPropsClassName}Mixin on UiProps {
               String foo;
               int bar;
@@ -623,6 +622,7 @@ void main() {
             // FIXME:
             //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
             //   2. Fix any analyzer warnings on this class about missing mixins.
+            @Props()
             class $publicPropsClassName = UiProps with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin;
     
             $componentDecl
@@ -710,12 +710,11 @@ void main() {
               // Run it a third time - this time simulating `--convert-classes-with-external-superclasses`
               // being set - which allows conversion of external mixins
               testSuggestor(convertClassesWithExternalSuperclass: true)(
-                expectedPatchCount: 7,
+                expectedPatchCount: 8,
                 input: expectedOutputWithExternalMixinReasonComment,
                 expectedOutput: '''
                 $factoryDecl
     
-                @Props()
                 mixin ${publicPropsClassName}Mixin on UiProps {
                   String foo;
                   int bar;
@@ -729,6 +728,7 @@ void main() {
                 //
                 //      If it is not deprecated, something most likely went wrong during the migration of the 
                 //      library that contains it. 
+                @Props()
                 class $publicPropsClassName = UiProps with ${publicPropsClassName}Mixin, $externalMixinName;
     
                 $componentDecl
@@ -818,12 +818,11 @@ void main() {
               // Run it a third time - this time simulating `--convert-classes-with-external-superclasses`
               // being set - which allows conversion of external mixins
               testSuggestor(convertClassesWithExternalSuperclass: true)(
-                expectedPatchCount: 7,
+                expectedPatchCount: 8,
                 input: expectedOutputWithExternalMixinReasonComment,
                 expectedOutput: '''
                 $factoryDecl
     
-                @Props()
                 mixin ${publicPropsClassName}Mixin on UiProps {
                   String foo;
                   int bar;
@@ -837,6 +836,7 @@ void main() {
                 //
                 //      If they are not deprecated, something most likely went wrong during the migration of the 
                 //      library that contains them. 
+                @Props()
                 class $publicPropsClassName = UiProps with ${publicPropsClassName}Mixin, $externalMixinNames;
     
                 $componentDecl
@@ -882,7 +882,6 @@ void main() {
         const expectedOutput = '''
             $factoryDecl
     
-            @Props()
             mixin ${publicPropsClassName}Mixin on UiProps {
               String foo;
               int bar;
@@ -891,9 +890,9 @@ void main() {
             // FIXME:
             //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
             //   2. Fix any analyzer warnings on this class about missing mixins.
+            @Props()
             class $publicPropsClassName = UiProps with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin;
     
-            @State()
             mixin ${publicStateClassName}Mixin on UiState {
               String foo;
               int bar;
@@ -902,6 +901,7 @@ void main() {
             // FIXME:
             //   1. Ensure that all mixins used by ADifferentStateClass are also mixed into this class.
             //   2. Fix any analyzer warnings on this class about missing mixins.
+            @State()
             class $publicStateClassName = UiState with ADifferentStateClassMixin, ${publicStateClassName}Mixin;
     
             $statefulComponentDecl
@@ -915,7 +915,7 @@ void main() {
               'ADifferentStateClass': 'ADifferentStateClassMixin',
             },
           )(
-            expectedPatchCount: 12,
+            expectedPatchCount: 14,
             input: input,
             expectedOutput: expectedOutput,
           );
@@ -943,7 +943,7 @@ void main() {
               'ADifferentStateClass': 'ADifferentStateClassMixin',
             },
           )(
-            expectedPatchCount: 12,
+            expectedPatchCount: 14,
             input: input,
             expectedOutput: expectedOutput,
           );
@@ -981,20 +981,20 @@ void main() {
         const expectedOutput = '''
             $factoryDecl
     
-            @Props()
             mixin ${publicPropsClassName}Mixin on UiProps {
               String foo;
               int bar;
             }
-    
+
+            @Props()
             class $publicPropsClassName = UiProps with ${publicPropsClassName}Mixin, AMixin, AnotherMixin;
-    
-            @State()
+
             mixin ${publicStateClassName}Mixin on UiState {
               String foo;
               int bar;
             }
     
+            @State()
             class $publicStateClassName = UiState with ${publicStateClassName}Mixin, AStateMixin, AnotherStateMixin;
     
             $statefulComponentDecl
@@ -1010,7 +1010,7 @@ void main() {
               'AnotherStateMixin': 'AnotherStateMixin',
             },
           )(
-            expectedPatchCount: 12,
+            expectedPatchCount: 14,
             input: input,
             expectedOutput: expectedOutput,
           );
@@ -1037,7 +1037,7 @@ void main() {
               'AnotherStateMixin': 'AnotherStateMixin',
             },
           )(
-            expectedPatchCount: 12,
+            expectedPatchCount: 14,
             input: input,
             expectedOutput: expectedOutput,
           );
@@ -1078,17 +1078,17 @@ void main() {
                 ''';
 
             testSuggestor()(
-              expectedPatchCount: 6,
+              expectedPatchCount: 7,
               input: input,
               expectedOutput: '''
               $factoryDecl
   
-              @Props()
               mixin ${publicPropsClassName}Mixin on UiProps {
                 String foo;
                 int bar;
               }
   
+              @Props()
               class $publicPropsClassName = UiProps 
                   with FluxUiPropsMixin<SomeActions, SomeStore>, ${publicPropsClassName}Mixin;
   
@@ -1135,12 +1135,12 @@ void main() {
             const expectedOutput = '''
                 $factoryDecl
     
-                @Props()
                 mixin ${publicPropsClassName}Mixin on UiProps {
                   String foo;
                   int bar;
                 }
-    
+
+                @Props()    
                 class $publicPropsClassName = UiProps 
                     with 
                         FluxUiPropsMixin<SomeActions, SomeStore>, 
@@ -1163,7 +1163,7 @@ void main() {
               testSuggestor(visitedClassNames: {
                 'SomePropsMixin': 'SomePropsMixin',
               })(
-                expectedPatchCount: 7,
+                expectedPatchCount: 8,
                 input: input,
                 expectedOutput: expectedOutput,
               );
@@ -1181,7 +1181,7 @@ void main() {
               testSuggestor(visitedClassNames: {
                 'SomePropsMixin': 'SomePropsMixin',
               })(
-                expectedPatchCount: 7,
+                expectedPatchCount: 8,
                 input: input,
                 expectedOutput: expectedOutput,
               );
@@ -1199,7 +1199,7 @@ void main() {
             testSuggestor(visitedClassNames: {
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
             })(
-              expectedPatchCount: 6,
+              expectedPatchCount: 7,
               input: '''
               $factoryDecl
 
@@ -1214,7 +1214,6 @@ void main() {
               expectedOutput: '''
               $factoryDecl
 
-              @Props()
               mixin ${publicPropsClassName}Mixin on UiProps {
                 String foo;
                 int bar;
@@ -1223,6 +1222,7 @@ void main() {
               // FIXME:
               //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
               //   2. Fix any analyzer warnings on this class about missing mixins.
+              @Props()
               class $publicPropsClassName = UiProps with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin;
 
               $componentDecl
@@ -1266,10 +1266,9 @@ void main() {
                 'LayoutPropsMixin': 'LayoutPropsMixin',
                 'BlockPropsMixin': null,
               })(
-                expectedPatchCount: 8,
+                expectedPatchCount: 9,
                 input: input,
                 expectedOutput: r'''
-                @AbstractProps()
                 mixin AbstractBlockPropsMixin on UiProps implements BlockClassHelperMapView {
                   String foo;
                   int bar;
@@ -1278,6 +1277,7 @@ void main() {
                 // FIXME:
                 //   1. Ensure that all mixins used by SomeAbstractPropsClass are also mixed into this class.
                 //   2. Fix any analyzer warnings on this class about missing mixins.
+                @AbstractProps()
                 abstract class AbstractBlockProps implements
                         SomeAbstractPropsClass,
                         AbstractBlockPropsMixin,
@@ -1333,6 +1333,7 @@ void main() {
                 // FIXME:
                 //   1. Ensure that all mixins used by SomeAbstractPropsClass are also mixed into this class.
                 //   2. Fix any analyzer warnings on this class about missing mixins.
+                @AbstractProps()
                 abstract class AbstractBlockProps implements
                         SomeAbstractPropsClass,
                         LayoutPropsMixin,
@@ -1360,7 +1361,7 @@ void main() {
               testSuggestor(visitedClassNames: {
                 'SomeAbstractPropsClass': 'SomeAbstractPropsClassMixin',
               })(
-                expectedPatchCount: 6,
+                expectedPatchCount: 7,
                 input: '''
                 $factoryDecl
 
@@ -1384,7 +1385,6 @@ void main() {
                 expectedOutput: '''
                 $factoryDecl
 
-                @Props()
                 mixin ${publicPropsClassName}Mixin on UiProps implements SomeInterface {
                   String foo;
                   int bar;
@@ -1393,6 +1393,7 @@ void main() {
                 // FIXME:
                 //   1. Ensure that all mixins used by SomeAbstractPropsClass are also mixed into this class.
                 //   2. Fix any analyzer warnings on this class about missing mixins.
+                @Props()
                 class $publicPropsClassName = UiProps 
                     with SomeAbstractPropsClassMixin, ${publicPropsClassName}Mixin
                     implements SomeAbstractPropsClass, SomeInterface;
@@ -1444,6 +1445,7 @@ void main() {
                 // FIXME:
                 //   1. Ensure that all mixins used by SomeAbstractPropsClass are also mixed into this class.
                 //   2. Fix any analyzer warnings on this class about missing mixins.
+                @Props()
                 class $publicPropsClassName extends UiProps implements SomeAbstractPropsClass, SomeInterface {}
 
                 @Component2()
@@ -1493,17 +1495,17 @@ void main() {
             'ConvertedMixin': 'ConvertedMixin',
             'UnconvertedMixin': null,
           })(
-            expectedPatchCount: 6,
+            expectedPatchCount: 7,
             input: input,
             expectedOutput: '''
             $factoryDecl
 
-            @Props()
             mixin ${publicPropsClassName}Mixin on UiProps {
               String foo;
               int bar;
             }
 
+            @Props()
             class $publicPropsClassName = UiProps
                 with ${publicPropsClassName}Mixin, ConvertedMixin, UnconvertedMixin, // ignore: mixin_of_non_class, undefined_class
                 \$UnconvertedMixin;
@@ -1525,7 +1527,7 @@ void main() {
             testSuggestor(visitedClassNames: {
               'ConvertedMixin': 'ConvertedMixin',
             })(
-              expectedPatchCount: 6,
+              expectedPatchCount: 7,
               input: '''
               $factoryDecl
 
@@ -1540,12 +1542,12 @@ void main() {
               expectedOutput: '''
               $factoryDecl
 
-              @Props()
               mixin ${publicPropsClassName}Mixin on UiProps implements SomeInterface, SomeOtherInterface {
                 String foo;
                 int bar;
               }
 
+              @Props()
               class $publicPropsClassName = UiProps 
                   with ${publicPropsClassName}Mixin, ConvertedMixin implements SomeInterface, SomeOtherInterface;
 
@@ -1589,15 +1591,15 @@ void main() {
                 'LayoutPropsMixin': 'LayoutPropsMixin',
                 'BlockPropsMixin': null,
               })(
-                expectedPatchCount: 7,
+                expectedPatchCount: 8,
                 input: input,
                 expectedOutput: r'''
-                @AbstractProps()
                 mixin AbstractBlockPropsMixin on UiProps implements BlockClassHelperMapView {
                   String foo;
                   int bar;
                 }
 
+                @AbstractProps()
                 abstract class AbstractBlockProps implements
                         AbstractBlockPropsMixin,
                         LayoutPropsMixin,
@@ -1647,6 +1649,7 @@ void main() {
                 expectedPatchCount: 2,
                 input: input,
                 expectedOutput: r'''
+                @AbstractProps()
                 abstract class AbstractBlockProps implements
                         LayoutPropsMixin,
                         BlockPropsMixin, // ignore: mixin_of_non_class, undefined_class
@@ -1699,6 +1702,7 @@ void main() {
                 int bar;
               }
 
+              @Props()
               class $publicPropsClassName = UiProps with ${publicPropsClassName}Mixin;
 
               $componentDecl
@@ -1742,6 +1746,7 @@ void main() {
                 String baz;
               }
 
+              @Props()
               class $publicPropsClassName = UiProps with ${publicPropsClassName}Mixin;
 
               $componentDecl
@@ -1788,12 +1793,11 @@ void main() {
           'AnotherStateMixin': 'AnotherStateMixin',
           'ADifferentStateClass': 'ADifferentStateClass',
         })(
-          expectedPatchCount: 14,
+          expectedPatchCount: 16,
           input: input,
           expectedOutput: '''
           $factoryDecl
 
-          @Props()
           mixin ${publicPropsClassName}Mixin on UiProps {
             String foo;
             int bar;
@@ -1802,10 +1806,10 @@ void main() {
           // FIXME:
           //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
           //   2. Fix any analyzer warnings on this class about missing mixins.
+          @Props()
           class $publicPropsClassName = UiProps 
               with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin, AMixin, AnotherMixin;
 
-          @State()
           mixin ${publicStateClassName}Mixin on UiState {
             String foo;
             int bar;
@@ -1814,6 +1818,7 @@ void main() {
           // FIXME:
           //   1. Ensure that all mixins used by ADifferentStateClass are also mixed into this class.
           //   2. Fix any analyzer warnings on this class about missing mixins.
+          @State()
           class $publicStateClassName = UiState 
               with ADifferentStateClass, ${publicStateClassName}Mixin, AStateMixin, AnotherStateMixin;
 
@@ -1874,6 +1879,7 @@ void main() {
               // FIXME:
               //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
               //   2. Fix any analyzer warnings on this class about missing mixins.
+              @Props()
               class $publicPropsClassName = UiProps with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin;
 
               $componentDecl
@@ -1919,6 +1925,7 @@ void main() {
               // FIXME:
               //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
               //   2. Fix any analyzer warnings on this class about missing mixins.
+              @Props()
               class $publicPropsClassName = UiProps with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin;
 
               $componentDecl
@@ -1960,6 +1967,7 @@ void main() {
               // FIXME:
               //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
               //   2. Fix any analyzer warnings on this class about missing mixins.
+              @Props()
               class $publicPropsClassName = UiProps with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin;
 
               $componentDecl
@@ -1992,6 +2000,7 @@ void main() {
               // FIXME:
               //   1. Ensure that all mixins used by ADifferentPropsClass are also mixed into this class.
               //   2. Fix any analyzer warnings on this class about missing mixins.
+              @Props()
               class $publicPropsClassName extends UiProps with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin {
                 // FIXME: Everything in this body needs to be moved to the body of ${publicPropsClassName}Mixin.
                 // Once that is done, the body can be removed, and `extends` can be replaced with `=`.

--- a/test/boilerplate_suggestors/annotations_remover_test.dart
+++ b/test/boilerplate_suggestors/annotations_remover_test.dart
@@ -24,12 +24,12 @@ main() {
     final testSuggestor = getSuggestorTester(AnnotationsRemover(converter));
 
     tearDown(() {
-      converter.setConvertedClassNames({});
+      converter.setVisitedClassNames({});
     });
 
     group('does not perform a migration', () {
       test('when it encounters an empty file', () {
-        converter.setConvertedClassNames({
+        converter.setVisitedClassNames({
           'FooProps': 'FooProps',
         });
 
@@ -37,7 +37,7 @@ main() {
       });
 
       test('when there are no relevant annotations present', () {
-        converter.setConvertedClassNames({
+        converter.setVisitedClassNames({
           'FooProps': 'FooProps',
         });
 
@@ -55,7 +55,7 @@ main() {
     group('performs a migration when there are relevant annotations present',
         () {
       test('', () {
-        converter.setConvertedClassNames({
+        converter.setVisitedClassNames({
           'AbstractFooProps': 'AbstractFooProps',
           'FooProps': 'FooProps',
           'AbstractFooState': 'AbstractFooState',
@@ -140,7 +140,7 @@ main() {
       });
 
       test('handling class name edge cases', () {
-        converter.setConvertedClassNames({
+        converter.setVisitedClassNames({
           'GraphFormStateWrapperProps': 'GraphFormStateWrapperProps',
           'GraphFormStateWrapperState': 'GraphFormStateWrapperState',
         });
@@ -205,7 +205,7 @@ main() {
       });
 
       test('leaving annotations with arguments in place', () {
-        converter.setConvertedClassNames({
+        converter.setVisitedClassNames({
           'AbstractFooProps': 'AbstractFooProps',
           'FooProps': 'FooProps',
           'AbstractFooState': 'AbstractFooState',

--- a/test/boilerplate_suggestors/annotations_remover_test.dart
+++ b/test/boilerplate_suggestors/annotations_remover_test.dart
@@ -24,12 +24,12 @@ main() {
     final testSuggestor = getSuggestorTester(AnnotationsRemover(converter));
 
     tearDown(() {
-      converter.setVisitedClassNames({});
+      converter.setVisitedNames({});
     });
 
     group('does not perform a migration', () {
       test('when it encounters an empty file', () {
-        converter.setVisitedClassNames({
+        converter.setVisitedNames({
           'FooProps': 'FooProps',
         });
 
@@ -37,7 +37,7 @@ main() {
       });
 
       test('when there are no relevant annotations present', () {
-        converter.setVisitedClassNames({
+        converter.setVisitedNames({
           'FooProps': 'FooProps',
         });
 
@@ -55,8 +55,8 @@ main() {
     group('performs a migration when there are relevant annotations present',
         () {
       test('', () {
-        converter.setVisitedClassNames({
           'AbstractFooProps': 'AbstractFooProps',
+        converter.setVisitedNames({
           'AbstractBarProps': 'AbstractBarProps',
           'FooProps': 'FooProps',
           'AbstractFooState': 'AbstractFooState',
@@ -155,7 +155,7 @@ main() {
       });
 
       test('handling class name edge cases', () {
-        converter.setVisitedClassNames({
+        converter.setVisitedNames({
           'GraphFormStateWrapperProps': 'GraphFormStateWrapperProps',
           'GraphFormStateWrapperState': 'GraphFormStateWrapperState',
         });
@@ -220,9 +220,9 @@ main() {
       });
 
       test('leaving annotations with arguments in place', () {
-        converter.setVisitedClassNames({
           'AbstractFooProps': 'AbstractFooProps',
           'FooProps': 'FooProps',
+        converter.setVisitedNames({
           'AbstractFooState': 'AbstractFooState',
           'FooState': 'FooState',
         });

--- a/test/boilerplate_suggestors/annotations_remover_test.dart
+++ b/test/boilerplate_suggestors/annotations_remover_test.dart
@@ -55,16 +55,16 @@ main() {
     group('performs a migration when there are relevant annotations present',
         () {
       test('', () {
-          'AbstractFooProps': 'AbstractFooProps',
         converter.setVisitedNames({
+          'AbstractFooProps': 'AbstractFooPropsMixin',
           'AbstractBarProps': 'AbstractBarProps',
-          'FooProps': 'FooProps',
+          'FooProps': 'FooPropsMixin',
           'AbstractFooState': 'AbstractFooState',
           'FooState': 'FooState',
         });
 
         testSuggestor(
-          expectedPatchCount: 8,
+          expectedPatchCount: 9,
           input: '''
           @Factory()
           UiFactory<FooProps> Foo =
@@ -72,7 +72,7 @@ main() {
               \$Foo;
     
           @AbstractProps()
-          mixin AbstractFooProps on UiProps {
+          mixin AbstractFooPropsMixin on UiProps {
             bool baz;
           }
           
@@ -82,10 +82,13 @@ main() {
           }
           
           @Props()
-          mixin FooProps on UiProps {
+          mixin FooPropsMixin on UiProps {
             String foo;
             int bar;
           }
+          
+          @Props()
+          class FooProps = UiProps with FooPropsMixin;
           
           @AbstractState()
           mixin AbstractFooState on UiState {
@@ -117,7 +120,7 @@ main() {
               // ignore: undefined_identifier
               \$Foo;
     
-          mixin AbstractFooProps on UiProps {
+          mixin AbstractFooPropsMixin on UiProps {
             bool baz;
           }
           
@@ -125,10 +128,12 @@ main() {
             bool baz;
           }
           
-          mixin FooProps on UiProps {
+          mixin FooPropsMixin on UiProps {
             String foo;
             int bar;
           }
+          
+          class FooProps = UiProps with FooPropsMixin;
           
           mixin AbstractFooState on UiState {
             bool baz;
@@ -220,11 +225,12 @@ main() {
       });
 
       test('leaving annotations with arguments in place', () {
-          'AbstractFooProps': 'AbstractFooProps',
-          'FooProps': 'FooProps',
         converter.setVisitedNames({
+          'AbstractFooProps': 'AbstractFooPropsMixin',
+          'AbstractBarProps': 'AbstractBarProps',
+          'FooProps': 'FooPropsMixin',
           'AbstractFooState': 'AbstractFooState',
-          'FooState': 'FooState',
+          'FooState': 'FooStateMixin',
         });
 
         testSuggestor(
@@ -236,15 +242,23 @@ main() {
               \$Foo;
     
           @AbstractProps(keyNamespace: '')
-          mixin AbstractFooProps on UiProps {
+          mixin AbstractFooPropsMixin on UiProps {
+            bool baz;
+          }
+          
+          @AbstractProps(keyNamespace: '')
+          abstract class AbstractBarProps implements UiProps {
             bool baz;
           }
     
           @Props(keyNamespace: '')
-          mixin FooProps on UiProps {
+          mixin FooPropsMixin on UiProps {
             String foo;
             int bar;
           }
+          
+          @Props(keyNamespace: '')
+          class FooProps = UiProps with FooPropsMixin;
           
           @AbstractState(keyNamespace: '')
           mixin AbstractFooState on UiState {
@@ -274,15 +288,23 @@ main() {
               \$Foo;
     
           @AbstractProps(keyNamespace: '')
-          mixin AbstractFooProps on UiProps {
+          mixin AbstractFooPropsMixin on UiProps {
+            bool baz;
+          }
+          
+          @AbstractProps(keyNamespace: '')
+          abstract class AbstractBarProps implements UiProps {
             bool baz;
           }
     
           @Props(keyNamespace: '')
-          mixin FooProps on UiProps {
+          mixin FooPropsMixin on UiProps {
             String foo;
             int bar;
           }
+          
+          @Props(keyNamespace: '')
+          class FooProps = UiProps with FooPropsMixin;
           
           @AbstractState(keyNamespace: '')
           mixin AbstractFooState on UiState {

--- a/test/boilerplate_suggestors/annotations_remover_test.dart
+++ b/test/boilerplate_suggestors/annotations_remover_test.dart
@@ -57,13 +57,14 @@ main() {
       test('', () {
         converter.setVisitedClassNames({
           'AbstractFooProps': 'AbstractFooProps',
+          'AbstractBarProps': 'AbstractBarProps',
           'FooProps': 'FooProps',
           'AbstractFooState': 'AbstractFooState',
           'FooState': 'FooState',
         });
 
         testSuggestor(
-          expectedPatchCount: 6,
+          expectedPatchCount: 8,
           input: '''
           @Factory()
           UiFactory<FooProps> Foo =
@@ -72,6 +73,11 @@ main() {
     
           @AbstractProps()
           mixin AbstractFooProps on UiProps {
+            bool baz;
+          }
+          
+          @AbstractProps()
+          abstract class AbstractBarProps implements UiProps {
             bool baz;
           }
           
@@ -102,6 +108,9 @@ main() {
               );
             }
           }
+    
+          @AbstractComponent2()
+          abstract class AbstractBarComponent extends UiComponent2<AbstractBarProps> {}
         ''',
           expectedOutput: '''
           UiFactory<FooProps> Foo =
@@ -109,6 +118,10 @@ main() {
               \$Foo;
     
           mixin AbstractFooProps on UiProps {
+            bool baz;
+          }
+          
+          abstract class AbstractBarProps implements UiProps {
             bool baz;
           }
           
@@ -135,6 +148,8 @@ main() {
               );
             }
           }
+
+          abstract class AbstractBarComponent extends UiComponent2<AbstractBarProps> {}
       ''',
         );
       });

--- a/test/boilerplate_suggestors/props_meta_migrator_test.dart
+++ b/test/boilerplate_suggestors/props_meta_migrator_test.dart
@@ -24,12 +24,12 @@ main() {
     final testSuggestor = getSuggestorTester(PropsMetaMigrator(converter));
 
     tearDown(() {
-      converter.setConvertedClassNames({});
+      converter.setVisitedClassNames({});
     });
 
     group('does not perform a migration', () {
       test('when it encounters an empty file', () {
-        converter.setConvertedClassNames({
+        converter.setVisitedClassNames({
           'FooProps': 'FooProps',
         });
 
@@ -37,7 +37,7 @@ main() {
       });
 
       test('when there are no `PropsClass.meta` identifiers', () {
-        converter.setConvertedClassNames({
+        converter.setVisitedClassNames({
           'FooProps': 'FooProps',
         });
 
@@ -56,7 +56,7 @@ main() {
         'performs a migration when there are one or more `PropsClass.meta` identifiers',
         () {
       test('', () {
-        converter.setConvertedClassNames({
+        converter.setVisitedClassNames({
           'FooProps': 'FooProps',
           'BarProps': 'BarPropsMixin',
         });
@@ -127,7 +127,7 @@ main() {
       test(
           'unless the props class is not found within `propsAndStateClassNamesConvertedToNewBoilerplate`',
           () {
-        converter.setConvertedClassNames({
+        converter.setVisitedClassNames({
           'BarProps': 'BarProps',
         });
 
@@ -156,7 +156,7 @@ main() {
       test(
           'unless component class containing the meta usage is not @Component2()',
           () {
-        converter.setConvertedClassNames({
+        converter.setVisitedClassNames({
           'FooProps': 'FooProps',
           'BarProps': 'BarPropsMixin',
         });

--- a/test/boilerplate_suggestors/props_meta_migrator_test.dart
+++ b/test/boilerplate_suggestors/props_meta_migrator_test.dart
@@ -24,12 +24,12 @@ main() {
     final testSuggestor = getSuggestorTester(PropsMetaMigrator(converter));
 
     tearDown(() {
-      converter.setVisitedClassNames({});
+      converter.setVisitedNames({});
     });
 
     group('does not perform a migration', () {
       test('when it encounters an empty file', () {
-        converter.setVisitedClassNames({
+        converter.setVisitedNames({
           'FooProps': 'FooProps',
         });
 
@@ -37,7 +37,7 @@ main() {
       });
 
       test('when there are no `PropsClass.meta` identifiers', () {
-        converter.setVisitedClassNames({
+        converter.setVisitedNames({
           'FooProps': 'FooProps',
         });
 
@@ -56,7 +56,7 @@ main() {
         'performs a migration when there are one or more `PropsClass.meta` identifiers',
         () {
       test('', () {
-        converter.setVisitedClassNames({
+        converter.setVisitedNames({
           'FooProps': 'FooProps',
           'BarProps': 'BarPropsMixin',
         });
@@ -127,7 +127,7 @@ main() {
       test(
           'unless the props class is not found within `propsAndStateClassNamesConvertedToNewBoilerplate`',
           () {
-        converter.setVisitedClassNames({
+        converter.setVisitedNames({
           'BarProps': 'BarProps',
         });
 
@@ -156,7 +156,7 @@ main() {
       test(
           'unless component class containing the meta usage is not @Component2()',
           () {
-        converter.setVisitedClassNames({
+        converter.setVisitedNames({
           'FooProps': 'FooProps',
           'BarProps': 'BarPropsMixin',
         });

--- a/test/boilerplate_suggestors/props_meta_migrator_test.dart
+++ b/test/boilerplate_suggestors/props_meta_migrator_test.dart
@@ -59,18 +59,26 @@ main() {
         converter.setVisitedNames({
           'FooProps': 'FooProps',
           'BarProps': 'BarPropsMixin',
+          'ConvertedPropsMixin': 'ConvertedPropsMixin',
+          'UnconvertedPropsMixin': null,
         });
 
         testSuggestor(
-          expectedPatchCount: 7,
+          expectedPatchCount: 10,
           input: '''
           /// Some doc comment
           @PropsMixin()
-          abstract class FooPropsMixin implements UiProps {
+          mixin ConvertedPropsMixin on UiProps {
+            String foo;
+          }
+          
+          /// Some doc comment
+          @PropsMixin()
+          abstract class UnconvertedPropsMixin implements UiProps {
             // To ensure the codemod regression checking works properly, please keep this
             // field at the top of the class!
             // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-            static const PropsMeta meta = _\$metaForFooPropsMixin;
+            static const PropsMeta meta = _\$metaForUnconvertedPropsMixin;
             
             String foo;
           }
@@ -79,9 +87,16 @@ main() {
           class FooComponent extends UiComponent2<FooProps> {
             static const foo = FooProps.meta;
             static const bar = [FooProps.meta];
+            static const con = ConvertedPropsMixin.meta;
+            static const uncon = UnconvertedPropsMixin.meta;
           
             @override
-            get consumedProps => const [FooProps.meta, BarProps.meta];
+            get consumedProps => const [
+              FooProps.meta, 
+              BarProps.meta, 
+              ConvertedPropsMixin.meta, 
+              UnconvertedPropsMixin.meta,
+            ];
         
             @override
             render() {
@@ -95,11 +110,17 @@ main() {
           expectedOutput: '''
         /// Some doc comment
         @PropsMixin()
-        abstract class FooPropsMixin implements UiProps {
+        mixin ConvertedPropsMixin on UiProps {
+          String foo;
+        }
+        
+        /// Some doc comment
+        @PropsMixin()
+        abstract class UnconvertedPropsMixin implements UiProps {
           // To ensure the codemod regression checking works properly, please keep this
           // field at the top of the class!
           // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-          static const PropsMeta meta = _\$metaForFooPropsMixin;
+          static const PropsMeta meta = _\$metaForUnconvertedPropsMixin;
           
           String foo;
         }
@@ -108,9 +129,16 @@ main() {
         class FooComponent extends UiComponent2<FooProps> {
           static final foo = propsMeta.forMixin(FooProps);
           static final bar = [propsMeta.forMixin(FooProps)];
+          static final con = propsMeta.forMixin(ConvertedPropsMixin);
+          static const uncon = UnconvertedPropsMixin.meta;
         
           @override
-          get consumedProps => [propsMeta.forMixin(FooProps), propsMeta.forMixin(BarPropsMixin)];
+          get consumedProps => [
+            propsMeta.forMixin(FooProps), 
+            propsMeta.forMixin(BarPropsMixin), 
+            propsMeta.forMixin(ConvertedPropsMixin), 
+            UnconvertedPropsMixin.meta,
+          ];
           
           @override
           render() {
@@ -125,7 +153,7 @@ main() {
       });
 
       test(
-          'unless the props class is not found within `propsAndStateClassNamesConvertedToNewBoilerplate`',
+          'unless the props class is not found within `ClassToMixinConverter.visitedNames`',
           () {
         converter.setVisitedNames({
           'BarProps': 'BarProps',

--- a/test/boilerplate_suggestors/props_mixin_migrator_test.dart
+++ b/test/boilerplate_suggestors/props_mixin_migrator_test.dart
@@ -31,7 +31,7 @@ main() {
     });
 
     tearDown(() {
-      converter.setVisitedClassNames({});
+      converter.setVisitedNames({});
     });
 
     group('does not perform a migration', () {
@@ -82,7 +82,7 @@ main() {
             ''',
             );
 
-            expect(converter.visitedClassNames, {
+            expect(converter.visitedNames, {
               'Foo${typeStr}Mixin': 'Foo${typeStr}Mixin',
             });
           });
@@ -113,7 +113,7 @@ main() {
             ''',
             );
 
-            expect(converter.visitedClassNames, {
+            expect(converter.visitedNames, {
               'Foo${typeStr}Mixin': 'Foo${typeStr}Mixin',
             });
           });
@@ -144,7 +144,7 @@ main() {
             ''',
             );
 
-            expect(converter.visitedClassNames, {
+            expect(converter.visitedNames, {
               'Foo${typeStr}Mixin': 'Foo${typeStr}Mixin',
             });
           });
@@ -177,7 +177,7 @@ main() {
             ''',
             );
 
-            expect(converter.visitedClassNames, {
+            expect(converter.visitedNames, {
               'Foo${typeStr}Mixin': 'Foo${typeStr}Mixin',
             });
           });
@@ -207,7 +207,7 @@ main() {
             ''',
             );
 
-            expect(converter.visitedClassNames, {
+            expect(converter.visitedNames, {
               'Foo${typeStr}Mixin': 'Foo${typeStr}Mixin',
             });
           });

--- a/test/boilerplate_suggestors/props_mixin_migrator_test.dart
+++ b/test/boilerplate_suggestors/props_mixin_migrator_test.dart
@@ -24,7 +24,7 @@ main() {
     final testSuggestor = getSuggestorTester(PropsMixinMigrator(converter));
 
     tearDown(() {
-      converter.setConvertedClassNames({});
+      converter.setVisitedClassNames({});
     });
 
     group('does not perform a migration', () {
@@ -75,7 +75,7 @@ main() {
             ''',
             );
 
-            expect(converter.convertedClassNames, {
+            expect(converter.visitedClassNames, {
               'Foo${typeStr}Mixin': 'Foo${typeStr}Mixin',
             });
           });
@@ -106,7 +106,7 @@ main() {
             ''',
             );
 
-            expect(converter.convertedClassNames, {
+            expect(converter.visitedClassNames, {
               'Foo${typeStr}Mixin': 'Foo${typeStr}Mixin',
             });
           });
@@ -137,7 +137,7 @@ main() {
             ''',
             );
 
-            expect(converter.convertedClassNames, {
+            expect(converter.visitedClassNames, {
               'Foo${typeStr}Mixin': 'Foo${typeStr}Mixin',
             });
           });
@@ -170,7 +170,7 @@ main() {
             ''',
             );
 
-            expect(converter.convertedClassNames, {
+            expect(converter.visitedClassNames, {
               'Foo${typeStr}Mixin': 'Foo${typeStr}Mixin',
             });
           });
@@ -200,7 +200,7 @@ main() {
             ''',
             );
 
-            expect(converter.convertedClassNames, {
+            expect(converter.visitedClassNames, {
               'Foo${typeStr}Mixin': 'Foo${typeStr}Mixin',
             });
           });

--- a/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
@@ -89,7 +89,7 @@ main() {
 
         @Props()
         // FIXME: `FooProps` could not be auto-migrated to the new over_react boilerplate 
-        // because `FooComponent` does not extend from `react.Component2`.
+        // because `FooComponent` does not extend from `UiComponent2`.
         // 
         // Once you have upgraded the component, you can remove this FIXME comment and 
         // re-run the boilerplate migration script:

--- a/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
@@ -32,14 +32,14 @@ main() {
     });
 
     tearDown(() {
-      converter.setVisitedClassNames({});
+      converter.setVisitedNames({});
     });
 
     group('does not migrate when', () {
       test('its an empty file', () {
         testSuggestor(expectedPatchCount: 0, input: '');
 
-        expect(converter.visitedClassNames, isEmpty);
+        expect(converter.visitedNames, isEmpty);
       });
 
       test('there are no matches', () {
@@ -52,7 +52,7 @@ main() {
       ''',
         );
 
-        expect(converter.visitedClassNames, isEmpty);
+        expect(converter.visitedNames, isEmpty);
       });
 
       test('the component is not Component2, but does add a FIXME comment', () {
@@ -112,7 +112,7 @@ main() {
       ''',
         );
 
-        expect(converter.visitedClassNames, {
+        expect(converter.visitedNames, {
           'FooProps': null,
         });
       });
@@ -151,7 +151,7 @@ main() {
       ''',
         );
 
-        expect(converter.visitedClassNames, {
+        expect(converter.visitedNames, {
           'FooProps': null,
         });
       });
@@ -224,7 +224,7 @@ main() {
       ''',
         );
 
-        expect(converter.visitedClassNames, {
+        expect(converter.visitedNames, {
           'BarProps': null,
         });
       });
@@ -264,7 +264,7 @@ main() {
       ''',
           );
 
-          expect(converter.visitedClassNames, {
+          expect(converter.visitedNames, {
             'FooProps': null,
             'FooState': null,
           });
@@ -298,7 +298,7 @@ main() {
       ''',
           );
 
-          expect(converter.visitedClassNames, {
+          expect(converter.visitedNames, {
             'FooProps': null,
           });
         });
@@ -369,7 +369,7 @@ main() {
         ''',
         );
 
-        expect(converter.visitedClassNames, {
+        expect(converter.visitedNames, {
           'FooProps': 'FooProps',
           'FooState': 'FooState',
         });
@@ -426,7 +426,7 @@ main() {
         ''',
         );
 
-        expect(converter.visitedClassNames, {
+        expect(converter.visitedNames, {
           'FooProps': 'FooProps',
         });
       });
@@ -494,7 +494,7 @@ main() {
           ''',
         );
 
-        expect(converter.visitedClassNames, {
+        expect(converter.visitedNames, {
           'FooProps': 'FooProps',
           'FooState': 'FooState',
         });

--- a/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
@@ -152,6 +152,7 @@ main() {
         );
 
         expect(converter.visitedNames, {
+          'FooPropsMixin': null,
           'FooProps': null,
         });
       });

--- a/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
@@ -87,13 +87,13 @@ main() {
             // ignore: undefined_identifier
             $Foo;
 
+        @Props()
         // FIXME: `FooProps` could not be auto-migrated to the new over_react boilerplate 
         // because `FooComponent` does not extend from `react.Component2`.
         // 
         // Once you have upgraded the component, you can remove this FIXME comment and 
         // re-run the boilerplate migration script:
         // pub run over_react_codemod:boilerplate_upgrade
-        @Props()
         class _$FooProps extends UiProps {
           String foo;
           int bar;
@@ -188,7 +188,8 @@ main() {
           UiFactory<BarProps> Bar =
               // ignore: undefined_identifier
               $Bar;
-  
+
+          @Props()
           // FIXME: `BarProps` could not be auto-migrated to the new over_react boilerplate 
           // because doing so would be a breaking change since `BarProps` is exported from a 
           // library in this repo.
@@ -206,7 +207,6 @@ main() {
           //       "V2" class / mixin public, update the `hide` clause you added in step 4 to include both the 
           //       concrete class and the newly created mixin.
           //   6. Remove this FIXME comment.
-          @Props()
           class _$BarProps extends UiProps {
             String foo;
             int bar;

--- a/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import 'package:over_react_codemod/src/boilerplate_suggestors/boilerplate_utilities.dart';
-import 'package:over_react_codemod/src/boilerplate_suggestors/migration_decision.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/simple_props_and_state_class_migrator.dart';
 import 'package:test/test.dart';
 

--- a/test/boilerplate_suggestors/stubbed_props_and_state_class_remover_test.dart
+++ b/test/boilerplate_suggestors/stubbed_props_and_state_class_remover_test.dart
@@ -95,7 +95,7 @@ main() {
 
     group('performs a migration', () {
       test('when the analogous private class has been migrated (simple)', () {
-        converter.setVisitedClassNames({
+        converter.setVisitedNames({
           'FooProps': 'FooProps',
           'FooState': 'FooState',
         });
@@ -177,7 +177,7 @@ main() {
       });
 
       test('when the analogous private class has been migrated (advanced)', () {
-        converter.setVisitedClassNames({
+        converter.setVisitedNames({
           'FooProps': 'FooPropsMixin',
           'FooState': 'FooStateMixin',
         });

--- a/test/boilerplate_suggestors/stubbed_props_and_state_class_remover_test.dart
+++ b/test/boilerplate_suggestors/stubbed_props_and_state_class_remover_test.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:over_react_codemod/src/boilerplate_suggestors/boilerplate_utilities.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/stubbed_props_and_state_class_remover.dart';
 import 'package:test/test.dart';
 
@@ -19,8 +20,9 @@ import '../util.dart';
 
 main() {
   group('StubbedPropsAndStateClassRemover', () {
+    final converter = ClassToMixinConverter();
     final testSuggestor = getSuggestorTester(
-      StubbedPropsAndStateClassRemover(),
+      StubbedPropsAndStateClassRemover(converter),
     );
 
     group('does not perform a migration', () {

--- a/test/boilerplate_suggestors/stubbed_props_and_state_class_remover_test.dart
+++ b/test/boilerplate_suggestors/stubbed_props_and_state_class_remover_test.dart
@@ -41,157 +41,25 @@ main() {
         );
       });
 
-      test(
-          'when the stubbed "companion" class(es) are not associated with a UiComponent2 instance',
-          () {
+      test('when the class was unable able to be migrated', () {
+        // The empty value of converter.visitedClassNames
+        // will signify that FooProps / FooState were not converted
         testSuggestor(
           expectedPatchCount: 0,
-          input: '''
+          input: r'''
           @Factory()
           UiFactory<FooProps> Foo =
               // ignore: undefined_identifier
-              \$Foo;
-  
-          @Props()
-          class _\$FooProps extends UiProps {
-            String foo;
-            int bar;
-          }
-  
-          @Component()
-          class FooComponent extends UiComponent<FooProps, FooState> {
-            @override
-            render() {
-              return Dom.ul()(
-                Dom.li()('Foo: ', props.foo),
-                Dom.li()('Bar: ', props.bar),
-              );
-            }
-          }
-          
-          // AF-3369 This will be removed once the transition to Dart 2 is complete.
-          // ignore: mixin_of_non_class, undefined_class
-          class FooProps extends _\$FooProps with _\$FooPropsAccessorsMixin {
-            // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-            static const PropsMeta meta = _\$metaForFooProps;
-          }
-        ''',
-        );
-      });
-
-      test(
-          'when the class inheritance is advanced and unable able to be migrated',
-          () {
-        // TODO add a test for when the class is advanced and unable to be migrated
-      });
-
-      test('when the stubbed "companion" class(es) are publicly exported', () {
-        // TODO add a test for when the class is publicly exported
-      });
-    });
-
-    group('performs a migration', () {
-      test(
-          'when the class inheritance is advanced, but still able to be migrated',
-          () {
-        // TODO add a test for when the class is advanced, but still able to be migrated
-      });
-
-      test('when the class inheritance is simple (private)', () {
-        testSuggestor(
-          expectedPatchCount: 2,
-          input: '''
-          @Factory()
-          UiFactory<FooProps> Foo =
-              // ignore: undefined_identifier
-              \$Foo;
+              $Foo;
       
           @Props()
-          class _\$_FooProps extends UiProps {
+          class _$FooProps extends SomeCustomExternalPropsClass {
             String foo;
             int bar;
           }
       
           @State()
-          class _\$_FooState extends UiState {
-            String foo;
-            int bar;
-          }
-      
-          @Component2()
-          class FooComponent extends UiStatefulComponent2<_FooProps, _FooState> {
-            @override
-            render() {
-              return Dom.ul()(
-                Dom.li()('Foo: ', props.foo),
-                Dom.li()('Bar: ', props.bar),
-              );
-            }
-          }
-          
-          // AF-3369 This will be removed once the transition to Dart 2 is complete.
-          // ignore: mixin_of_non_class, undefined_class
-          class _FooProps extends _\$_FooProps with _\$_FooPropsAccessorsMixin {
-            // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-            static const PropsMeta meta = _\$metaFor_FooProps;
-          }
-          
-          // AF-3369 This will be removed once the transition to Dart 2 is complete.
-          // ignore: mixin_of_non_class, undefined_class
-          class _FooState extends _\$_FooState with _\$_FooStateAccessorsMixin {
-            // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-            static const StateMeta meta = _\$metaFor_FooState;
-          }
-        ''',
-          expectedOutput: '''
-          @Factory()
-          UiFactory<FooProps> Foo =
-              // ignore: undefined_identifier
-              \$Foo;
-      
-          @Props()
-          class _\$_FooProps extends UiProps {
-            String foo;
-            int bar;
-          }
-      
-          @State()
-          class _\$_FooState extends UiState {
-            String foo;
-            int bar;
-          }
-      
-          @Component2()
-          class FooComponent extends UiStatefulComponent2<_FooProps, _FooState> {
-            @override
-            render() {
-              return Dom.ul()(
-                Dom.li()('Foo: ', props.foo),
-                Dom.li()('Bar: ', props.bar),
-              );
-            }
-          }
-        ''',
-        );
-      });
-
-      test('when the class inheritance is simple (public)', () {
-        testSuggestor(
-          expectedPatchCount: 2,
-          input: '''
-          @Factory()
-          UiFactory<FooProps> Foo =
-              // ignore: undefined_identifier
-              \$Foo;
-      
-          @Props()
-          class _\$FooProps extends UiProps {
-            String foo;
-            int bar;
-          }
-      
-          @State()
-          class _\$FooState extends UiState {
+          class _$FooState extends SomeCustomExternalStateClass {
             String foo;
             int bar;
           }
@@ -209,35 +77,180 @@ main() {
           
           // AF-3369 This will be removed once the transition to Dart 2 is complete.
           // ignore: mixin_of_non_class, undefined_class
-          class FooProps extends _\$FooProps with _\$FooPropsAccessorsMixin {
+          class FooProps extends _$FooProps with _$FooPropsAccessorsMixin {
             // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-            static const PropsMeta meta = _\$metaForFooProps;
+            static const PropsMeta meta = _$metaForFooProps;
           }
           
           // AF-3369 This will be removed once the transition to Dart 2 is complete.
           // ignore: mixin_of_non_class, undefined_class
-          class FooState extends _\$FooState with _\$FooStateAccessorsMixin {
+          class FooState extends _$FooState with _$FooStateAccessorsMixin {
             // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-            static const StateMeta meta = _\$metaForFooState;
+            static const StateMeta meta = _$metaForFooState;
           }
         ''',
-          expectedOutput: '''
+        );
+      });
+    });
+
+    group('performs a migration', () {
+      test('when the analogous private class has been migrated (simple)', () {
+        converter.setVisitedClassNames({
+          'FooProps': 'FooProps',
+          'FooState': 'FooState',
+        });
+        testSuggestor(
+          expectedPatchCount: 2,
+          input: r'''
           @Factory()
           UiFactory<FooProps> Foo =
               // ignore: undefined_identifier
-              \$Foo;
+              $Foo;
       
           @Props()
-          class _\$FooProps extends UiProps {
+          mixin FooProps on UiProps {
             String foo;
             int bar;
           }
       
           @State()
-          class _\$FooState extends UiState {
+          mixin FooState on UiState {
             String foo;
             int bar;
           }
+      
+          @Component2()
+          class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+          
+          // AF-3369 This will be removed once the transition to Dart 2 is complete.
+          // ignore: mixin_of_non_class, undefined_class
+          class FooProps extends _$FooProps with _$FooPropsAccessorsMixin {
+            // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+            static const PropsMeta meta = _$metaForFooProps;
+          }
+          
+          // AF-3369 This will be removed once the transition to Dart 2 is complete.
+          // ignore: mixin_of_non_class, undefined_class
+          class FooState extends _$FooState with _$FooStateAccessorsMixin {
+            // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+            static const StateMeta meta = _$metaForFooState;
+          }
+        ''',
+          expectedOutput: r'''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              $Foo;
+      
+          @Props()
+          mixin FooProps on UiProps {
+            String foo;
+            int bar;
+          }
+      
+          @State()
+          mixin FooState on UiState {
+            String foo;
+            int bar;
+          }
+      
+          @Component2()
+          class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+        ''',
+        );
+      });
+
+      test('when the analogous private class has been migrated (advanced)', () {
+        converter.setVisitedClassNames({
+          'FooProps': 'FooPropsMixin',
+          'FooState': 'FooStateMixin',
+        });
+        testSuggestor(
+          expectedPatchCount: 2,
+          input: r'''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              $Foo;
+      
+          mixin FooPropsMixin on UiProps {
+            String foo;
+            int bar;
+          }
+      
+          @Props()    
+          class FooProps = UiProps with FooPropsMixin, SomeOtherPropsMixin;
+      
+          mixin FooStateMixin on UiState {
+            String foo;
+            int bar;
+          }
+      
+          @State()    
+          class FooState = UiProps with FooPropsMixin, SomeOtherStateMixin;
+      
+          @Component2()
+          class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+            @override
+            render() {
+              return Dom.ul()(
+                Dom.li()('Foo: ', props.foo),
+                Dom.li()('Bar: ', props.bar),
+              );
+            }
+          }
+          
+          // AF-3369 This will be removed once the transition to Dart 2 is complete.
+          // ignore: mixin_of_non_class, undefined_class
+          class FooProps extends _$FooProps with _$FooPropsAccessorsMixin {
+            // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+            static const PropsMeta meta = _$metaForFooProps;
+          }
+          
+          // AF-3369 This will be removed once the transition to Dart 2 is complete.
+          // ignore: mixin_of_non_class, undefined_class
+          class FooState extends _$FooState with _$FooStateAccessorsMixin {
+            // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
+            static const StateMeta meta = _$metaForFooState;
+          }
+        ''',
+          expectedOutput: r'''
+          @Factory()
+          UiFactory<FooProps> Foo =
+              // ignore: undefined_identifier
+              $Foo;
+      
+          mixin FooPropsMixin on UiProps {
+            String foo;
+            int bar;
+          }
+      
+          @Props()    
+          class FooProps = UiProps with FooPropsMixin, SomeOtherPropsMixin;
+      
+          mixin FooStateMixin on UiState {
+            String foo;
+            int bar;
+          }
+      
+          @State()    
+          class FooState = UiProps with FooPropsMixin, SomeOtherStateMixin;
       
           @Component2()
           class FooComponent extends UiStatefulComponent2<FooProps, FooState> {

--- a/test/util.dart
+++ b/test/util.dart
@@ -206,7 +206,7 @@ void testSuggestor({
   String modifiedInput;
   {
     final sourceFile = SourceFile.fromString(input, url: inputUrl);
-    final patches = suggestor.generatePatches(sourceFile);
+    final patches = suggestor.generatePatches(sourceFile).toList();
     final emptyPatches = patches.where((p) => p.isNoop);
     expect(emptyPatches, isEmpty,
         reason: 'Suggested ${emptyPatches.length} empty patch(es).');
@@ -231,7 +231,7 @@ void testSuggestor({
   if (testIdempotency) {
     final sourceFile =
         SourceFile.fromString(modifiedInput, url: 'modifiedInput');
-    final patches = suggestor.generatePatches(sourceFile);
+    final patches = suggestor.generatePatches(sourceFile).toList();
     var doubleModifiedInput =
         applyPatches(sourceFile, patches).trimRight() + '\n';
     if (shouldDartfmtOutput) {


### PR DESCRIPTION
> **NOTE:** I'd recommend just reading through the `advanced_props_and_state_migrator_test.dart` file without attempting to make sense of the diff.

## Motivation
Currently, when the codemod runs the `AdvancedPropsAndStateClassMigrator`, the migrator does not short-circuit if a custom superclass, or one or more mixins is not present in the map of "known converted classes" that the migrators update as classes are converted.

This is done because we have no way to control the order in which classes are visited by the suggestor.  This means that just because a superclass or mixin is not present in the map of "known converted classes" at the time the subclass is visited - does not mean it will never be converted.

We also need to improve how we communicate to the consumer when our codemod short-circuits because of public API detection / superclasses from external libs.

## Changes
1. Expand the role of the `ClassToMixinConverter` class to record visits, as well as record whether the class that was visited was converted.
    1. This allows us to short-circuit other migrations when a class that another class extends from / mixes in: 
        1. Was visited, but not converted
        1. Was never visited (meaning it lives in an external lib)
1. Run the `AdvancedPropsAndStateClassMigrator` twice during the migration.
    1. On the first run, short-circuit - but do not add FIXME comments when an unknown/unconverted superclass or mixin is encountered.
    2. On the second run, short-circuit AND add FIXME comments when an unknown/unconverted superclass or mixin is encountered.
1. Add a `--convert-classes-with-external-superclasses` flag that can be set to force the conversion of classes that extend from or mix in classes that do not live in the same library.
1. Add a `MigrationDecision` class that is responsible for determining when short-circuits occur during migrations, as well as storing a `reason` comment that we will apply to keep the consumers informed about what they can do to either migrate the classes manually, or to make some adjustments before running the migration script again.
1. Move the `StubbedPropsAndStateClassRemover` so that it runs with the knowledge of which classes have been converted.
1. Misc. logic updates to handle additional edge cases while testing the migrators in `graph_ui`.
1. Add crap-tons of tests.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @joebingham-wk @sydneyjodon-wk @greglittlefield-wf 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
