### PR TITLE
CPLAT-10066 Update react / over_react versions for boilerplate migration

### DIFF
--- a/lib/src/boilerplate_suggestors/constants.dart
+++ b/lib/src/boilerplate_suggestors/constants.dart
@@ -1,0 +1,2 @@
+const reactVersionRange = '^5.4.0-alpha';
+const overReactVersionRange = '^3.5.0-alpha';

--- a/lib/src/executables/boilerplate_upgrade.dart
+++ b/lib/src/executables/boilerplate_upgrade.dart
@@ -14,6 +14,7 @@
 
 import 'dart:io';
 
+import 'package:args/args.dart';
 import 'package:codemod/codemod.dart';
 import 'package:logging/logging.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/annotations_remover.dart';
@@ -37,15 +38,18 @@ const _changesRequiredOutput = '''
 ''';
 
 void main(List<String> args) {
+  final parser = ArgParser.allowAnything()
+    ..addFlag(_convertedClassesWithExternalSuperclassFlag)
+    ..addFlag(_treatAllComponentsAsPrivateFlag);
+  final parsedArgs = parser.parse(args);
+
   final logger = Logger('over_react_codemod.boilerplate_upgrade');
 
-  final convertClassesWithExternalSuperclass =
-      args.contains(_convertedClassesWithExternalSuperclassFlag);
-  args.removeWhere((arg) => arg == _convertedClassesWithExternalSuperclassFlag);
 
+  final convertClassesWithExternalSuperclass =
+      parsedArgs[_convertedClassesWithExternalSuperclassFlag] == true;
   final shouldTreatAllComponentsAsPrivate =
-      args.contains(_treatAllComponentsAsPrivateFlag);
-  args.removeWhere((arg) => arg == _treatAllComponentsAsPrivateFlag);
+      parsedArgs[_treatAllComponentsAsPrivateFlag] == true;
 
   final query = FileQuery.dir(
     pathFilter: (path) {
@@ -93,7 +97,7 @@ void main(List<String> args) {
       StubbedPropsAndStateClassRemover(classToMixinConverter),
       AnnotationsRemover(classToMixinConverter),
     ].map((s) => Ignoreable(s)),
-    args: args,
+    args: parsedArgs.rest,
     defaultYes: true,
     changesRequiredOutput: _changesRequiredOutput,
   );

--- a/lib/src/executables/boilerplate_upgrade.dart
+++ b/lib/src/executables/boilerplate_upgrade.dart
@@ -59,42 +59,6 @@ void main(List<String> args) {
   final semverHelper = getSemverHelper('semver_report.json',
       shouldTreatAllComponentsAsPrivate: shouldTreatAllComponentsAsPrivate);
 
-  // General plan:
-  //  - Things that need to be accomplished (very simplified)
-  //    1. Make props / state class a mixin
-  //    2. Remove stub props / state classes
-  //    3. Remove annotations
-  //
-  //  - Before any changes occur (short circuit conditions):
-  //    1. Check that the component is `component2`
-  //    2. Check whether the props class is a public API
-  //      i. If this is unavailable, check the flag
-  //
-  //  - Suggestors:
-  //    1. Handle basic use cases
-  //    2. Handle advanced cases
-  //    3. Remove stubbed meta class
-  //    4. Remove annotations
-  //    5. Transition `PropsMixins`
-  //
-  //  - Common Utilities
-  //    - Detect Component2 (for short circuit condition 1)
-  //      - use `isAssociatedWithComponent2`
-  //    - Detect if the class is "simple".
-  //      - If false, short circuit suggestor 1
-  //      - If true, short circuit suggestor 2
-  //      - use `isSimplePropsOrStateClass`
-  //    - Switch a props / state class to a `mixin`
-  //      - Both the simple and advanced migrators likely need to switch a class
-  //        to a mixin (the advanced case can then just add a new line)
-  //      - use `migrateClassToMixin`
-  //    -? Detect if the file _will_ be updated
-  //      - NOTE: not created yet
-  //      - Can we rely on timing of suggestors? As in, if a suggestor runs after a different one, will its changes be in place?
-  //          - IIRC, no?
-  //      - If this is needed, it can be used for suggestors 3 and 4
-  //
-  //
   exitCode = runInteractiveCodemodSequence(
     query,
     <Suggestor>[

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   logging: ^0.11.3+2
   meta: ^1.1.7
   path: ^1.6.2
+  prompts: ^1.3.1
   pub_semver: ^1.4.2
   source_span: ^1.4.1
   yaml: ^2.1.16


### PR DESCRIPTION
## Motivation
The migration to the new over_react boilerplate will require updated lower bounds for the `react` and `over_react` dependencies for consumer libs.

## Changes
Add a standalone interactive codemod that runs before the rest of the migrators that updates the react / over_react dependencies.

> _NOTE: These versions don't exist yet, but they should / will very soon._ 

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @greglittlefield-wf @sydneyjodon-wk @joebingham-wk 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
