### PR TITLE
CPLAT-12873 Create executables to update pubspec for React 17 Rollout

### DIFF
--- a/bin/react17_dependency_override_update.dart
+++ b/bin/react17_dependency_override_update.dart
@@ -1,0 +1,15 @@
+// Copyright 2020 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export 'package:over_react_codemod/src/executables/react17_dependency_override_update.dart';

--- a/bin/react17_upgrade.dart
+++ b/bin/react17_upgrade.dart
@@ -1,0 +1,15 @@
+// Copyright 2020 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export 'package:over_react_codemod/src/executables/react17_upgrade.dart';

--- a/lib/src/executables/react17_dependency_override_update.dart
+++ b/lib/src/executables/react17_dependency_override_update.dart
@@ -1,0 +1,51 @@
+// Copyright 2020 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:io';
+
+import 'package:codemod/codemod.dart';
+import 'package:over_react_codemod/src/dart2_suggestors/pubspec_over_react_upgrader.dart';
+import 'package:over_react_codemod/src/ignoreable.dart';
+import 'package:over_react_codemod/src/react16_suggestors/pubspec_react_upgrader.dart';
+import 'package:over_react_codemod/src/util.dart';
+import 'package:pub_semver/pub_semver.dart';
+
+const _changesRequiredOutput = """
+  To update your pubspec, run the following commands:
+  pub global activate over_react_codemod
+  pub global run over_react_codemod:react17_dependency_override_update
+Then, review the the changes and commit.
+""";
+
+const reactVersionRangeForTesting = '^6.0.0-alpha';
+const overReactVersionRangeForTesting = '^4.0.0-alpha';
+
+void main(List<String> args) {
+  final reactVersionConstraint =
+      VersionConstraint.parse(reactVersionRangeForTesting);
+  final overReactVersionConstraint =
+      VersionConstraint.parse(overReactVersionRangeForTesting);
+
+  exitCode = runInteractiveCodemod(
+    pubspecYamlPaths(),
+    AggregateSuggestor([
+      PubspecReactUpdater(reactVersionConstraint, shouldAddDependencies: false),
+      PubspecOverReactUpgrader(overReactVersionConstraint,
+          shouldAddDependencies: true)
+    ].map((s) => Ignoreable(s))),
+    args: args,
+    defaultYes: true,
+    changesRequiredOutput: _changesRequiredOutput,
+  );
+}

--- a/lib/src/executables/react17_upgrade.dart
+++ b/lib/src/executables/react17_upgrade.dart
@@ -27,8 +27,8 @@ const _changesRequiredOutput = """
   pub global run over_react_codemod:react17_upgrade
 """;
 
-const reactVersionRange = '>=5.0.0 <7.0.0';
-const overReactVersionRange = '>=3.0.0 <5.0.0';
+const reactVersionRange = '>=5.7.0 <7.0.0';
+const overReactVersionRange = '>=3.12.0 <5.0.0';
 
 void main(List<String> args) {
   final reactVersionConstraint = VersionConstraint.parse(reactVersionRange);

--- a/lib/src/executables/react17_upgrade.dart
+++ b/lib/src/executables/react17_upgrade.dart
@@ -39,7 +39,8 @@ void main(List<String> args) {
     pubspecYamlPaths(),
     AggregateSuggestor([
       PubspecReactUpdater(reactVersionConstraint, shouldAddDependencies: false),
-      PubspecOverReactUpgrader(overReactVersionConstraint, shouldAddDependencies: false),
+      PubspecOverReactUpgrader(overReactVersionConstraint,
+          shouldAddDependencies: false),
     ].map((s) => Ignoreable(s))),
     args: args,
     defaultYes: true,

--- a/lib/src/executables/react17_upgrade.dart
+++ b/lib/src/executables/react17_upgrade.dart
@@ -1,0 +1,48 @@
+// Copyright 2020 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:io';
+
+import 'package:codemod/codemod.dart';
+import 'package:over_react_codemod/src/ignoreable.dart';
+import 'package:over_react_codemod/src/dart2_suggestors/pubspec_over_react_upgrader.dart';
+import 'package:over_react_codemod/src/react16_suggestors/pubspec_react_upgrader.dart';
+import 'package:over_react_codemod/src/util.dart';
+import 'package:pub_semver/pub_semver.dart';
+
+const _changesRequiredOutput = """
+  To update your code, run the following commands in your repository:
+  pub global activate over_react_codemod
+  pub global run over_react_codemod:react17_upgrade
+""";
+
+const reactVersionRange = '>=5.0.0 <7.0.0';
+const overReactVersionRange = '>=3.0.0 <5.0.0';
+
+void main(List<String> args) {
+  final reactVersionConstraint = VersionConstraint.parse(reactVersionRange);
+  final overReactVersionConstraint =
+      VersionConstraint.parse(overReactVersionRange);
+
+  exitCode = runInteractiveCodemod(
+    pubspecYamlPaths(),
+    AggregateSuggestor([
+      PubspecReactUpdater(reactVersionConstraint, shouldAddDependencies: false),
+      PubspecOverReactUpgrader(overReactVersionConstraint, shouldAddDependencies: false),
+    ].map((s) => Ignoreable(s))),
+    args: args,
+    defaultYes: true,
+    changesRequiredOutput: _changesRequiredOutput,
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,3 +55,5 @@ executables:
   react16_dependency_override_update:
   react16_post_rollout_cleanup:
   react16_upgrade:
+  react17_dependency_override_update:
+  react17_upgrade:


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
For the sourcegraph campaign, we need two different codemod scripts that:
1. Widen current versions to accept react-dart 6.0.0 and over_react 4.0.0
2. Add overrides for testing the alpha versions

## Changes
  <!-- What this PR changes to fix the problem. -->
- Added `react17_upgrade` and `react17_dependency_override_update` codemod executables 
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
      - [ ] pull down this branch and run `pub global activate -s path .` in the repo
      - [ ] run the following commands in a different repo:
        - [ ] `pub global run over_react_codemod:react17_dependency_override_update`
          - [ ] verify that the dependencies have been updated to: `react: ^6.0.0-alpha` and `over_react: ^4.0.0-alpha`
        - [ ] `pub global run over_react_codemod:react17_upgrade`
          - [ ] verify in the pubspec that the `react` and `over_react` version ranges have been widened to include 6.0.0 and 4.0.0 respectively. 
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
