### PR TITLE
CPLAT-11695 Add option to specify a path or glob upon which to run boilerplate upgrade codemod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-  - stable
+  - "2.8.4" # Change back to stable if we find a path forward with https://github.com/dart-lang/sdk/issues/42977
 
 # Re-use downloaded pub packages everywhere.
 cache:

--- a/docs/boilerplate_upgrade.md
+++ b/docs/boilerplate_upgrade.md
@@ -15,9 +15,9 @@ To address:
    
        pub global run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
 
-       You can use the -p flag to specify a path or glob to run the codemod on only some files:
-       pub global run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses -p "path/to/your/file.dart"
-       pub global run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses -p "lib/**.dart"
+       You can specify one or more paths or globs to run the codemod on only some files:
+       pub global run over_react_codemod:boilerplate_upgrade path/to/your/file.dart another/file.dart --convert-classes-with-external-superclasses
+       pub global run over_react_codemod:boilerplate_upgrade lib/**.dart --convert-classes-with-external-superclasses
    
 4. Once the migration is complete, you should notice that $superclassName has been deprecated. 
    Follow the deprecation instructions to consume the replacement by either updating your usage to
@@ -46,9 +46,9 @@ To complete the migration (for instance, for a class named `FooProps`), you can:
      
        pub global run over_react_codemod:boilerplate_upgrade
 
-       You can use the -p flag to specify a path or glob to run the codemod on only some files:
-       pub global run over_react_codemod:boilerplate_upgrade -p "path/to/your/file.dart"
-       pub global run over_react_codemod:boilerplate_upgrade -p "lib/**.dart"
+       You can specify one or more paths or globs to run the codemod on only some files:
+       pub global run over_react_codemod:boilerplate_upgrade path/to/your/file.dart another/file.dart
+       pub global run over_react_codemod:boilerplate_upgrade lib/**.dart
      
 5.
     1. If `FooProps` had consumers outside this repo, and it was intentionally made public, remove the `hide` clause you added in step 4 so that the new mixin created from `FooPropsV2` will be a viable replacement for `FooProps`.
@@ -66,9 +66,9 @@ To complete the migration (for instance, for a class named `FooProps`), you can:
 
     pub global run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private
 
-    You can use the -p flag to specify a path or glob to run the codemod on only some files:
-    pub global run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private -p "path/to/your/file.dart"
-    pub global run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private -p "lib/**.dart"
+    You can specify one or more paths or globs to run the codemod on only some files:
+    pub global run over_react_codemod:boilerplate_upgrade path/to/your/file.dart another/file.dart --treat-all-components-as-private
+    pub global run over_react_codemod:boilerplate_upgrade lib/**.dart --treat-all-components-as-private
 
 1. Make the concrete props class (`FooProps`) private, and make a public copy of it. In the public copy, mix in all generated classes, and expose the meta constant.
 
@@ -134,9 +134,9 @@ To complete the migration, you should:
    
        pub global run over_react_codemod:boilerplate_upgrade
 
-       You can use the -p flag to specify a path or glob to run the codemod on only some files:
-       pub global run over_react_codemod:boilerplate_upgrade -p "path/to/your/file.dart"
-       pub global run over_react_codemod:boilerplate_upgrade -p "lib/**.dart"
+       You can specify one or more paths or globs to run the codemod on only some files:
+       pub global run over_react_codemod:boilerplate_upgrade path/to/your/file.dart another/file.dart
+       pub global run over_react_codemod:boilerplate_upgrade lib/**.dart
 
 ## Non-Component2
 > FIXME: `FooProps` could not be auto-migrated to the new over_react boilerplate because `FooComponent` does not extend from `UiComponent2`.
@@ -147,6 +147,6 @@ To complete the migration, you should:
     
        pub global run over_react_codemod:boilerplate_upgrade 
 
-       You can use the -p flag to specify a path or glob to run the codemod on only some files:
-       pub global run over_react_codemod:boilerplate_upgrade -p "path/to/your/file.dart"
-       pub global run over_react_codemod:boilerplate_upgrade -p "lib/**.dart"
+       You can specify one or more paths or globs to run the codemod on only some files:
+       pub global run over_react_codemod:boilerplate_upgrade path/to/your/file.dart another/file.dart
+       pub global run over_react_codemod:boilerplate_upgrade lib/**.dart

--- a/docs/boilerplate_upgrade.md
+++ b/docs/boilerplate_upgrade.md
@@ -14,6 +14,10 @@ To address:
 3. Re-run the migration script with the following flag:
    
        pub global run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
+
+       You can use the -p flag to specify a path or glob to run the codemod on only some files:
+       pub global run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses -p "path/to/your/file.dart"
+       pub global run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses -p "lib/**.dart"
    
 4. Once the migration is complete, you should notice that $superclassName has been deprecated. 
    Follow the deprecation instructions to consume the replacement by either updating your usage to
@@ -41,6 +45,10 @@ To complete the migration (for instance, for a class named `FooProps`), you can:
 4. Add a `hide FooPropsV2` clause to all places where it is exported, and then run:
      
        pub global run over_react_codemod:boilerplate_upgrade
+
+       You can use the -p flag to specify a path or glob to run the codemod on only some files:
+       pub global run over_react_codemod:boilerplate_upgrade -p "path/to/your/file.dart"
+       pub global run over_react_codemod:boilerplate_upgrade -p "lib/**.dart"
      
 5.
     1. If `FooProps` had consumers outside this repo, and it was intentionally made public, remove the `hide` clause you added in step 4 so that the new mixin created from `FooPropsV2` will be a viable replacement for `FooProps`.
@@ -57,6 +65,10 @@ To complete the migration (for instance, for a class named `FooProps`), you can:
 1. Remove the fixme comment and perform the migration as if the component were private:     
 
     pub global run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private
+
+    You can use the -p flag to specify a path or glob to run the codemod on only some files:
+    pub global run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private -p "path/to/your/file.dart"
+    pub global run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private -p "lib/**.dart"
 
 1. Make the concrete props class (`FooProps`) private, and make a public copy of it. In the public copy, mix in all generated classes, and expose the meta constant.
 
@@ -122,6 +134,9 @@ To complete the migration, you should:
    
        pub global run over_react_codemod:boilerplate_upgrade
 
+       You can use the -p flag to specify a path or glob to run the codemod on only some files:
+       pub global run over_react_codemod:boilerplate_upgrade -p "path/to/your/file.dart"
+       pub global run over_react_codemod:boilerplate_upgrade -p "lib/**.dart"
 
 ## Non-Component2
 > FIXME: `FooProps` could not be auto-migrated to the new over_react boilerplate because `FooComponent` does not extend from `UiComponent2`.
@@ -131,3 +146,7 @@ To complete the migration, you should:
 1. Re-run the boilerplate migration script:
     
        pub global run over_react_codemod:boilerplate_upgrade 
+
+       You can use the -p flag to specify a path or glob to run the codemod on only some files:
+       pub global run over_react_codemod:boilerplate_upgrade -p "path/to/your/file.dart"
+       pub global run over_react_codemod:boilerplate_upgrade -p "lib/**.dart"

--- a/lib/src/creator_utils.dart
+++ b/lib/src/creator_utils.dart
@@ -143,7 +143,7 @@ class DependencyCreator {
 class DartProjectCreatorTestConfig {
   String _testName;
 
-  /// Wether or not the codemod is expected to run based on the dependencies provided.
+  /// Whether or not the codemod is expected to run based on the dependencies provided.
   ///
   /// default: `false`
   bool shouldRunCodemod = false;

--- a/lib/src/executables/boilerplate_upgrade.dart
+++ b/lib/src/executables/boilerplate_upgrade.dart
@@ -98,10 +98,7 @@ void main(List<String> args) {
   // If a path or multiple paths are provided as a basic arg, get file paths for them.
   Iterable<String> filePaths = [];
   if (pathArgs != null) {
-    Set<String> pathSet = {};
-    pathArgs.forEach((path) =>
-        pathSet.addAll(filePathsFromGlob(Glob(path, recursive: true))));
-    filePaths = pathSet;
+    filePaths = pathArgs.toSet();
     logger?.info("Codemod will run on these files: ${filePaths}");
   } else {
     filePaths = allDartPathsExceptHiddenAndGenerated();

--- a/lib/src/executables/boilerplate_upgrade.dart
+++ b/lib/src/executables/boilerplate_upgrade.dart
@@ -17,7 +17,6 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:codemod/codemod.dart';
 import 'package:collection/collection.dart';
-import 'package:glob/glob.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/annotations_remover.dart';

--- a/lib/src/executables/component2_upgrade.dart
+++ b/lib/src/executables/component2_upgrade.dart
@@ -23,6 +23,7 @@ import 'package:over_react_codemod/src/component2_suggestors/deprecated_lifecycl
 import 'package:over_react_codemod/src/component2_suggestors/setstate_updater.dart';
 import 'package:over_react_codemod/src/component2_suggestors/copyunconsumeddomprops_migrator.dart';
 import 'package:over_react_codemod/src/ignoreable.dart';
+import 'package:over_react_codemod/src/util.dart';
 
 const _noPartialUpgradesFlag = '--no-partial-upgrades';
 const _upgradeAbstractComponentsFlag = '--upgrade-abstract-components';
@@ -42,14 +43,8 @@ void main(List<String> args) {
       args.contains(_upgradeAbstractComponentsFlag);
   args.removeWhere((arg) => arg == _upgradeAbstractComponentsFlag);
 
-  final query = FileQuery.dir(
-    pathFilter: (path) {
-      return isDartFile(path) && !isGeneratedDartFile(path);
-    },
-    recursive: true,
-  );
   exitCode = runInteractiveCodemodSequence(
-    query,
+    allDartPathsExceptHiddenAndGenerated(),
     <Suggestor>[
       // This suggestor needs to be run first in order for subsequent suggestors
       // to run when converting Component to Component2 for the first time.

--- a/lib/src/executables/dart2_upgrade.dart
+++ b/lib/src/executables/dart2_upgrade.dart
@@ -16,7 +16,6 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:codemod/codemod.dart';
-import 'package:path/path.dart' as p;
 
 import '../dart2_suggestors/component_default_props_migrator.dart';
 import '../dart2_suggestors/dollar_prop_keys_migrator.dart';
@@ -60,11 +59,8 @@ void main(List<String> args) {
   final commentPrefix = parseAndRemoveCommentPrefixArg(args);
 
   // Phase 1: Upgrade the over_react dependency in any `pubspec.yaml` files.
-  final pubspecYamlQuery = FileQuery.dir(
-    pathFilter: (path) => p.basename(path) == 'pubspec.yaml',
-  );
   exitCode = runInteractiveCodemod(
-    pubspecYamlQuery,
+    pubspecYamlPaths(),
     PubspecOverReactUpgrader(
       backwardsCompat
           ? PubspecOverReactUpgrader.dart1And2Constraint
@@ -132,10 +128,7 @@ void main(List<String> args) {
   }
 
   exitCode = runInteractiveCodemodSequence(
-    FileQuery.dir(
-      pathFilter: isDartFile,
-      recursive: true,
-    ),
+    allDartPathsExceptHidden(),
     suggestorSequence,
     args: args,
     defaultYes: true,

--- a/lib/src/executables/react16_ci_precheck.dart
+++ b/lib/src/executables/react16_ci_precheck.dart
@@ -14,11 +14,11 @@
 
 import 'dart:io';
 
-import 'package:codemod/codemod.dart';
 import 'package:logging/logging.dart';
 import 'package:pub_semver/pub_semver.dart';
-import 'package:path/path.dart' as p;
 import 'package:yaml/yaml.dart';
+
+import '../util.dart';
 
 final ciLogger = Logger('over_react_codemod.react16_ci_preheck');
 
@@ -68,25 +68,13 @@ void main(List<String> args) {
   });
   ciLogger.info('Checking if project needs to run React 16 codemod...');
 
-  final pubspecYamlQuery = FileQuery.dir(
-    pathFilter: (path) => p.basename(path) == 'pubspec.yaml',
-    recursive: true,
-  );
-
-  List<String> paths;
-  try {
-    paths = pubspecYamlQuery.generateFilePaths().toList();
-  } catch (e, st) {
-    ciLogger.severe('Error listing pubspec.yaml files.', e, st);
-    return;
-  }
-
-  if (paths.isEmpty) {
+  final pubspecYamlQuery = pubspecYamlPaths();
+  if (pubspecYamlQuery == null || pubspecYamlQuery.isEmpty) {
     ciLogger.warning('No pubspec.yaml files found.'
         '\nThe React 16 codemod should not be run.');
   } else {
-    ciLogger.info('Found pubspec.yaml files: $paths');
-    if (paths.any(isInTransition)) {
+    ciLogger.info('Found pubspec.yaml files: ${pubspecYamlQuery.toList()}');
+    if (pubspecYamlQuery.any(isInTransition)) {
       // If there is any pubspec in transition, set the exit code.
       // We want anyone attempting to be in transition to ensure all of their
       // pubspec.yaml files are also in transition.

--- a/lib/src/executables/react16_consumer_overlay_update.dart
+++ b/lib/src/executables/react16_consumer_overlay_update.dart
@@ -16,6 +16,7 @@ import 'dart:io';
 
 import 'package:codemod/codemod.dart';
 import 'package:over_react_codemod/src/react16_suggestors/consumer_overlay_migrator.dart';
+import 'package:over_react_codemod/src/util.dart';
 
 const _changesRequiredOutput = """
   To update your code, run the following commands in your repository:
@@ -26,13 +27,8 @@ Then, review the the changes, address any FIXMEs, and commit.
 """;
 
 void main(List<String> args) {
-  final query = FileQuery.dir(
-    pathFilter: isDartFile,
-    recursive: true,
-  );
-
   exitCode = runInteractiveCodemodSequence(
-    query,
+    allDartPathsExceptHidden(),
     [
       ConsumerOverlayMigrator(),
     ],

--- a/lib/src/executables/react16_dependency_override_update.dart
+++ b/lib/src/executables/react16_dependency_override_update.dart
@@ -19,7 +19,7 @@ import 'package:over_react_codemod/src/dart2_suggestors/pubspec_over_react_upgra
 import 'package:over_react_codemod/src/ignoreable.dart';
 import 'package:over_react_codemod/src/react16_suggestors/constants.dart';
 import 'package:over_react_codemod/src/react16_suggestors/pubspec_react_upgrader.dart';
-import 'package:path/path.dart' as p;
+import 'package:over_react_codemod/src/util.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 import '../react16_suggestors/constants.dart';
@@ -37,13 +37,8 @@ void main(List<String> args) {
   final overReactVersionConstraint =
       VersionConstraint.parse(overReactVersionRangeForTesting);
 
-  final pubspecYamlQuery = FileQuery.dir(
-    pathFilter: (path) => p.basename(path) == 'pubspec.yaml',
-    recursive: true,
-  );
-
   exitCode = runInteractiveCodemod(
-    pubspecYamlQuery,
+    pubspecYamlPaths(),
     AggregateSuggestor([
       PubspecReactUpdater(reactVersionConstraint, shouldAddDependencies: false),
       PubspecOverReactUpgrader(overReactVersionConstraint,

--- a/lib/src/executables/react16_post_rollout_cleanup.dart
+++ b/lib/src/executables/react16_post_rollout_cleanup.dart
@@ -15,13 +15,12 @@
 import 'dart:io';
 
 import 'package:codemod/codemod.dart';
+import 'package:glob/glob.dart';
 import 'package:logging/logging.dart';
 import 'package:over_react_codemod/src/dart2_suggestors/pubspec_over_react_upgrader.dart';
-import 'package:over_react_codemod/src/ignoreable.dart';
 import 'package:over_react_codemod/src/react16_suggestors/comment_remover.dart';
 import 'package:over_react_codemod/src/react16_suggestors/pubspec_react_upgrader.dart';
 import 'package:over_react_codemod/src/react16_suggestors/react16_utilities.dart';
-import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 
 const _changesRequiredOutput = """
@@ -43,12 +42,7 @@ void main(List<String> args) {
   const startingString = 'Check this box';
   const endingString = 'complete';
 
-  final query = FileQuery.dir(
-    pathFilter: (path) {
-      return isDartFile(path) && !isGeneratedDartFile(path);
-    },
-    recursive: true,
-  );
+  final query = filePathsFromGlob(Glob('**.dart', recursive: true));
 
   if (hasUnaddressedReact16Comment(query, logger: logger)) {
     logger.severe(
@@ -58,10 +52,8 @@ void main(List<String> args) {
     return;
   }
 
-  final pubspecYamlQuery = FileQuery.dir(
-    pathFilter: (path) => p.basename(path) == 'pubspec.yaml',
-    recursive: true,
-  );
+  final pubspecYamlQuery =
+      filePathsFromGlob(Glob('**pubspec.yaml', recursive: true));
 
   exitCode = runInteractiveCodemod(
     pubspecYamlQuery,

--- a/lib/src/executables/react16_upgrade.dart
+++ b/lib/src/executables/react16_upgrade.dart
@@ -23,7 +23,7 @@ import 'package:over_react_codemod/src/react16_suggestors/react_dom_render_migra
 import 'package:over_react_codemod/src/react16_suggestors/react_style_maps_updater.dart';
 import 'package:over_react_codemod/src/dart2_suggestors/pubspec_over_react_upgrader.dart';
 import 'package:over_react_codemod/src/react16_suggestors/pubspec_react_upgrader.dart';
-import 'package:path/path.dart' as p;
+import 'package:over_react_codemod/src/util.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 import '../react16_suggestors/constants.dart';
@@ -42,13 +42,8 @@ void main(List<String> args) {
   final overReactVersionConstraint =
       VersionConstraint.parse(overReactVersionRange);
 
-  final pubspecYamlQuery = FileQuery.dir(
-    pathFilter: (path) => p.basename(path) == 'pubspec.yaml',
-    recursive: true,
-  );
-
   exitCode = runInteractiveCodemod(
-    pubspecYamlQuery,
+    pubspecYamlPaths(),
     AggregateSuggestor([
       PubspecReactUpdater(reactVersionConstraint, shouldAddDependencies: false),
       PubspecOverReactUpgrader(overReactVersionConstraint,
@@ -67,15 +62,11 @@ void main(List<String> args) {
     return;
   }
 
+  final dartPaths = allDartPathsExceptHiddenAndGenerated();
+
   // Update Componentry
-  final query = FileQuery.dir(
-    pathFilter: (path) {
-      return isDartFile(path) && !isGeneratedDartFile(path);
-    },
-    recursive: true,
-  );
   exitCode = runInteractiveCodemodSequence(
-    query,
+    dartPaths,
     <Suggestor>[
       ReactDomRenderMigrator(),
       ReactStyleMapsUpdater(),
@@ -87,7 +78,7 @@ void main(List<String> args) {
 
   final logger = Logger('over_react_codemod.fixmes');
 
-  if (hasUnaddressedReact16Comment(query, logger: logger)) {
+  if (hasUnaddressedReact16Comment(dartPaths, logger: logger)) {
     exitCode = 1;
   }
 }

--- a/lib/src/react16_suggestors/react16_utilities.dart
+++ b/lib/src/react16_suggestors/react16_utilities.dart
@@ -15,7 +15,6 @@
 import 'dart:io';
 
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:codemod/codemod.dart';
 import 'package:logging/logging.dart';
 import 'package:over_react_codemod/src/util.dart';
 import 'package:source_span/source_span.dart';
@@ -99,10 +98,10 @@ SourceSpan nodeCommentSpan(AnnotatedNode node, SourceFile sourceFile) {
 
 /// Returns whether or not there is a React 16 upgrade comment within a
 /// project that is unaddressed.
-bool hasUnaddressedReact16Comment(FileQuery query, {Logger logger}) {
+bool hasUnaddressedReact16Comment(Iterable<String> paths, {Logger logger}) {
   bool hasUnaddressedComment = false;
 
-  for (var dartFile in query.generateFilePaths()) {
+  for (final dartFile in paths) {
     final dartSource = File(dartFile).readAsStringSync();
     if (dartSource.contains('[ ] $manualValidationCommentSubstring')) {
       logger?.severe(

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -19,6 +19,8 @@ library over_react_codemod.src.util;
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:args/args.dart';
+import 'package:codemod/codemod.dart';
+import 'package:glob/glob.dart';
 import 'package:meta/meta.dart';
 import 'package:over_react_codemod/src/boilerplate_suggestors/boilerplate_utilities.dart';
 import 'package:path/path.dart' as p;
@@ -599,3 +601,13 @@ String stripPrivateGeneratedPrefix(String value) {
 extension IterableNullHelpers<E> on Iterable<E> {
   E get firstOrNull => isEmpty ? null : first;
 }
+
+Iterable<String> pubspecYamlPaths() =>
+    filePathsFromGlob(Glob('**pubspec.yaml', recursive: true));
+
+Iterable<String> allDartPathsExceptHidden() =>
+    filePathsFromGlob(Glob('**.dart', recursive: true));
+
+Iterable<String> allDartPathsExceptHiddenAndGenerated() =>
+    filePathsFromGlob(Glob('**.dart', recursive: true))
+        .where((path) => !path.endsWith('.g.dart'));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,8 +23,9 @@ environment:
 dependencies:
   analyzer: '>=0.37.0 <0.39.0'
   args: ^1.5.1
-  codemod: ^0.1.5
+  codemod: ^0.2.0
   collection: ^1.14.7
+  glob: ^1.2.0
   logging: ^0.11.3+2
   meta: ^1.1.7
   path: ^1.6.2


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
We direct consumers to re-run the boilerplate_upgrade script after making certain changes to individual components. However, there is no way for them to run the script on one or some files, only all files. Running the script on all files can lead to many changes in files other than the ones the consumer updated, which may cause him or her to abandon ship on the update entirely (✋ )

## Changes
  <!-- What this PR changes to fix the problem. -->
This PR adds the ability to specify one or more paths or globs to the boilerplate_upgrade codemod to run the codemod only on the specified files.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->
- Add ability to pass paths or globs to boilerplate_upgrade as basic args to only run the codemod on the specified files.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Run the `boilerplate_upgrade.dart` script locally
- [ ] Ensure that the `--help` flag prints help output
- [ ] Ensure that you can pass one or more paths or globs as a basic argument to the codemod, and that the codemod only runs on the files specified
- [ ] Ensure that not passing in a path as a basic arg runs the codemod on all of the Dart files where you run the codemod
- [ ] Ensure you can mix passing in paths/globs with other options for the codemod such as `--treat-all-components-as-private`

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
