### PR TITLE
RM-90277 Release over_react_codemod 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.11.0](https://github.com/Workiva/over_react_codemod/compare/1.11.0...1.10.0)
+
+- Update the `react17_dependency_override_update` codemod to add overrides that point to the release branches for React 17 instead of alpha versions.
+
 ## [1.10.0](https://github.com/Workiva/over_react_codemod/compare/1.10.0...1.9.0)
 
 - Add `react17_upgrade` codemod

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_codemod
-version: 1.10.0
+version: 1.11.0
 homepage: https://github.com/Workiva/over_react_codemod
 
 description: >


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [CPLAT-12873 Switch React 17 Test Executable to Add Overrides](https://github.com/Workiva/over_react_codemod/pull/104)


Requested by: @joebingham-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react_codemod/compare/1.10.0...Workiva:release_over_react_codemod_1.11.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react_codemod/compare/1.10.0...1.11.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6153708125028352/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6153708125028352/?pull_number=105&repo_name=Workiva%2Fover_react_codemod)