### PR TITLE
CPLAT-11169 Improve handling of newlines in boilerplate upgrades

### DIFF
--- a/lib/src/boilerplate_suggestors/annotations_remover.dart
+++ b/lib/src/boilerplate_suggestors/annotations_remover.dart
@@ -43,7 +43,12 @@ class AnnotationsRemover extends GeneralizingAstVisitor
     if (!_propsOrStateClassBoilerplateIsCompatible(node)) return;
 
     // --- Migrate --- //
-    yieldPatch(annotationToRemove.offset, annotationToRemove.end, '');
+    // Take out the whole line if we can
+    var end = annotationToRemove.end;
+    if (sourceFile.getText(end, end + 1) == '\n') {
+      end = end + 1;
+    }
+    yieldPatch(annotationToRemove.offset, end, '');
   }
 
   static const _relevantAnnotationNames = [

--- a/lib/src/dart2_suggestors/generated_part_directive_ignore_remover.dart
+++ b/lib/src/dart2_suggestors/generated_part_directive_ignore_remover.dart
@@ -35,7 +35,17 @@ class GeneratedPartDirectiveIgnoreRemover extends RecursiveAstVisitor
     final prevLineStart = sourceFile.getOffset(sourceFile.getLine(prevLineEnd));
     final prevLine = sourceFile.getText(prevLineStart, prevLineEnd);
     if (_ignoreComment.hasMatch(prevLine)) {
-      yieldPatch(prevLineStart, prevLineEnd + 1, '');
+      final lineBeforeCommentEnd = prevLineStart - 1;
+      final lineBeforeCommentStart =
+          sourceFile.getOffset(sourceFile.getLine(lineBeforeCommentEnd));
+      final lineBeforeComment =
+          sourceFile.getText(lineBeforeCommentStart, lineBeforeCommentEnd);
+
+      // Only replace with a newline unless it'd result in double spaces or spaces between parts
+      final shouldRemoveNewline =
+          lineBeforeComment.isEmpty || lineBeforeComment.startsWith('part');
+      yieldPatch(
+          prevLineStart, prevLineEnd + (shouldRemoveNewline ? 1 : 0), '');
     }
   }
 }

--- a/test/boilerplate_suggestors/annotations_remover_test.dart
+++ b/test/boilerplate_suggestors/annotations_remover_test.dart
@@ -73,6 +73,7 @@ main() {
               // ignore: undefined_identifier
               \$Foo;
     
+          /// Doc comment that should not have a blank space after it after annotation removal
           @AbstractProps()
           mixin AbstractFooPropsMixin on UiProps {
             bool baz;
@@ -128,6 +129,7 @@ main() {
               // ignore: undefined_identifier
               \$Foo;
     
+          /// Doc comment that should not have a blank space after it after annotation removal
           mixin AbstractFooPropsMixin on UiProps {
             bool baz;
           }

--- a/test/dart2_suggestors/generated_part_directive_ignore_remover.suggestor_test
+++ b/test/dart2_suggestors/generated_part_directive_ignore_remover.suggestor_test
@@ -13,7 +13,7 @@ var a = 'b';
 class Random {}
 
 
->>> removes comment (patches 1)
+>>> removes comment and leaves a newline after imports (patches 1)
 library foo;
 
 import 'bar.dart';
@@ -23,4 +23,29 @@ part 'foo.over_react.g.dart';
 library foo;
 
 import 'bar.dart';
+
+part 'foo.over_react.g.dart';
+
+
+>>> removes comment and newline to avoid double newlines (patches 1)
+library foo;
+
+// ignore: uri_has_not_been_generated
+part 'foo.over_react.g.dart';
+<<<
+library foo;
+
+part 'foo.over_react.g.dart';
+
+
+>>> removes comment and newline to avoid newlines between parts (patches 1)
+library foo;
+
+part 'some_other_part.dart';
+// ignore: uri_has_not_been_generated
+part 'foo.over_react.g.dart';
+<<<
+library foo;
+
+part 'some_other_part.dart';
 part 'foo.over_react.g.dart';


### PR DESCRIPTION
## Motivation
Newlines would be removed when removing annotations and part ignores, leading to undesirable output even after running dartfmt:

Before:
```dart
import 'foo.dart';
// ignore: uri_has_not_been_generated
part `foo_component.over_react.g.dart`;

/// Displays the foos.
@Factory()
UiFactory Foo = _$Foo; ignore: undefined_identifier
```

After, dartfmt'd:
```dart
import 'foo.dart';
part `foo_component.over_react.g.dart`;

/// Displays the foos.

UiFactory Foo = _$Foo; ignore: undefined_identifier
```

Desired output:
```dart
import 'foo.dart';

part `foo_component.over_react.g.dart`;

/// Displays the foos.
UiFactory Foo = _$Foo; ignore: undefined_identifier
```



## Changes
- Improve newline handling when removing part ignores
- Improve newline handling when removing annotations
- Add tests

#### Release Notes
Improve handling of newlines in boilerplate upgrades

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
