### PR TITLE
CPLAT-10380 Add suggestor to move factory ignore comments

### DIFF
--- a/lib/src/boilerplate_suggestors/factory_ignore_comment_mover.dart
+++ b/lib/src/boilerplate_suggestors/factory_ignore_comment_mover.dart
@@ -1,0 +1,44 @@
+// Copyright 2020 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:codemod/codemod.dart';
+
+/// Suggestor that moves the `// ignore: ...` comment attached to each
+/// over_react factory from the line before the initializer
+/// to after the semicolon.
+class FactoryIgnoreCommentMover extends RecursiveAstVisitor
+    with AstVisitingSuggestorMixin
+    implements Suggestor {
+  @override
+  void visitTopLevelVariableDeclaration(TopLevelVariableDeclaration node) {
+    final type = node.variables.type;
+    if (!(type is NamedType && type.name.name == 'UiFactory')) {
+      return;
+    }
+
+    final initializer = node.variables.variables.first.initializer;
+    if (initializer == null) return;
+
+    final comment = initializer.beginToken.precedingComments;
+    if (comment == null) return;
+
+    final commentText = sourceFile.getText(comment.offset, comment.end);
+    if (commentText.contains('ignore: undefined_identifier')) {
+      yieldPatch(comment.offset, comment.end, '');
+      yieldPatch(node.end, node.end, ' // ignore: undefined_identifier');
+    }
+  }
+}

--- a/lib/src/executables/boilerplate_upgrade.dart
+++ b/lib/src/executables/boilerplate_upgrade.dart
@@ -21,6 +21,7 @@ import 'package:meta/meta.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/annotations_remover.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/boilerplate_utilities.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/constants.dart';
+import 'package:over_react_codemod/src/boilerplate_suggestors/factory_ignore_comment_mover.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/props_meta_migrator.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/simple_props_and_state_class_migrator.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/advanced_props_and_state_class_migrator.dart';
@@ -121,6 +122,7 @@ void main(List<String> args) {
       StubbedPropsAndStateClassRemover(classToMixinConverter),
       AnnotationsRemover(classToMixinConverter),
       GeneratedPartDirectiveIgnoreRemover(),
+      FactoryIgnoreCommentMover(),
     ].map((s) => Ignoreable(s)),
     args: parsedArgs.rest,
     defaultYes: true,

--- a/test/boilerplate_suggestors/factory_ignore_comment_mover.suggestor_test
+++ b/test/boilerplate_suggestors/factory_ignore_comment_mover.suggestor_test
@@ -1,0 +1,41 @@
+FactoryIgnoreCommentMover @dartfmt_output
+>>> empty file (patches 0)
+<<<
+
+
+>>> no matches (patches 0)
+library foo;
+var a = 'b';
+class Foo {}
+<<<
+library foo;
+var a = 'b';
+class Foo {}
+
+
+>>> factory with no initializer (patches 0)
+UiFactory<FooProps> Foo;
+<<<
+UiFactory<FooProps> Foo;
+
+
+>>> factory with no ignore comment (patches 0)
+UiFactory<FooProps> Foo = _$Foo;
+<<<
+UiFactory<FooProps> Foo = _$Foo;
+
+
+>>> factory (patches 2)
+UiFactory<FooProps> Foo =
+    // ignore: undefined_identifier
+    _$Foo;
+<<<
+UiFactory<FooProps> Foo = _$Foo; // ignore: undefined_identifier
+
+
+>>> factory with no type params (patches 2)
+UiFactory Foo =
+    // ignore: undefined_identifier
+    _$Foo;
+<<<
+UiFactory Foo = _$Foo; // ignore: undefined_identifier

--- a/test/suggestors_test.dart
+++ b/test/suggestors_test.dart
@@ -14,6 +14,7 @@
 
 @TestOn('vm')
 import 'package:mockito/mockito.dart';
+import 'package:over_react_codemod/src/boilerplate_suggestors/factory_ignore_comment_mover.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -102,5 +103,14 @@ void main() {
       ),
     };
     testSuggestorsDir(suggestorMap, 'test/dart2_suggestors');
+  });
+
+  group('Boilerplate suggestors', () {
+    final suggestorMap = {
+      'FactoryIgnoreCommentMover': Ignoreable(
+        FactoryIgnoreCommentMover(),
+      ),
+    };
+    testSuggestorsDir(suggestorMap, 'test/boilerplate_suggestors');
   });
 }


### PR DESCRIPTION
## Motivation
Currently, most factories look like this:
```dart
UiFactory<FooProps> Foo =
    // ignore: undefined_identifier
    _$Foo;
```
However, we want the comment to go at the end of the line, so it can become:
```dart
UiFactory<FooProps> Foo = _$Foo; // ignore: undefined_identifier
```

## Changes
- Add suggestor that moves these ignore comments
- Add tests

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->


### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
