### PR TITLE
CPLAT-10515 Preserve consumed props behavior defaults

### DIFF
--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -147,11 +147,12 @@ bool isReservedBaseClass(String className) {
       .contains(className);
 }
 
-/// Returns whether the [classNode] should be considered "abstract" based on both
-/// the presence of the `abstract` keyword, and also the `@AbstractProps()` / `@AbstractState()`
-/// annotations present.
+/// Returns whether the [classNode] should be considered "abstract" based on either
+/// the presence of the `abstract` keyword, and `Abstract`- annotations.
 bool isAbstract(ClassDeclaration classNode) =>
     classNode.isAbstract ||
+    getAnnotationNode(classNode, 'AbstractComponent') != null ||
+    getAnnotationNode(classNode, 'AbstractComponent2') != null ||
     getAnnotationNode(classNode, 'AbstractProps') != null ||
     getAnnotationNode(classNode, 'AbstractState') != null;
 

--- a/lib/src/component2_suggestors/component2_utilities.dart
+++ b/lib/src/component2_suggestors/component2_utilities.dart
@@ -80,16 +80,7 @@ bool fullyUpgradableToComponent2(ClassDeclaration classNode) {
   String reactImportName =
       getImportNamespace(classNode, 'package:react/react.dart');
 
-  var componentClassNames = [
-    'UiComponent',
-    'UiComponent2',
-    'UiStatefulComponent',
-    'UiStatefulComponent2',
-    'FluxUiComponent',
-    'FluxUiComponent2',
-    'FluxUiStatefulComponent',
-    'FluxUiStatefulComponent2',
-  ];
+  final componentClassNames = {...overReactBaseComponentClasses};
 
   if (reactImportName != null) {
     componentClassNames.add('$reactImportName.Component');

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -80,6 +80,17 @@ const List<String> upgradableV1ComponentClassNames = [
   'FluxUiStatefulComponent',
 ];
 
+const overReactBaseComponentClasses = {
+  'UiComponent',
+  'UiComponent2',
+  'UiStatefulComponent',
+  'UiStatefulComponent2',
+  'FluxUiComponent',
+  'FluxUiComponent2',
+  'FluxUiStatefulComponent',
+  'FluxUiStatefulComponent2',
+};
+
 /// Dart type for the static meta field on props classes.
 const String propsMetaType = 'PropsMeta';
 

--- a/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
@@ -414,7 +414,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
             },
           )(
-            expectedPatchCount: 6,
             input: '''
             $factoryDecl
 
@@ -524,7 +523,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
             // Run it a third time - this time simulating `--convert-classes-with-external-superclasses`
             // being set - which allows conversion of external superclasses
             testSuggestor(convertClassesWithExternalSuperclass: true)(
-              expectedPatchCount: 7,
               input: expectedOutputWithExternalSuperclassReasonComment,
               expectedOutput: '''
               $factoryDecl
@@ -574,7 +572,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
           // Run it a second time - this time simulating `--convert-classes-with-external-superclasses`
           // being set - which allows conversion of external superclasses
           testSuggestor(convertClassesWithExternalSuperclass: true)(
-            expectedPatchCount: 6,
             input: '''
             $factoryDecl
 
@@ -688,7 +685,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
             // we don't know if the custom classes are external or not.
             testSuggestor()(expectedPatchCount: 0, input: input);
             testSuggestor()(
-              expectedPatchCount: 1,
               input: input,
               expectedOutput: expectedOutputWithExternalSuperclassReasonComment,
             );
@@ -714,7 +710,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
             // Run it a third time - this time simulating `--convert-classes-with-external-superclasses`
             // being set - which allows conversion of external superclasses
             testSuggestor(convertClassesWithExternalSuperclass: true)(
-              expectedPatchCount: 8,
               input: expectedOutputWithExternalSuperclassReasonComment,
               expectedOutput: '''
               $factoryDecl
@@ -764,7 +759,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
           // Run it a second time - this time simulating `--convert-classes-with-external-superclasses`
           // being set - which allows conversion of external superclasses
           testSuggestor(convertClassesWithExternalSuperclass: true)(
-            expectedPatchCount: 7,
             input: input,
             expectedOutput: '''
               $factoryDecl
@@ -850,7 +844,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
               'ADifferentPropsClass': null,
             },
           )(
-            expectedPatchCount: 1,
             input: input,
             expectedOutput: expectedOutputWithUnMigratedSuperclassReasonComment,
           );
@@ -875,7 +868,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
             },
           )(
-            expectedPatchCount: 7,
             input: expectedOutputWithUnMigratedSuperclassReasonComment,
             expectedOutput: '''
             $factoryDecl
@@ -952,7 +944,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
               // we don't know if the custom classes are external or not.
               testSuggestor()(expectedPatchCount: 0, input: input);
               testSuggestor()(
-                expectedPatchCount: 1,
                 input: input,
                 expectedOutput: expectedOutputWithExternalMixinReasonComment,
               );
@@ -977,7 +968,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
               // Run it a third time - this time simulating `--convert-classes-with-external-superclasses`
               // being set - which allows conversion of external mixins
               testSuggestor(convertClassesWithExternalSuperclass: true)(
-                expectedPatchCount: 7,
                 input: expectedOutputWithExternalMixinReasonComment,
                 expectedOutput: '''
                 $factoryDecl
@@ -1063,7 +1053,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
               // we don't know if the custom classes are external or not.
               testSuggestor()(expectedPatchCount: 0, input: input);
               testSuggestor()(
-                expectedPatchCount: 1,
                 input: input,
                 expectedOutput: expectedOutputWithExternalMixinReasonComment,
               );
@@ -1088,7 +1077,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
               // Run it a third time - this time simulating `--convert-classes-with-external-superclasses`
               // being set - which allows conversion of external mixins
               testSuggestor(convertClassesWithExternalSuperclass: true)(
-                expectedPatchCount: 7,
                 input: expectedOutputWithExternalMixinReasonComment,
                 expectedOutput: '''
                 $factoryDecl
@@ -1192,7 +1180,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
               'ADifferentStateClass': 'ADifferentStateClassMixin',
             },
           )(
-            expectedPatchCount: 12,
             input: input,
             expectedOutput: expectedOutput,
           );
@@ -1220,7 +1207,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
               'ADifferentStateClass': 'ADifferentStateClassMixin',
             },
           )(
-            expectedPatchCount: 12,
             input: input,
             expectedOutput: expectedOutput,
           );
@@ -1291,7 +1277,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
               'AnotherStateMixin': 'AnotherStateMixin',
             },
           )(
-            expectedPatchCount: 12,
             input: input,
             expectedOutput: expectedOutput,
           );
@@ -1318,7 +1303,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
               'AnotherStateMixin': 'AnotherStateMixin',
             },
           )(
-            expectedPatchCount: 12,
             input: input,
             expectedOutput: expectedOutput,
           );
@@ -1359,7 +1343,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
                 ''';
 
             testSuggestor()(
-              expectedPatchCount: 6,
               input: input,
               expectedOutput: '''
               $factoryDecl
@@ -1450,7 +1433,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
               testSuggestor(visitedClassNames: {
                 'SomePropsMixin': 'SomePropsMixin',
               })(
-                expectedPatchCount: 7,
                 input: input,
                 expectedOutput: expectedOutput,
               );
@@ -1468,7 +1450,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
               testSuggestor(visitedClassNames: {
                 'SomePropsMixin': 'SomePropsMixin',
               })(
-                expectedPatchCount: 7,
                 input: input,
                 expectedOutput: expectedOutput,
               );
@@ -1498,7 +1479,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
               testSuggestor(visitedClassNames: {
                 'SomePropsMixin': 'SomePropsMixin',
               })(
-                expectedPatchCount: 8,
                 input: input,
                 expectedOutput: r'''
                 @AbstractProps()
@@ -1536,7 +1516,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
               testSuggestor(visitedClassNames: {
                 'SomePropsMixin': 'SomePropsMixin',
               })(
-                expectedPatchCount: 2,
                 input: input,
                 expectedOutput: r'''
                 @AbstractProps()
@@ -1561,7 +1540,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
             testSuggestor(visitedClassNames: {
               'ADifferentPropsClass': 'ADifferentPropsClassMixin',
             })(
-              expectedPatchCount: 6,
               input: '''
               $factoryDecl
 
@@ -1631,7 +1609,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
                 'LayoutPropsMixin': 'LayoutPropsMixin',
                 'BlockPropsMixin': null,
               })(
-                expectedPatchCount: 8,
                 input: input,
                 expectedOutput: r'''
                 @AbstractProps()
@@ -1690,7 +1667,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
                 'LayoutPropsMixin': 'LayoutPropsMixin',
                 'BlockPropsMixin': null,
               })(
-                expectedPatchCount: 2,
                 input: input,
                 expectedOutput: r'''
                 @AbstractProps()
@@ -1741,7 +1717,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
                 'BreadcrumbPathPropsMixin': 'BreadcrumbPathPropsMixin',
                 'AbstractGraphFormProps': 'AbstractGraphFormProps',
               })(
-                expectedPatchCount: 7,
                 input: input,
                 expectedOutput: r'''
                 @PropsMixin()
@@ -1795,7 +1770,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
                 'BreadcrumbPathPropsMixin': 'BreadcrumbPathPropsMixin',
                 'AbstractGraphFormProps': 'AbstractGraphFormProps',
               })(
-                expectedPatchCount: 2,
                 input: input,
                 expectedOutput: r'''
                 @PropsMixin()
@@ -1826,7 +1800,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
               testSuggestor(visitedClassNames: {
                 'SomeAbstractPropsClass': 'SomeAbstractPropsClassMixin',
               })(
-                expectedPatchCount: 6,
                 input: '''
                 $factoryDecl
 
@@ -1889,7 +1862,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
               testSuggestor(visitedClassNames: {
                 'SomeAbstractPropsClass': 'SomeAbstractPropsClass',
               })(
-                expectedPatchCount: 2,
                 input: '''
                 $factoryDecl
 
@@ -1965,7 +1937,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
             'ConvertedMixin': 'ConvertedMixin',
             'UnconvertedMixin': null,
           })(
-            expectedPatchCount: 6,
             input: input,
             expectedOutput: '''
             $factoryDecl
@@ -2009,7 +1980,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
             ''';
 
           testSuggestor()(
-            expectedPatchCount: 6,
             input: input,
             expectedOutput: '''
             $factoryDecl
@@ -2039,7 +2009,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
             testSuggestor(visitedClassNames: {
               'ConvertedMixin': 'ConvertedMixin',
             })(
-              expectedPatchCount: 6,
               input: '''
               $factoryDecl
 
@@ -2106,7 +2075,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
                 'LayoutPropsMixin': 'LayoutPropsMixin',
                 'BlockPropsMixin': null,
               })(
-                expectedPatchCount: 7,
                 input: input,
                 expectedOutput: r'''
                 @AbstractProps()
@@ -2162,7 +2130,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
                 'LayoutPropsMixin': 'LayoutPropsMixin',
                 'BlockPropsMixin': null,
               })(
-                expectedPatchCount: 2,
                 input: input,
                 expectedOutput: r'''
                 @AbstractProps()
@@ -2210,7 +2177,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
               testSuggestor(visitedClassNames: {
                 'BreadcrumbPathPropsMixin': 'BreadcrumbPathPropsMixin',
               })(
-                expectedPatchCount: 6,
                 input: input,
                 expectedOutput: r'''
                 @PropsMixin()
@@ -2261,7 +2227,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
               testSuggestor(visitedClassNames: {
                 'BreadcrumbPathPropsMixin': 'BreadcrumbPathPropsMixin',
               })(
-                expectedPatchCount: 2,
                 input: input,
                 expectedOutput: r'''
                 @PropsMixin()
@@ -2295,7 +2260,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
               testSuggestor(visitedClassNames: {
                 '${publicPropsClassName}Mixin': '${publicPropsClassName}Mixin',
               })(
-                expectedPatchCount: 3,
                 input: '''
                 $factoryDecl
   
@@ -2350,7 +2314,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
                   '${publicPropsClassName}Mixin':
                       '${publicPropsClassName}Mixin',
                 })(
-                  expectedPatchCount: 2,
                   input: '''
                   $factoryDecl
     
@@ -2400,7 +2363,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
                     '${publicPropsClassName}Mixin':
                         '${publicPropsClassName}Mixin',
                   })(
-                    expectedPatchCount: 4,
                     input: '''
                     $factoryDecl
       
@@ -2456,7 +2418,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
                     '${publicPropsClassName}Mixin':
                         '${publicPropsClassName}Mixin',
                   })(
-                    expectedPatchCount: 3,
                     input: '''
                     $factoryDecl
       
@@ -2513,7 +2474,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
                     '${publicPropsClassName}Mixin':
                         '${publicPropsClassName}Mixin',
                   })(
-                    expectedPatchCount: 4,
                     input: '''
                     $factoryDecl
       
@@ -2573,7 +2533,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
                     '${publicPropsClassName}Mixin':
                         '${publicPropsClassName}Mixin',
                   })(
-                    expectedPatchCount: 3,
                     input: '''
                     $factoryDecl
       
@@ -2637,7 +2596,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
               testSuggestor(visitedClassNames: {
                 '${publicPropsClassName}Mixin': '${publicPropsClassName}Mixin',
               })(
-                expectedPatchCount: 4,
                 input: '''
                 $factoryDecl
 
@@ -2695,7 +2653,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
                   '${publicPropsClassName}Mixin':
                       '${publicPropsClassName}Mixin',
                 })(
-                  expectedPatchCount: 3,
                   input: '''
                   $factoryDecl
     
@@ -2748,7 +2705,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
                     '${publicPropsClassName}Mixin':
                         '${publicPropsClassName}Mixin',
                   })(
-                    expectedPatchCount: 5,
                     input: '''
                     $factoryDecl
       
@@ -2807,7 +2763,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
                     '${publicPropsClassName}Mixin':
                         '${publicPropsClassName}Mixin',
                   })(
-                    expectedPatchCount: 4,
                     input: '''
                     $factoryDecl
       
@@ -2867,7 +2822,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
                     '${publicPropsClassName}Mixin':
                         '${publicPropsClassName}Mixin',
                   })(
-                    expectedPatchCount: 5,
                     input: '''
                     $factoryDecl
       
@@ -2930,7 +2884,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
                     '${publicPropsClassName}Mixin':
                         '${publicPropsClassName}Mixin',
                   })(
-                    expectedPatchCount: 4,
                     input: '''
                     $factoryDecl
       
@@ -3024,7 +2977,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
           'AnotherStateMixin': 'AnotherStateMixin',
           'ADifferentStateClass': 'ADifferentStateClass',
         })(
-          expectedPatchCount: 14,
           input: input,
           expectedOutput: '''
           $factoryDecl
@@ -3087,7 +3039,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
 
           test('and the class has no members', () {
             testSuggestor()(
-              expectedPatchCount: 2,
               input: '''
               $factoryDecl
 
@@ -3130,7 +3081,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
 
           test('and the class has members', () {
             testSuggestor()(
-              expectedPatchCount: 3,
               input: '''
               $factoryDecl
 
@@ -3191,7 +3141,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
 
           test('and the class has no members', () {
             testSuggestor()(
-              expectedPatchCount: 2,
               input: '''
               $factoryDecl
 
@@ -3222,7 +3171,6 @@ void advancedPropsAndStateClassMigratorTestHelper({
 
           test('and the class has members', () {
             testSuggestor()(
-              expectedPatchCount: 2,
               input: '''
               $factoryDecl
 

--- a/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
@@ -47,9 +47,36 @@ void advancedPropsAndStateClassMigratorTestHelper({
       @Component2()
       class FooComponent extends UiComponent2<$publicPropsClassName> {}
       ''';
+
   const statefulComponentDecl = '''
       @Component2()
       class FooComponent extends UiStatefulComponent2<$publicPropsClassName, $publicStateClassName> {}
+      ''';
+
+  String consumedPropsOverride(Iterable<String> mixinNames,
+          {String fixmeComment = ''}) =>
+      '''
+      $fixmeComment
+      @override
+      get consumedProps => ${mixinNames.isEmpty ? '[]' : 'propsMeta.forMixins({${mixinNames.join(',')}})'};
+      ''';
+
+  String componentDeclWithConsumedProps(Iterable<String> mixinNames,
+          {String fixmeComment = ''}) =>
+      '''
+      @Component2()
+      class FooComponent extends UiComponent2<$publicPropsClassName> {
+        ${consumedPropsOverride(mixinNames, fixmeComment: fixmeComment)}
+      }
+      ''';
+
+  String statefulComponentDeclWithConsumedProps(Iterable<String> mixinNames,
+          {String fixmeComment = ''}) =>
+      '''
+      @Component2()
+      class FooComponent extends UiStatefulComponent2<$publicPropsClassName, $publicStateClassName> {
+        ${consumedPropsOverride(mixinNames, fixmeComment: fixmeComment)}
+      }
       ''';
 
   group('', () {
@@ -414,7 +441,7 @@ void advancedPropsAndStateClassMigratorTestHelper({
             //   2. Fix any analyzer warnings on this class about missing mixins.
             class $publicPropsClassName = UiProps with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin;
 
-            $componentDecl
+            ${componentDeclWithConsumedProps(['${publicPropsClassName}Mixin'])}
           ''',
           );
 
@@ -521,7 +548,9 @@ void advancedPropsAndStateClassMigratorTestHelper({
               //      library that contains it. 
               class $publicPropsClassName = UiProps with $externalSuperclassName, ${publicPropsClassName}Mixin;
   
-              $componentDecl
+              ${componentDeclWithConsumedProps([
+                '${publicPropsClassName}Mixin'
+              ])}
             ''',
             );
 
@@ -579,7 +608,9 @@ void advancedPropsAndStateClassMigratorTestHelper({
               //      library that contains it.
               class $publicPropsClassName = UiProps with $externalSuperclassName, ${publicPropsClassName}Mixin;
   
-              $componentDecl
+              ${componentDeclWithConsumedProps([
+              '${publicPropsClassName}Mixin'
+            ])}
             ''',
           );
 
@@ -707,7 +738,9 @@ void advancedPropsAndStateClassMigratorTestHelper({
               //      library that contains them. 
               class $publicPropsClassName = UiProps with $externalSuperclassName, ${publicPropsClassName}Mixin, $externalMixinName;
   
-              $componentDecl
+              ${componentDeclWithConsumedProps([
+                '${publicPropsClassName}Mixin'
+              ])}
             ''',
             );
 
@@ -755,7 +788,9 @@ void advancedPropsAndStateClassMigratorTestHelper({
               //      library that contains them. 
               class $publicPropsClassName = UiProps with $externalSuperclassName, ${publicPropsClassName}Mixin, $externalMixinName;
   
-              $componentDecl
+              ${componentDeclWithConsumedProps([
+              '${publicPropsClassName}Mixin'
+            ])}
             ''',
           );
 
@@ -857,7 +892,7 @@ void advancedPropsAndStateClassMigratorTestHelper({
             //   2. Fix any analyzer warnings on this class about missing mixins.
             class $publicPropsClassName = UiProps with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin;
     
-            $componentDecl
+            ${componentDeclWithConsumedProps(['${publicPropsClassName}Mixin'])}
           ''',
           );
 
@@ -964,7 +999,9 @@ void advancedPropsAndStateClassMigratorTestHelper({
                 //      library that contains it. 
                 class $publicPropsClassName = UiProps with ${publicPropsClassName}Mixin, $externalMixinName;
     
-                $componentDecl
+                ${componentDeclWithConsumedProps([
+                  '${publicPropsClassName}Mixin'
+                ])}
               ''',
               );
 
@@ -1073,7 +1110,9 @@ void advancedPropsAndStateClassMigratorTestHelper({
                 //      library that contains them. 
                 class $publicPropsClassName = UiProps with ${publicPropsClassName}Mixin, $externalMixinNames;
     
-                $componentDecl
+                ${componentDeclWithConsumedProps([
+                  '${publicPropsClassName}Mixin'
+                ])}
               ''',
               );
 
@@ -1113,7 +1152,7 @@ void advancedPropsAndStateClassMigratorTestHelper({
             $statefulComponentDecl
           ''';
 
-        const expectedOutput = '''
+        final expectedOutput = '''
             $factoryDecl
     
             @Props()
@@ -1140,7 +1179,9 @@ void advancedPropsAndStateClassMigratorTestHelper({
             //   2. Fix any analyzer warnings on this class about missing mixins.
             class $publicStateClassName = UiState with ADifferentStateClassMixin, ${publicStateClassName}Mixin;
     
-            $statefulComponentDecl
+            ${statefulComponentDeclWithConsumedProps([
+          '${publicPropsClassName}Mixin'
+        ])}
           ''';
 
         test('on the first run', () {
@@ -1214,7 +1255,7 @@ void advancedPropsAndStateClassMigratorTestHelper({
             $statefulComponentDecl
             ''';
 
-        const expectedOutput = '''
+        final expectedOutput = '''
             $factoryDecl
     
             @Props()
@@ -1235,7 +1276,9 @@ void advancedPropsAndStateClassMigratorTestHelper({
             @State()
             class $publicStateClassName = UiState with ${publicStateClassName}Mixin, AStateMixin, AnotherStateMixin;
     
-            $statefulComponentDecl
+            ${statefulComponentDeclWithConsumedProps([
+          '${publicPropsClassName}Mixin'
+        ])}
           ''';
 
         test('on the first run', () {
@@ -1333,6 +1376,8 @@ void advancedPropsAndStateClassMigratorTestHelper({
   
               @Component2()
               class FooComponent extends FluxUiComponent2<$publicPropsClassName> {
+                ${consumedPropsOverride(['${publicPropsClassName}Mixin'])}
+                  
                 @override
                 render() {
                   return Dom.ul()(
@@ -1371,7 +1416,7 @@ void advancedPropsAndStateClassMigratorTestHelper({
                 }
                 ''';
 
-            const expectedOutput = '''
+            final expectedOutput = '''
                 $factoryDecl
     
                 @Props()
@@ -1389,6 +1434,8 @@ void advancedPropsAndStateClassMigratorTestHelper({
     
                 @Component2()
                 class FooComponent extends FluxUiComponent2<$publicPropsClassName> {
+                  ${consumedPropsOverride(['${publicPropsClassName}Mixin'])}
+                
                   @override
                   render() {
                     return Dom.ul()(
@@ -1541,7 +1588,9 @@ void advancedPropsAndStateClassMigratorTestHelper({
               //   2. Fix any analyzer warnings on this class about missing mixins.
               class $publicPropsClassName = UiProps with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin;
 
-              $componentDecl
+              ${componentDeclWithConsumedProps([
+                '${publicPropsClassName}Mixin'
+              ])}
             ''',
             );
 
@@ -1817,6 +1866,8 @@ void advancedPropsAndStateClassMigratorTestHelper({
 
                 @Component2()
                 class FooComponent extends AbstractComponentClass<$publicPropsClassName> {
+                  ${consumedPropsOverride(['${publicPropsClassName}Mixin'])}
+                
                   @override
                   render() {
                     return Dom.ul()(
@@ -1867,6 +1918,8 @@ void advancedPropsAndStateClassMigratorTestHelper({
 
                 @Component2()
                 class FooComponent extends AbstractComponentClass<$publicPropsClassName> {
+                  ${consumedPropsOverride([])}
+                
                   @override
                   render() {
                     return Dom.ul()(
@@ -1928,7 +1981,7 @@ void advancedPropsAndStateClassMigratorTestHelper({
                 with ${publicPropsClassName}Mixin, ConvertedMixin, UnconvertedMixin, // ignore: mixin_of_non_class, undefined_class
                 \$UnconvertedMixin;
 
-            $componentDecl
+            ${componentDeclWithConsumedProps(['${publicPropsClassName}Mixin'])}
           ''',
           );
 
@@ -1971,7 +2024,7 @@ void advancedPropsAndStateClassMigratorTestHelper({
             class $publicPropsClassName = UiProps
                 with ${publicPropsClassName}Mixin, DomPropsMixin;
 
-            $componentDecl
+            ${componentDeclWithConsumedProps(['${publicPropsClassName}Mixin'])}
           ''',
           );
 
@@ -2011,7 +2064,9 @@ void advancedPropsAndStateClassMigratorTestHelper({
               class $publicPropsClassName = UiProps 
                   with ${publicPropsClassName}Mixin, ConvertedMixin implements SomeInterface, SomeOtherInterface;
 
-              $componentDecl
+              ${componentDeclWithConsumedProps([
+                '${publicPropsClassName}Mixin'
+              ])}
             ''',
             );
 
@@ -3000,7 +3055,9 @@ void advancedPropsAndStateClassMigratorTestHelper({
           class $publicStateClassName = UiState 
               with ADifferentStateClass, ${publicStateClassName}Mixin, AStateMixin, AnotherStateMixin;
 
-          $statefulComponentDecl
+          ${statefulComponentDeclWithConsumedProps([
+            '${publicPropsClassName}Mixin'
+          ])}
         ''',
         );
 
@@ -3060,7 +3117,7 @@ void advancedPropsAndStateClassMigratorTestHelper({
               //   2. Fix any analyzer warnings on this class about missing mixins.
               class $publicPropsClassName = UiProps with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin;
 
-              $componentDecl
+              ${componentDeclWithConsumedProps([])}
             ''',
             );
 
@@ -3106,7 +3163,11 @@ void advancedPropsAndStateClassMigratorTestHelper({
               //   2. Fix any analyzer warnings on this class about missing mixins.
               class $publicPropsClassName = UiProps with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin;
 
-              $componentDecl
+              ${componentDeclWithConsumedProps(
+                ['${publicPropsClassName}Mixin'],
+                fixmeComment:
+                    '// FIXME ensure that these consumed props are correct, since fields were moved from $publicPropsClassName to ${publicPropsClassName}Mixin, but ${publicPropsClassName}Mixin was not consumed before.',
+              )}
             ''',
             );
 
@@ -3148,7 +3209,7 @@ void advancedPropsAndStateClassMigratorTestHelper({
               //   2. Fix any analyzer warnings on this class about missing mixins.
               class $publicPropsClassName = UiProps with ADifferentPropsClassMixin, ${publicPropsClassName}Mixin;
 
-              $componentDecl
+              ${componentDeclWithConsumedProps([])}
             ''',
             );
 
@@ -3183,9 +3244,8 @@ void advancedPropsAndStateClassMigratorTestHelper({
                 // FIXME: Everything in this body needs to be moved to the body of ${publicPropsClassName}Mixin.
                 // Once that is done, the body can be removed, and `extends` can be replaced with `=`.
                 String baz;
-              }
-
-              $componentDecl
+              }              
+              ${componentDeclWithConsumedProps([])}
             ''',
             );
 

--- a/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
@@ -1839,7 +1839,9 @@ void advancedPropsAndStateClassMigratorTestHelper({
 
                 @Component2()
                 class FooComponent extends AbstractComponentClass<$publicPropsClassName> {
-                  ${consumedPropsOverride(['${publicPropsClassName}Mixin'])}
+                  ${consumedPropsOverride([
+                  '${publicPropsClassName}Mixin'
+                ], fixmeComment: '// FIXME Ensure that consumedProps shouldn\'t be inherited from AbstractComponentClass instead of overridden here.')}
                 
                   @override
                   render() {
@@ -1890,7 +1892,7 @@ void advancedPropsAndStateClassMigratorTestHelper({
 
                 @Component2()
                 class FooComponent extends AbstractComponentClass<$publicPropsClassName> {
-                  ${consumedPropsOverride([])}
+                  ${consumedPropsOverride([], fixmeComment: '// FIXME Ensure that consumedProps shouldn\'t be inherited from AbstractComponentClass instead of overridden here.')}
                 
                   @override
                   render() {

--- a/test/util.dart
+++ b/test/util.dart
@@ -204,6 +204,7 @@ void testSuggestor({
   }
 
   if (shouldDartfmtOutput) {
+    input = formatter.format(input, uri: 'input');
     expectedOutput = formatter.format(expectedOutput, uri: 'expectedOutput');
   }
 

--- a/test/util.dart
+++ b/test/util.dart
@@ -204,7 +204,6 @@ void testSuggestor({
   }
 
   if (shouldDartfmtOutput) {
-    input = formatter.format(input, uri: 'input');
     expectedOutput = formatter.format(expectedOutput, uri: 'expectedOutput');
   }
 


### PR DESCRIPTION
## Motivation
Since over_react's new boilerplate will be consuming all mixed in props by defaults (via https://github.com/Workiva/over_react/pull/485), we need to update the codemod to preserve the same set of consumed props when converting legacy boilerplate.

## Changes
**1\. Update migrators to preserve this behavior via `consumedProps` impl updates:**
- simple_props_and_state_migrator - No changes necessary.

  These classes will result in only one props mixin being used, so the default behavior change still results in the single mixin being consumed.

- advanced_props_and_state_migrator

    Cases:
    1. Component already overrides `consumedProps`; do nothing
    1. Props class had no members, so no mixin was created: add `consumedProps` override that consumes no props
    1. Mixin was created from props/state class; add `consumedProps` override that consumes that mixin
    1. Props were moved from class into existing mixin; add `consumedProps` override that consumes that mixin and add a fixme

    Also, if any of these extend from a non-base component, add a fixme to ensure that that consumedProps impl shouldn't be inherited instead of overriding it in the base class

**2\. Update tests, which already had all of these cases covered, to match new behavior**

#### Release Notes
- Update boilerplate migrator to preserve consumedProps behavior

## Review
Please review: @aaronlademann-wf @joebingham-wk @sydneyjodon-wk 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
