### PR TITLE
RM-90664 Release over_react_codemod 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.12.0](https://github.com/Workiva/over_react_codemod/compare/1.12.0...1.11.0)
+
+- Add `dart2_9_upgrade` executable that can either:
+  - Upgrade a repo from the mixin based boilerplate to the new factory syntax.
+  - Perform a dry run (using the `--check-for-transitioning` flag) to check if the repo has migrated but also contains the now deprecated mixin based factories.
+
 ## [1.11.0](https://github.com/Workiva/over_react_codemod/compare/1.11.0...1.10.0)
 
 - Update the `react17_dependency_override_update` codemod to add overrides that point to the release branches for React 17 instead of alpha versions.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_codemod
-version: 1.11.0
+version: 1.12.0
 homepage: https://github.com/Workiva/over_react_codemod
 
 description: >


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [CPLAT-12621 Codemod to update factory syntax for Dart 2.9](https://github.com/Workiva/over_react_codemod/pull/106)
	* [CPLAT-13196 Add Flag For Core Check](https://github.com/Workiva/over_react_codemod/pull/109)


Requested by: @joebingham-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react_codemod/compare/1.11.0...Workiva:release_over_react_codemod_1.12.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react_codemod/compare/1.11.0...1.12.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6153708125028352/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6153708125028352/?pull_number=110&repo_name=Workiva%2Fover_react_codemod)