### PR TITLE
CPLAT-10164 Preserve consumedProps behavior when shorthand used

### DIFF
--- a/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
+++ b/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
@@ -329,8 +329,8 @@ class AdvancedPropsAndStateClassMigrator extends GeneralizingAstVisitor
           .whereType<MethodDeclaration>()
           .where((method) => method.name.name == 'consumedProps');
       if (consumedPropsDeclarations.isEmpty) {
-        yieldPatch(componentNode.leftBracket.offset + 1,
-            componentNode.leftBracket.offset + 1, '''
+        yieldPatch(componentNode.leftBracket.end,
+            componentNode.leftBracket.end, '''
         // Override consumedProps to an empty list so that props within 
         // $nameOfDupeMixin are forwarded when `addUnconsumedProps` is used.
         @override

--- a/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
+++ b/lib/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart
@@ -88,8 +88,8 @@ class AdvancedPropsAndStateClassMigrator extends GeneralizingAstVisitor
         node.extendsClause.superclass.typeArguments ?? '';
 
     final className = stripPrivateGeneratedPrefix(node.name.name);
-    final dupeMixinExists =
-        getNameOfDupeClass(className, node.root, converter) != null;
+    final nameOfDupeMixin = getNameOfDupeClass(className, node.root, converter);
+    final dupeMixinExists = nameOfDupeMixin != null;
     final mixinWillBeCreatedFromClass =
         !dupeMixinExists && node.members.isNotEmpty;
     final dupeClassInSameRoot = getDupeClassInSameRoot(className, node.root);
@@ -276,7 +276,127 @@ class AdvancedPropsAndStateClassMigrator extends GeneralizingAstVisitor
         convertClassesWithExternalSuperclass:
             convertClassesWithExternalSuperclass,
         sourceFile: sourceFile);
-    yieldPatch(node.end, node.end, newDeclarationBuffer.toString());
+
+    // If a class extends from UiProps/UiState and uses a single mixin that has a name
+    // that matches the concrete class name appended with `Mixin`, the call to
+    // `converter.migrate` will result in the old concrete class being deleted.
+    //
+    // In this case, we should also not create a new concrete class declaration
+    // since the "shorthand" / "mixin only" boilerplate will suffice.
+    if (!extendsFromCustomClass &&
+        dupeMixinExists &&
+        node.withClause.mixinTypes.length == 1 &&
+        node.implementsClause == null) {
+      // Do not patch with a new concrete class. Instead, update the component
+      // declaration to utilize the mixin instead of the old concrete class.
+      final componentNode = getComponentNodeInRoot(node);
+
+      final classNameAsSuperclassTypeArgument = componentNode
+          .extendsClause.superclass.typeArguments.arguments
+          .where((arg) => arg.toSource() == className);
+      final classNameAsMixinTypeArgument = componentNode.withClause?.mixinTypes
+          ?.map((type) => type.typeArguments.arguments
+              .where((arg) => arg.toSource() == className))
+          ?.expand((arg) => arg);
+      final classNameAsInterfaceTypeArgument = componentNode
+          .implementsClause?.interfaces
+          ?.map((type) => type.typeArguments.arguments
+              .where((arg) => arg.toSource() == className))
+          ?.expand((arg) => arg);
+      final allClassNameAsTypeArguments = [
+        ...classNameAsSuperclassTypeArgument,
+        ...?classNameAsMixinTypeArgument,
+        ...?classNameAsInterfaceTypeArgument,
+      ];
+
+      for (var classNameAsTypeArg in allClassNameAsTypeArguments) {
+        yieldPatch(
+            classNameAsTypeArg.offset, classNameAsTypeArg.end, nameOfDupeMixin);
+      }
+
+      // By deleting the dupe class and using the migrated (existing) mixin,
+      // we are converting the declaration into a "shorthand" version of the boilerplate
+      // in which the mixin now doubles as the props class for the component instance.
+      //
+      // This means that the default `consumedProps` for the component will be all the
+      // props within the mixin. With the old boilerplate, if `consumedProps` was not
+      // overridden in the component - the props within the mixin would get forwarded to
+      // children via `addUnconsumedProps` since the default `consumedProps` were the props
+      // in the separate concrete class.  But in the new "shorthand" boilerplate, since there
+      // is no separate concrete class, those mixin props will get consumed by
+      // default - which is a breaking change.
+      //
+      // To counteract this, we need to override `consumedProps` to be an empty list if
+      // the component isn't already overriding it so that the mixin props continue to
+      // get forwarded to child components the same way they did before the migration.
+      final consumedPropsDeclarations = componentNode.members
+          .whereType<MethodDeclaration>()
+          .where((method) => method.name.name == 'consumedProps');
+      if (consumedPropsDeclarations.isEmpty) {
+        yieldPatch(componentNode.leftBracket.offset + 1,
+            componentNode.leftBracket.offset + 1, '''
+        // Override consumedProps to an empty list so that props within 
+        // $nameOfDupeMixin are forwarded when `addUnconsumedProps` is used.
+        @override
+        get consumedProps => [];
+        
+        ''');
+      } else {
+        final consumedPropsDeclaration = consumedPropsDeclarations.single;
+        ListLiteral currentConsumedProps;
+        final consumedPropsExpressionFunctionBody = consumedPropsDeclaration
+            .childEntities
+            .whereType<ExpressionFunctionBody>();
+        final consumedPropsBlockBody = consumedPropsDeclaration.childEntities
+            .whereType<BlockFunctionBody>();
+        if (consumedPropsExpressionFunctionBody.isNotEmpty) {
+          currentConsumedProps = consumedPropsExpressionFunctionBody
+              .single.childEntities
+              .whereType<ListLiteral>()
+              .single;
+        } else if (consumedPropsBlockBody.isNotEmpty) {
+          currentConsumedProps = consumedPropsBlockBody
+              .single.block.childEntities
+              .whereType<ReturnStatement>()
+              .single
+              .childEntities
+              .whereType<ListLiteral>()
+              .single;
+        }
+
+        if (currentConsumedProps.elements.isNotEmpty) {
+          if (node.members.isNotEmpty) {
+            yieldPatch(consumedPropsDeclaration.offset,
+                consumedPropsDeclaration.offset, '''
+              // FIXME: As part of the over_react boilerplate migration, $className was removed, 
+              // and all of its props were moved to $nameOfDupeMixin. Double check the `consumedProps` values below,
+              // and the prop forwarding behavior of this component to ensure that no regressions have occurred.
+              ''');
+          } else {
+            yieldPatch(consumedPropsDeclaration.offset,
+                consumedPropsDeclaration.offset, '''
+              // FIXME: As part of the over_react boilerplate migration, $className was removed, 
+              // and replaced by $nameOfDupeMixin. Double check the `consumedProps` values below,
+              // and the prop forwarding behavior of this component to ensure that no regressions have occurred.
+              ''');
+          }
+
+          final metaForConcreteClassThatWillBeRemoved = currentConsumedProps
+              .elements
+              .singleWhere((el) => el.toSource() == '$className.meta',
+                  orElse: () => null);
+          if (metaForConcreteClassThatWillBeRemoved != null) {
+            yieldPatch(
+                metaForConcreteClassThatWillBeRemoved.offset,
+                metaForConcreteClassThatWillBeRemoved.end,
+                'propsMeta.forMixin($nameOfDupeMixin)');
+          }
+        }
+      }
+    } else {
+      // Patch with our newly generated concrete class
+      yieldPatch(node.end, node.end, newDeclarationBuffer.toString());
+    }
 
     // If a class did not get migrated previously because it extended from a custom superclass that
     // did not get migrated, the FIX ME comment that was added may now need to be removed if the

--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -472,7 +472,7 @@ class ClassToMixinConverter {
         // since the "shorthand" / "mixin only" boilerplate will suffice.
         if (!shouldSwapParentClass &&
             dupeClassName != null &&
-            node.withClause.mixinTypes.length == 1 &&
+            node.withClause?.mixinTypes?.length == 1 &&
             node.implementsClause == null) {
           _visitedNames[originalPublicClassName] =
               '${originalPublicClassName}Mixin';

--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -465,7 +465,20 @@ class ClassToMixinConverter {
         // Delete the class since a mixin with the same name already exists,
         // or the class has no members of its own.
         yieldPatch(node.offset, node.end, '');
-        _visitedNames[originalPublicClassName] = originalPublicClassName;
+
+        // If a class extends from UiProps/UiState and uses a single mixin that has a name
+        // that matches the concrete class name appended with `Mixin`,
+        // the advanced props/state migrator will not create a new concrete class declaration
+        // since the "shorthand" / "mixin only" boilerplate will suffice.
+        if (!shouldSwapParentClass &&
+            dupeClassName != null &&
+            node.withClause.mixinTypes.length == 1 &&
+            node.implementsClause == null) {
+          _visitedNames[originalPublicClassName] =
+              '${originalPublicClassName}Mixin';
+        } else {
+          _visitedNames[originalPublicClassName] = originalPublicClassName;
+        }
         return;
       }
     }


### PR DESCRIPTION
## Motivation
When the boilerplate codemod converts components to the "shorthand" (mixin-only) syntax, there is a case where `consumedProps` behavior is changed: when the original props extends directly from UiProps and mixes in a single mixin.

This is because the default consumed props go from being derived from the concrete props class to being derived from the mixin.

#### Reduced test case / illustration of issue:

Before codemod:
```dart
@Factory()
UiFactory<FooProps> Foo = _$Foo;

@PropsMixin()
abstract class FooPropsMixin {
  Map get props;
  
  String foo;
}

@Props()
class FooProps extends UiProps with FooPropsMixin {}

@Component2()
class FooComponent extends UiComponent2<FooProps> {  
  get defaultProps => (newProps()..foo = 'bar');

  render() {
    print(props);                 // {FooPropsMixin.foo: bar}
    print(copyUnconsumedProps()); // {FooPropsMixin.foo: bar}
  }
}
```

After codemod
```dart
UiFactory<FooPropsMixin> Foo = _$Foo;

mixin FooPropsMixin on UiProps {
  String foo;
}

class FooComponent extends UiComponent2<FooPropsMixin> {  
  get defaultProps => FooPropsMixin.defaultProps;

  render() {
    print(props);                 // {FooPropsMixin.foo: bar}
    print(copyUnconsumedProps()); // {}
  }
}
```

## Changes
1. To counteract this, when converting to use the shorthand syntax for this case: 
add a `get consumedProps => [];` (if `consumedProps` isn't already overridden) override to preserve the pre-existing prop forwarding behavior.
1. To avoid other prop namespacing behavior changes, add a fixme comment when merging classes that instructs the consumer to verify prop forwarding behavior.
1. If `OldConcretePropsClass.meta` is used within `consumedProps`, convert it to `propsMeta.forMixin(MergedPropsMixin)`
1. Add tests


#### Release Notes
Preserve `consumedProps` behavior when shorthand boilerplate is used during a migration

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: @greglittlefield-wf @joebingham-wk @sydneyjodon-wk 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
