### PR TITLE
CPLAT-12873 Switch React 17 Test Executable to Add Overrides

### DIFF
--- a/lib/src/creator_utils.dart
+++ b/lib/src/creator_utils.dart
@@ -155,8 +155,10 @@ class DependencyCreator {
   String toString() {
     if (asOverride && !asNonGitOrPathOverride) {
       var temp = '  $name:\n';
-      if (gitOverride.isNotEmpty) temp += '    git:\n      url: $gitOverride\n';
-      if (pathOverride.isNotEmpty) temp += '    path: $pathOverride\n';
+      if ((gitOverride?.isNotEmpty) ?? false)
+        temp += '    git:\n      url: $gitOverride\n';
+      if ((pathOverride?.isNotEmpty) ?? false)
+        temp += '    path: $pathOverride\n';
       if (ref != null) temp += '      ref: $ref\n';
       return temp;
     }

--- a/lib/src/creator_utils.dart
+++ b/lib/src/creator_utils.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:over_react_codemod/src/react16_suggestors/dependency_override_updater.dart';
 import 'package:path/path.dart' as p;
 
 /// Creates a temporary package with a `pubspec.yaml` and `main.dart` file
@@ -114,11 +115,35 @@ class DependencyCreator {
       throw ArgumentError(
           'Cannot provide both git and path overrides on single dep.');
     }
-    // Check if the version string is wrapped with quotes or not and if not add them.
+    this.version = _versionWithQuotes(version);
+  }
+
+  DependencyCreator.fromOverrideConfig(DependencyOverrideConfig config) {
+    this.name = config.name;
+
+    switch (config.type) {
+      case ConfigType.simple:
+        this.version =
+            _versionWithQuotes((config as SimpleOverrideConfig).version);
+        this.asNonGitOrPathOverride = true;
+        break;
+      case ConfigType.git:
+        final tConfig = config as GitOverrideConfig;
+        this.asNonGitOrPathOverride = false;
+        this.gitOverride = tConfig.url;
+        this.ref = tConfig.ref;
+        break;
+    }
+  }
+
+  /// Checks if the version string should have quotes ands adds them if necessary.
+  String _versionWithQuotes(String version) {
     if (version.contains(RegExp('[\>\<\=\ ]')) &&
         !version.startsWith(RegExp('[\'\"]'))) {
-      this.version = '"' + version + '"';
+      return '"' + version + '"';
     }
+
+    return version;
   }
 
   bool get asOverride =>

--- a/lib/src/creator_utils.dart
+++ b/lib/src/creator_utils.dart
@@ -155,10 +155,12 @@ class DependencyCreator {
   String toString() {
     if (asOverride && !asNonGitOrPathOverride) {
       var temp = '  $name:\n';
-      if ((gitOverride?.isNotEmpty) ?? false)
+      if ((gitOverride?.isNotEmpty) ?? false) {
         temp += '    git:\n      url: $gitOverride\n';
-      if ((pathOverride?.isNotEmpty) ?? false)
+      }
+      if ((pathOverride?.isNotEmpty) ?? false) {
         temp += '    path: $pathOverride\n';
+      }
       if (ref != null) temp += '      ref: $ref\n';
       return temp;
     }

--- a/lib/src/executables/react17_dependency_override_update.dart
+++ b/lib/src/executables/react17_dependency_override_update.dart
@@ -17,6 +17,7 @@ import 'dart:io';
 import 'package:codemod/codemod.dart';
 import 'package:over_react_codemod/src/dart2_suggestors/pubspec_over_react_upgrader.dart';
 import 'package:over_react_codemod/src/ignoreable.dart';
+import 'package:over_react_codemod/src/react16_suggestors/dependency_override_updater.dart';
 import 'package:over_react_codemod/src/react16_suggestors/pubspec_react_upgrader.dart';
 import 'package:over_react_codemod/src/util.dart';
 import 'package:pub_semver/pub_semver.dart';
@@ -32,18 +33,23 @@ const reactVersionRangeForTesting = '^6.0.0-alpha';
 const overReactVersionRangeForTesting = '^4.0.0-alpha';
 
 void main(List<String> args) {
-  final reactVersionConstraint =
-      VersionConstraint.parse(reactVersionRangeForTesting);
-  final overReactVersionConstraint =
-      VersionConstraint.parse(overReactVersionRangeForTesting);
+  final reactConfig = GitOverrideConfig(
+    name: 'react',
+    url: 'https://github.com/cleandart/react-dart.git',
+    ref: '6.0.0-wip',
+  );
+
+  final overReactConfig = GitOverrideConfig(
+    name: 'over_react',
+    url: 'https://github.com/Workiva/over_react.git',
+    ref: 'release_over_react_4.0.0',
+  );
 
   exitCode = runInteractiveCodemod(
     pubspecYamlPaths(),
-    AggregateSuggestor([
-      PubspecReactUpdater(reactVersionConstraint, shouldAddDependencies: false),
-      PubspecOverReactUpgrader(overReactVersionConstraint,
-          shouldAddDependencies: true)
-    ].map((s) => Ignoreable(s))),
+    DependencyOverrideUpdater(
+        reactOverrideConfig: reactConfig,
+        overReactOverrideConfig: overReactConfig),
     args: args,
     defaultYes: true,
     changesRequiredOutput: _changesRequiredOutput,

--- a/lib/src/executables/react17_dependency_override_update.dart
+++ b/lib/src/executables/react17_dependency_override_update.dart
@@ -15,12 +15,8 @@
 import 'dart:io';
 
 import 'package:codemod/codemod.dart';
-import 'package:over_react_codemod/src/dart2_suggestors/pubspec_over_react_upgrader.dart';
-import 'package:over_react_codemod/src/ignoreable.dart';
 import 'package:over_react_codemod/src/react16_suggestors/dependency_override_updater.dart';
-import 'package:over_react_codemod/src/react16_suggestors/pubspec_react_upgrader.dart';
 import 'package:over_react_codemod/src/util.dart';
-import 'package:pub_semver/pub_semver.dart';
 
 const _changesRequiredOutput = """
   To update your pubspec, run the following commands:

--- a/lib/src/executables/react17_dependency_override_update.dart
+++ b/lib/src/executables/react17_dependency_override_update.dart
@@ -29,9 +29,6 @@ const _changesRequiredOutput = """
 Then, review the the changes and commit.
 """;
 
-const reactVersionRangeForTesting = '^6.0.0-alpha';
-const overReactVersionRangeForTesting = '^4.0.0-alpha';
-
 void main(List<String> args) {
   final reactConfig = GitOverrideConfig(
     name: 'react',

--- a/lib/src/react16_suggestors/dependency_override_updater.dart
+++ b/lib/src/react16_suggestors/dependency_override_updater.dart
@@ -22,14 +22,61 @@ import 'package:yaml/yaml.dart';
 import '../constants.dart';
 import '../creator_utils.dart';
 
+/// A reference to all the known override types.
+enum ConfigType {
+  simple,
+  git,
+}
+
+/// A config representing an override to a git ref.
+///
+/// For example, when adding the following override:
+/// ```yaml
+/// dependency_overrides:
+///   react:
+///     git:
+///       url: https://github.com/cleandart/react-dart.git
+///       ref: a-specific-branch
+/// ```
+class GitOverrideConfig extends DependencyOverrideConfig {
+  final String ref;
+  final String url;
+
+  GitOverrideConfig(
+      {@required String name, @required this.url, @required this.ref})
+      : super(name, ConfigType.git);
+}
+
+/// A config representing an override to a simple version.
+///
+/// For example, adding the following override:
+/// ```yaml
+/// dependency_overrides:
+///   react: ^5.0.0
+/// ```
+class SimpleOverrideConfig extends DependencyOverrideConfig {
+  final String version;
+
+  SimpleOverrideConfig({@required String name, @required this.version})
+      : super(name, ConfigType.simple);
+}
+
+/// The base class for all dependency override configs.
+abstract class DependencyOverrideConfig {
+  final String name;
+  final ConfigType type;
+
+  DependencyOverrideConfig(this.name, this.type);
+}
+
 /// Suggestor that adds overrides for over_react and react in the pubspec.
 class DependencyOverrideUpdater implements Suggestor {
-  final String reactOverrideVersion;
-  final String overReactOverrideVersion;
+  final DependencyOverrideConfig reactOverrideConfig;
+  final DependencyOverrideConfig overReactOverrideConfig;
 
   DependencyOverrideUpdater({
-    this.reactOverrideVersion = '^5.0.0-alpha',
-    this.overReactOverrideVersion = '^3.0.0-alpha',
+    this.reactOverrideConfig,
+    this.overReactOverrideConfig,
   });
 
   @override
@@ -83,11 +130,10 @@ class DependencyOverrideUpdater implements Suggestor {
 
     // Each override has its own object to keep track of what the dependency
     // override is and what it needs to be overridden with.
-    var reactDependencyOverride = DependencyCreator('react',
-        version: reactOverrideVersion, asNonGitOrPathOverride: true);
-
-    var overReactDependencyOverride = DependencyCreator('over_react',
-        version: overReactOverrideVersion, asNonGitOrPathOverride: true);
+    var reactDependencyOverride =
+        DependencyCreator.fromOverrideConfig(reactOverrideConfig);
+    var overReactDependencyOverride =
+        DependencyCreator.fromOverrideConfig(overReactOverrideConfig);
 
     final dependenciesToUpdate = [
       reactDependencyOverride,

--- a/lib/src/react16_suggestors/dependency_override_updater.dart
+++ b/lib/src/react16_suggestors/dependency_override_updater.dart
@@ -42,8 +42,7 @@ class GitOverrideConfig extends DependencyOverrideConfig {
   final String ref;
   final String url;
 
-  GitOverrideConfig(
-      {@required String name, @required this.url, @required this.ref})
+  GitOverrideConfig({@required String name, @required this.url, this.ref})
       : super(name, ConfigType.git);
 }
 

--- a/test/react16_suggestors/dependency_override_updater_test.dart
+++ b/test/react16_suggestors/dependency_override_updater_test.dart
@@ -19,7 +19,14 @@ import '../util.dart';
 
 main() {
   group('DependencyOverrideUpdater', () {
-    final testSuggestor = getSuggestorTester(DependencyOverrideUpdater());
+    final defaultReactConfig =
+        SimpleOverrideConfig(name: 'react', version: '^5.0.0-alpha');
+    final defaultOverReactConfig =
+        SimpleOverrideConfig(name: 'over_react', version: '^3.0.0-alpha');
+
+    final testSuggestor = getSuggestorTester(DependencyOverrideUpdater(
+        reactOverrideConfig: defaultReactConfig,
+        overReactOverrideConfig: defaultOverReactConfig));
 
     const defaultDependencies = '  test: 1.5.1\n'
         '  react: ^4.6.0\n'


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
We need the React 17 test executable to add dependency_overrides instead of setting the dependency to a specific version.

## Changes
  <!-- What this PR changes to fix the problem. -->
- Refactor `DependencyOverrideUpdater` to be able to add git dependency overrides
- Add `DependencyCreator.fromOverrideConfig` to `DependencyCreator`
- Refactor / add tests

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->
- Change the functionality of `react17_dependency_override_update` to add dependency overrides

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
      - [ ] pull down this branch and run `pub global activate -s path .` in the repo
      - [ ] run `pub global run over_react_codemod:react17_dependency_override_update`
          - [ ] verify in the pubspec that dependency overrides were added for react and over_react, pointing to:
            - react
              - url: `https://github.com/cleandart/react-dart.git`
              - ref: `6.0.0-wip`
            - over_react
              - url: `https://github.com/Workiva/over_react.git`
              - ref: `release_over_react_4.0.0`
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
