### PR TITLE
RM-81673 Release over_react_codemod 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Boilerplate codemod fixes and improvements:
 - Fix locally-generated semver reports not being readable due to not being nested inside an `{"exports": ...}` object
 - Treat FIXMEs converted to TODOs the same as FIXMEs (and don't add new FIXMEs on top of them)
 - Account for edge cases when Props were named `${componentName}ComponentProps`
-- Ignore common mixins that are known to not implement lifecycle methods and thus shouldn't require necessitate migration:
+- Ignore common mixins that are known to not implement lifecycle methods and thus shouldn't necessitate migration:
     - TypedSnapshot
     - FocusRestorer (Workiva-specific)
     - FormControlApi/FormControlApiV2 (Workiva-specific)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.8.0](https://github.com/Workiva/over_react_codemod/compare/1.8.0...1.7.0)
+
+Boilerplate codemod fixes and improvements:
+- Fix locally-generated semver reports not being readable due to not being nested inside an `{"exports": ...}` object
+- Treat FIXMEs converted to TODOs the same as FIXMEs (and don't add new FIXMEs on top of them)
+- Account for edge cases when Props were named `${componentName}ComponentProps`
+- Ignore common mixins that are known to not implement lifecycle methods and thus shouldn't require necessitate migration:
+    - TypedSnapshot
+    - FocusRestorer (Workiva-specific)
+    - FormControlApi/FormControlApiV2 (Workiva-specific)
+- Update minimum versions of over_react/over_react_test to include important bugfixes
+
 ## [1.7.0](https://github.com/Workiva/over_react_codemod/compare/1.7.0...1.6.0)
 
 - Update boilerplate version updater.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_codemod
-version: 1.7.0
+version: 1.8.0
 homepage: https://github.com/Workiva/over_react_codemod
 
 description: >


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [More tweaks/improvements to boilerplate codemod](https://github.com/Workiva/over_react_codemod/pull/96)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react_codemod/compare/1.7.0...Workiva:release_over_react_codemod_1.8.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react_codemod/compare/1.7.0...1.8.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6153708125028352/logs/)