### PR TITLE
Add upgrade instructions, to be referenced in followup PR

### DIFF
--- a/docs/boilerplate_upgrade.md
+++ b/docs/boilerplate_upgrade.md
@@ -1,0 +1,68 @@
+# boilerplate_upgrade FIXME Instructions
+
+This page contains detailed follow-up instructions for FIXMEs added by the `boilerplate_upgrade` executable.
+
+
+### External Superclass
+
+> FIXME: `FooProps` could not be auto-migrated to the new over_react boilerplate because it extends from `BarProps`, which comes from from an external library.
+
+To address:
+1. Check on the boilerplate migration status of the library it comes from.
+2. Once the library has released a version that includes updated boilerplate,
+   bump the lower bound of your dependency to that version in your `pubspec.yaml`, and run `pub get`.
+3. Re-run the migration script with the following flag:
+   
+       pub global run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
+   
+4. Once the migration is complete, you should notice that $superclassName has been deprecated. 
+   Follow the deprecation instructions to consume the replacement by either updating your usage to
+   the new class name and/or updating to a different entrypoint that exports the version(s) of 
+   `BarProps` that is compatible with the new over_react boilerplate.
+
+
+### Public API
+
+> FIXME: `FooProps could not be auto-migrated to the new over_react boilerplate because it is exported from the following library in this repo:
+> lib/foo.dart
+> Upgrading it would be considered a breaking change since consumer components can no longer extend from it. 
+
+If are migrating a Workiva library and have questions, or want to discuss alternative solutions, 
+please reach out in the #support-ui-platform Slack room. 
+
+To complete the migration (for instance, for a class named `FooProps`), you can: 
+1. Deprecate `FooProps`.
+2. Make a copy of it, renaming it to something like `FooPropsV2`.
+3. Replace all your current usage of the deprecated `FooProps` with `FooPropsV2`.
+4. Add a `hide FooPropsV2` clause to all places where it is exported, and then run:
+     
+       pub global run over_react_codemod:boilerplate_upgrade
+     
+5a. If `FooProps` had consumers outside this repo, and it was intentionally made public,
+    remove the `hide` clause you added in step 4 so that the new mixin created from `FooPropsV2` 
+    will be a viable replacement for `FooProps`.
+5b. If `FooProps` had no consumers outside this repo, and you have no reason to make the new
+    "V2" class / mixin public, update the `hide` clause you added in step 4 to include both the 
+    concrete class and the newly created mixin.
+6. Remove this FIXME comment.
+
+
+### Unmigrated Superclass
+> FIXME: `FooProps` could not be auto-migrated to the new over_react boilerplate because it extends from `BarProps`, which was not able to be migrated.
+
+To complete the migration, you should:
+1. Look at the FIXME comment that has been added to `BarProps` - 
+   and follow the steps outlined there to complete the migration.
+2. Re-run the migration script:
+   
+       pub global run over_react_codemod:boilerplate_upgrade
+
+
+### Non-Component2
+> FIXME: `FooProps` could not be auto-migrated to the new over_react boilerplate because `FooComponent` does not extend from `UiComponent2`.
+
+To complete the migration, you should:
+1. [Convert the component to extend from UiComponent2](https://github.com/Workiva/over_react/blob/master/doc/ui_component2_transition.md)
+1. Re-run the boilerplate migration script:
+    
+       pub global run over_react_codemod:boilerplate_upgrade 


### PR DESCRIPTION
## Motivation
https://github.com/Workiva/over_react_codemod/pull/92 updates FIXME comments to link to more advanced instructions as opposed to including them in consumer repos, to cut down on clutter.

Example of the new comments:
```
// FIXME: `PlaceholderNodeProps` could not be auto-migrated to the new over_react boilerplate because it extends from WsDraggableItemProps, which comes from from an external library.
// Once that component has been upgraded to the new boilerplate, see instructions here: https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#external-superclass
```
which links to https://github.com/Workiva/over_react_codemod/tree/master/docs/boilerplate_upgrade.md#external-superclass.

That branch isn't ready to be merged yet, but we want to be able to use these comments in the meantime, so we need to get this markdown doc in master.

## Changes
Add in markdown document that will be referenced by FIXME comments added in the version of the codemod in https://github.com/Workiva/over_react_codemod/pull/92


## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
