### PR TITLE
Final cleanup for new boilerplate codemod

### DIFF
--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -166,7 +166,7 @@ MigrationDecision getPropsAndStateClassMigrationDecision(
     ClassDeclaration node, SemverHelper semverHelper) {
   final publicNodeName = stripPrivateGeneratedPrefix(node.name.name);
   const reRunMigrationScriptInstructions =
-      'pub run over_react_codemod:boilerplate_upgrade';
+      'pub global run over_react_codemod:boilerplate_upgrade';
   if (!isAPropsOrStateClass(node)) {
     return MigrationDecision(false);
   } else if (isPublic(node, semverHelper)) {

--- a/lib/src/boilerplate_suggestors/migration_decision.dart
+++ b/lib/src/boilerplate_suggestors/migration_decision.dart
@@ -68,7 +68,7 @@ String getExternalSuperclassOrMixinReasonComment(
   //   2. Once the library has released a version that includes updated boilerplate,
   //      bump the lower bound of your dependency to that version in your `pubspec.yaml`, and run `pub get`.
   //   3. Re-run the migration script with the following flag:
-  //      pub run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
+  //      pub global run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
   //   4. Once the migration is complete, you should notice that ${superclassOrMixinNames.join(', ')} ${superclassOrMixinNames.length == 1 ? 'has' : 'have'} been deprecated. 
   //      Follow the deprecation instructions to consume the ${superclassOrMixinNames.length == 1 ? 'replacement' : 'replacements'} by either updating your usage to
   //      the new ${mixinsAreExternal ? 'mixin' : 'class'} ${superclassOrMixinNames.length == 1 ? 'name' : 'names'} and/or updating to a different entrypoint that exports the version(s) of 
@@ -89,11 +89,11 @@ String getPublicApiReasonComment(String nodeName, List<String> locations) {
     //      pub global run semver_audit generate 2> semver_report.json
     //   2. Remove this FIXME comment.
     //   3. Re-run the migration script:
-    //      pub run over_react_codemod:boilerplate_upgrade
+    //      pub global run over_react_codemod:boilerplate_upgrade
     //
     // Alternatively, remove this FIXME comment and re-run the  migration script 
     // with the following flag to assume all components are not publicly exported:
-    // pub run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private
+    // pub global run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private
     ''';
   }
   return '''
@@ -107,7 +107,7 @@ String getPublicApiReasonComment(String nodeName, List<String> locations) {
   //   2. Make a copy of it, renaming it something like `${nodeName}V2`.
   //   3. Replace all your current usage of the deprecated `$nodeName` with `${nodeName}V2`.
   //   4. Add a `hide ${nodeName}V2` clause to all places where it is exported, and then run:
-  //        pub run over_react_codemod:boilerplate_upgrade
+  //        pub global run over_react_codemod:boilerplate_upgrade
   //   5a. If `$nodeName` had consumers outside this repo, and it was intentionally made public,
   //       remove the `hide` clause you added in step 4 so that the new mixin created from `${nodeName}V2` 
   //       will be a viable replacement for `$nodeName`.
@@ -128,7 +128,7 @@ String getUnMigratedSuperclassReasonComment(
   //   1. Look at the "FIXME" comment that has been added to `$superclassName` - 
   //      and follow the steps outlined there to complete the migration.
   //   2. Re-run the migration script:
-  //      pub run over_react_codemod:boilerplate_upgrade
+  //      pub global run over_react_codemod:boilerplate_upgrade
   ''';
 }
 

--- a/lib/src/boilerplate_suggestors/migration_decision.dart
+++ b/lib/src/boilerplate_suggestors/migration_decision.dart
@@ -79,21 +79,33 @@ String getExternalSuperclassOrMixinReasonComment(
 String getPublicApiReasonComment(String nodeName, List<String> locations) {
   if (locations.first == semverReportNotAvailable) {
     return '''
-    // FIXME: Semver report was not found. `$nodeName` is assumed to be exported from
-    // a library in this repo and thus was not auto-migrated to the new over_react
-    // boilerplate.
+    // FIXME: A Workiva Semver report was not found. `$nodeName` is assumed to be exported from
+    // a library in this repo and thus was not auto-migrated to the new over_react boilerplate.
     //
+    // --------- If you are migrating an OSS library outside of Workiva ---------
+    // You do not have access to Workiva's internal Semver audit tool. 
     // To complete the migration, you should:
-    //   1. Perform a semver report by running the following script:
-    //      pub global activate semver_audit --hosted-url=https://pub.workiva.org
-    //      pub global run semver_audit generate 2> semver_report.json
-    //   2. Remove this FIXME comment.
-    //   3. Re-run the migration script:
-    //      pub global run over_react_codemod:boilerplate_upgrade
     //
-    // Alternatively, remove this FIXME comment and re-run the  migration script 
-    // with the following flag to assume all components are not publicly exported:
-    // pub global run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private
+    //   1. Revert all changes to remove this FIXME comment
+    //   2. Re-run the migration script with the following flag:    
+    //
+    //        pub global run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private
+    //
+    //   NOTE: The changes made to props / state classes by the codemod constitute breaking changes
+    //   if you publicly export them from your library. We strongly recommend that you release 
+    //   the subsequent changes in a major version.
+    //
+    // --------- If you are migrating a Workiva library ---------
+    // To complete the migration, you should:
+    //   1. Revert all changes to remove this FIXME comment
+    //   2. Generate a semver report by running the following script:
+    //
+    //        pub global activate semver_audit --hosted-url=https://pub.workiva.org
+    //        pub global run semver_audit generate 2> semver_report.json
+    //
+    //   3. Re-run the migration script:
+    //
+    //        pub global run over_react_codemod:boilerplate_upgrade
     ''';
   }
   return '''

--- a/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
@@ -151,7 +151,7 @@ void advancedPropsAndStateClassMigratorTestHelper({
           // 
           // Once you have upgraded the component, you can remove this FIXME comment and 
           // re-run the boilerplate migration script:
-          // pub run over_react_codemod:boilerplate_upgrade
+          // pub global run over_react_codemod:boilerplate_upgrade
           class $propsClassName extends UiProps with SomePropsMixin {
             String foo;
             int bar;
@@ -223,7 +223,7 @@ void advancedPropsAndStateClassMigratorTestHelper({
           //   2. Make a copy of it, renaming it something like `BarPropsV2`.
           //   3. Replace all your current usage of the deprecated `BarProps` with `BarPropsV2`.
           //   4. Add a `hide BarPropsV2` clause to all places where it is exported, and then run:
-          //        pub run over_react_codemod:boilerplate_upgrade
+          //        pub global run over_react_codemod:boilerplate_upgrade
           //   5a. If `BarProps` had consumers outside this repo, and it was intentionally made public,
           //       remove the `hide` clause you added in step 4 so that the new mixin created from `BarPropsV2` 
           //       will be a viable replacement for `BarProps`.
@@ -247,7 +247,7 @@ void advancedPropsAndStateClassMigratorTestHelper({
           //   2. Make a copy of it, renaming it something like `BarStateV2`.
           //   3. Replace all your current usage of the deprecated `BarState` with `BarStateV2`.
           //   4. Add a `hide BarStateV2` clause to all places where it is exported, and then run:
-          //        pub run over_react_codemod:boilerplate_upgrade
+          //        pub global run over_react_codemod:boilerplate_upgrade
           //   5a. If `BarState` had consumers outside this repo, and it was intentionally made public,
           //       remove the `hide` clause you added in step 4 so that the new mixin created from `BarStateV2` 
           //       will be a viable replacement for `BarState`.
@@ -312,11 +312,11 @@ void advancedPropsAndStateClassMigratorTestHelper({
           //      pub global run semver_audit generate 2> semver_report.json
           //   2. Remove this FIXME comment.
           //   3. Re-run the migration script:
-          //      pub run over_react_codemod:boilerplate_upgrade
+          //      pub global run over_react_codemod:boilerplate_upgrade
           //
           // Alternatively, remove this FIXME comment and re-run the  migration script 
           // with the following flag to assume all components are not publicly exported:
-          // pub run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private'''}
+          // pub global run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private'''}
           class $propsClassName extends ADifferentPropsClass {
             String foo;
             int bar;
@@ -333,11 +333,11 @@ void advancedPropsAndStateClassMigratorTestHelper({
           //      pub global run semver_audit generate 2> semver_report.json
           //   2. Remove this FIXME comment.
           //   3. Re-run the migration script:
-          //      pub run over_react_codemod:boilerplate_upgrade
+          //      pub global run over_react_codemod:boilerplate_upgrade
           //
           // Alternatively, remove this FIXME comment and re-run the  migration script 
           // with the following flag to assume all components are not publicly exported:
-          // pub run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private'''}
+          // pub global run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private'''}
           class $stateClassName extends ADifferentStateClass {
             String foo;
             int bar;
@@ -380,7 +380,7 @@ void advancedPropsAndStateClassMigratorTestHelper({
             //   2. Once the library has released a version that includes updated boilerplate,
             //      bump the lower bound of your dependency to that version in your `pubspec.yaml`, and run `pub get`.
             //   3. Re-run the migration script with the following flag:
-            //      pub run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
+            //      pub global run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
             //   4. Once the migration is complete, you should notice that $externalSuperclassName has been deprecated. 
             //      Follow the deprecation instructions to consume the replacement by either updating your usage to
             //      the new class name and/or updating to a different entrypoint that exports the version(s) of 
@@ -551,7 +551,7 @@ void advancedPropsAndStateClassMigratorTestHelper({
             //   2. Once the library has released a version that includes updated boilerplate,
             //      bump the lower bound of your dependency to that version in your `pubspec.yaml`, and run `pub get`.
             //   3. Re-run the migration script with the following flag:
-            //      pub run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
+            //      pub global run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
             //   4. Once the migration is complete, you should notice that $externalMixinName has been deprecated. 
             //      Follow the deprecation instructions to consume the replacement by either updating your usage to
             //      the new mixin name and/or updating to a different entrypoint that exports the version(s) of 
@@ -565,7 +565,7 @@ void advancedPropsAndStateClassMigratorTestHelper({
             //   2. Once the library has released a version that includes updated boilerplate,
             //      bump the lower bound of your dependency to that version in your `pubspec.yaml`, and run `pub get`.
             //   3. Re-run the migration script with the following flag:
-            //      pub run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
+            //      pub global run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
             //   4. Once the migration is complete, you should notice that $externalSuperclassName has been deprecated. 
             //      Follow the deprecation instructions to consume the replacement by either updating your usage to
             //      the new class name and/or updating to a different entrypoint that exports the version(s) of 
@@ -712,7 +712,7 @@ void advancedPropsAndStateClassMigratorTestHelper({
             //   1. Look at the "FIXME" comment that has been added to `ADifferentPropsClass` - 
             //      and follow the steps outlined there to complete the migration.
             //   2. Re-run the migration script:
-            //      pub run over_react_codemod:boilerplate_upgrade
+            //      pub global run over_react_codemod:boilerplate_upgrade
             class $propsClassName extends ADifferentPropsClass {
               String foo;
               int bar;
@@ -825,7 +825,7 @@ void advancedPropsAndStateClassMigratorTestHelper({
               //   2. Once the library has released a version that includes updated boilerplate,
               //      bump the lower bound of your dependency to that version in your `pubspec.yaml`, and run `pub get`.
               //   3. Re-run the migration script with the following flag:
-              //      pub run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
+              //      pub global run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
               //   4. Once the migration is complete, you should notice that $externalMixinName has been deprecated. 
               //      Follow the deprecation instructions to consume the replacement by either updating your usage to
               //      the new mixin name and/or updating to a different entrypoint that exports the version(s) of 
@@ -934,7 +934,7 @@ void advancedPropsAndStateClassMigratorTestHelper({
               //   2. Once the library has released a version that includes updated boilerplate,
               //      bump the lower bound of your dependency to that version in your `pubspec.yaml`, and run `pub get`.
               //   3. Re-run the migration script with the following flag:
-              //      pub run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
+              //      pub global run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
               //   4. Once the migration is complete, you should notice that $externalMixinNames have been deprecated. 
               //      Follow the deprecation instructions to consume the replacements by either updating your usage to
               //      the new mixin names and/or updating to a different entrypoint that exports the version(s) of 

--- a/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
@@ -302,42 +302,66 @@ void advancedPropsAndStateClassMigratorTestHelper({
           $factoryDecl
   
           @Props()
-          ${shouldTreatAllComponentsAsPrivate ? '' : '''// FIXME: Semver report was not found. `$publicPropsClassName` is assumed to be exported from
-          // a library in this repo and thus was not auto-migrated to the new over_react
-          // boilerplate.
+          ${shouldTreatAllComponentsAsPrivate ? '' : '''// FIXME: A Workiva Semver report was not found. `$publicPropsClassName` is assumed to be exported from
+          // a library in this repo and thus was not auto-migrated to the new over_react boilerplate.
           //
+          // --------- If you are migrating an OSS library outside of Workiva ---------
+          // You do not have access to Workiva's internal Semver audit tool. 
           // To complete the migration, you should:
-          //   1. Perform a semver report by running the following script:
-          //      pub global activate semver_audit --hosted-url=https://pub.workiva.org
-          //      pub global run semver_audit generate 2> semver_report.json
-          //   2. Remove this FIXME comment.
-          //   3. Re-run the migration script:
-          //      pub global run over_react_codemod:boilerplate_upgrade
           //
-          // Alternatively, remove this FIXME comment and re-run the  migration script 
-          // with the following flag to assume all components are not publicly exported:
-          // pub global run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private'''}
+          //   1. Revert all changes to remove this FIXME comment
+          //   2. Re-run the migration script with the following flag:    
+          //
+          //        pub global run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private
+          //
+          //   NOTE: The changes made to props / state classes by the codemod constitute breaking changes
+          //   if you publicly export them from your library. We strongly recommend that you release 
+          //   the subsequent changes in a major version.
+          //
+          // --------- If you are migrating a Workiva library ---------
+          // To complete the migration, you should:
+          //   1. Revert all changes to remove this FIXME comment
+          //   2. Generate a semver report by running the following script:
+          //
+          //        pub global activate semver_audit --hosted-url=https://pub.workiva.org
+          //        pub global run semver_audit generate 2> semver_report.json
+          //
+          //   3. Re-run the migration script:
+          //
+          //        pub global run over_react_codemod:boilerplate_upgrade'''}
           class $propsClassName extends ADifferentPropsClass {
             String foo;
             int bar;
           }
   
           @State()
-          ${shouldTreatAllComponentsAsPrivate ? '' : '''// FIXME: Semver report was not found. `$publicStateClassName` is assumed to be exported from
-          // a library in this repo and thus was not auto-migrated to the new over_react
-          // boilerplate.
+          ${shouldTreatAllComponentsAsPrivate ? '' : '''// FIXME: A Workiva Semver report was not found. `$publicStateClassName` is assumed to be exported from
+          // a library in this repo and thus was not auto-migrated to the new over_react boilerplate.
           //
+          // --------- If you are migrating an OSS library outside of Workiva ---------
+          // You do not have access to Workiva's internal Semver audit tool. 
           // To complete the migration, you should:
-          //   1. Perform a semver report by running the following script:
-          //      pub global activate semver_audit --hosted-url=https://pub.workiva.org
-          //      pub global run semver_audit generate 2> semver_report.json
-          //   2. Remove this FIXME comment.
-          //   3. Re-run the migration script:
-          //      pub global run over_react_codemod:boilerplate_upgrade
           //
-          // Alternatively, remove this FIXME comment and re-run the  migration script 
-          // with the following flag to assume all components are not publicly exported:
-          // pub global run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private'''}
+          //   1. Revert all changes to remove this FIXME comment
+          //   2. Re-run the migration script with the following flag:    
+          //
+          //        pub global run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private
+          //
+          //   NOTE: The changes made to props / state classes by the codemod constitute breaking changes
+          //   if you publicly export them from your library. We strongly recommend that you release 
+          //   the subsequent changes in a major version.
+          //
+          // --------- If you are migrating a Workiva library ---------
+          // To complete the migration, you should:
+          //   1. Revert all changes to remove this FIXME comment
+          //   2. Generate a semver report by running the following script:
+          //
+          //        pub global activate semver_audit --hosted-url=https://pub.workiva.org
+          //        pub global run semver_audit generate 2> semver_report.json
+          //
+          //   3. Re-run the migration script:
+          //
+          //        pub global run over_react_codemod:boilerplate_upgrade'''}
           class $stateClassName extends ADifferentStateClass {
             String foo;
             int bar;

--- a/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
@@ -112,7 +112,7 @@ void simplePropsAndStateClassMigratorTestHelper({
         // 
         // Once you have upgraded the component, you can remove this FIXME comment and 
         // re-run the boilerplate migration script:
-        // pub run over_react_codemod:boilerplate_upgrade
+        // pub global run over_react_codemod:boilerplate_upgrade
         class _$FooProps extends UiProps {
           String foo;
           int bar;
@@ -328,7 +328,7 @@ void simplePropsAndStateClassMigratorTestHelper({
           //   2. Make a copy of it, renaming it something like `BarPropsV2`.
           //   3. Replace all your current usage of the deprecated `BarProps` with `BarPropsV2`.
           //   4. Add a `hide BarPropsV2` clause to all places where it is exported, and then run:
-          //        pub run over_react_codemod:boilerplate_upgrade
+          //        pub global run over_react_codemod:boilerplate_upgrade
           //   5a. If `BarProps` had consumers outside this repo, and it was intentionally made public,
           //       remove the `hide` clause you added in step 4 so that the new mixin created from `BarPropsV2`
           //       will be a viable replacement for `BarProps`.
@@ -843,9 +843,9 @@ String semverReportUnavailableComment(String nodeName) {
     //      pub global run semver_audit generate 2> semver_report.json
     //   2. Remove this FIXME comment.
     //   3. Re-run the migration script:
-    //      pub run over_react_codemod:boilerplate_upgrade
+    //      pub global run over_react_codemod:boilerplate_upgrade
     //
     // Alternatively, remove this FIXME comment and re-run the  migration script 
     // with the following flag to assume all components are not publicly exported:
-    // pub run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private''';
+    // pub global run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private''';
 }

--- a/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
@@ -833,19 +833,31 @@ void simplePropsAndStateClassMigratorTestHelper({
 
 String semverReportUnavailableComment(String nodeName) {
   return '''
-    // FIXME: Semver report was not found. `$nodeName` is assumed to be exported from
-    // a library in this repo and thus was not auto-migrated to the new over_react
-    // boilerplate.
+    // FIXME: A Workiva Semver report was not found. `$nodeName` is assumed to be exported from
+    // a library in this repo and thus was not auto-migrated to the new over_react boilerplate.
     //
+    // --------- If you are migrating an OSS library outside of Workiva ---------
+    // You do not have access to Workiva's internal Semver audit tool. 
     // To complete the migration, you should:
-    //   1. Perform a semver report by running the following script:
-    //      pub global activate semver_audit --hosted-url=https://pub.workiva.org
-    //      pub global run semver_audit generate 2> semver_report.json
-    //   2. Remove this FIXME comment.
-    //   3. Re-run the migration script:
-    //      pub global run over_react_codemod:boilerplate_upgrade
     //
-    // Alternatively, remove this FIXME comment and re-run the  migration script 
-    // with the following flag to assume all components are not publicly exported:
-    // pub global run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private''';
+    //   1. Revert all changes to remove this FIXME comment
+    //   2. Re-run the migration script with the following flag:    
+    //
+    //        pub global run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private
+    //
+    //   NOTE: The changes made to props / state classes by the codemod constitute breaking changes
+    //   if you publicly export them from your library. We strongly recommend that you release 
+    //   the subsequent changes in a major version.
+    //
+    // --------- If you are migrating a Workiva library ---------
+    // To complete the migration, you should:
+    //   1. Revert all changes to remove this FIXME comment
+    //   2. Generate a semver report by running the following script:
+    //
+    //        pub global activate semver_audit --hosted-url=https://pub.workiva.org
+    //        pub global run semver_audit generate 2> semver_report.json
+    //
+    //   3. Re-run the migration script:
+    //
+    //        pub global run over_react_codemod:boilerplate_upgrade''';
 }

--- a/test/executables/react16_ci_precheck_test.dart
+++ b/test/executables/react16_ci_precheck_test.dart
@@ -181,7 +181,7 @@ final versionChecksToTest = [
 ];
 
 ProcessResult runCiPrecheck({String onDirectory}) {
-  // This command is equivalent to `pub run over_react_codemod:react16_upgrade`
+  // This command is equivalent to `pub global run over_react_codemod:react16_upgrade`
   // but allows us to not need to run pub get on each of these fake packages because over_react/react.dart have not been
   // released yet these tests will fail a pub get
   var result = Process.runSync(

--- a/test/executables/react16_upgrade_test.dart
+++ b/test/executables/react16_upgrade_test.dart
@@ -54,7 +54,7 @@ final versionChecksToTest = [
 ];
 
 ProcessResult runUpgrade({String onDirectory}) {
-  // This command is equivalent to `pub run over_react_codemod:react16_upgrade`
+  // This command is equivalent to `pub global run over_react_codemod:react16_upgrade`
   // but allows us to not need to run pub get on each of these fake packages because over_react/react.dart have not been
   // released yet these tests will fail a pub get
   var result = Process.runSync(


### PR DESCRIPTION
## Motivation
Found a couple of things while QA'ing #80 that weren't worth preventing it from merging, but deserve to be cleaned up before finalizing the codemod / merging the integration branch into master.

## Changes
Improve the accuracy and clarity of some FIXME comments that are generated by the codemod(s).


## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @joebingham-wk 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
