### PR TITLE
Add comments to unblock Dart 2.12

### DIFF
--- a/lib/src/executables/boilerplate_upgrade.dart
+++ b/lib/src/executables/boilerplate_upgrade.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/executables/component2_upgrade.dart
+++ b/lib/src/executables/component2_upgrade.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/executables/dart2_9_upgrade.dart
+++ b/lib/src/executables/dart2_9_upgrade.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2021 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/executables/dart2_upgrade.dart
+++ b/lib/src/executables/dart2_upgrade.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/executables/react16_ci_precheck.dart
+++ b/lib/src/executables/react16_ci_precheck.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/executables/react16_consumer_overlay_update.dart
+++ b/lib/src/executables/react16_consumer_overlay_update.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/executables/react16_dependency_override_update.dart
+++ b/lib/src/executables/react16_dependency_override_update.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/executables/react16_post_rollout_cleanup.dart
+++ b/lib/src/executables/react16_post_rollout_cleanup.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/executables/react16_upgrade.dart
+++ b/lib/src/executables/react16_upgrade.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/executables/react17_dependency_override_update.dart
+++ b/lib/src/executables/react17_dependency_override_update.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/src/executables/react17_upgrade.dart
+++ b/lib/src/executables/react17_upgrade.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/advanced_props_and_state_class_migrator_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/boilerplate_suggestors/annotations_remover_test.dart
+++ b/test/boilerplate_suggestors/annotations_remover_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/boilerplate_suggestors/boilerplate_utilities_test.dart
+++ b/test/boilerplate_suggestors/boilerplate_utilities_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/boilerplate_suggestors/props_meta_migrator_test.dart
+++ b/test/boilerplate_suggestors/props_meta_migrator_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/boilerplate_suggestors/props_mixin_migrator_test.dart
+++ b/test/boilerplate_suggestors/props_mixin_migrator_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
+++ b/test/boilerplate_suggestors/simple_props_and_state_class_migrator_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/boilerplate_suggestors/stubbed_props_and_state_class_remover_test.dart
+++ b/test/boilerplate_suggestors/stubbed_props_and_state_class_remover_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/component2_suggestors/class_name_and_annotation_migrator_test.dart
+++ b/test/component2_suggestors/class_name_and_annotation_migrator_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/component2_suggestors/component2_utilities_test.dart
+++ b/test/component2_suggestors/component2_utilities_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/component2_suggestors/componentdidupdate_migrator_test.dart
+++ b/test/component2_suggestors/componentdidupdate_migrator_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/component2_suggestors/componentwillmount_migrator_test.dart
+++ b/test/component2_suggestors/componentwillmount_migrator_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/component2_suggestors/copyunconsumeddomprops_migrator_test.dart
+++ b/test/component2_suggestors/copyunconsumeddomprops_migrator_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/component2_suggestors/defaultprops_initialstate_migrator_test.dart
+++ b/test/component2_suggestors/defaultprops_initialstate_migrator_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/component2_suggestors/deprecated_lifecycle_suggestor_test.dart
+++ b/test/component2_suggestors/deprecated_lifecycle_suggestor_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/component2_suggestors/setstate_updater_test.dart
+++ b/test/component2_suggestors/setstate_updater_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/dart2_9_suggestors/dart2_9_utilities_test.dart
+++ b/test/dart2_9_suggestors/dart2_9_utilities_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2021 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/dart2_9_suggestors/factory_and_config_ignore_comment_remover_test.dart
+++ b/test/dart2_9_suggestors/factory_and_config_ignore_comment_remover_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2021 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/dart2_9_suggestors/factory_config_migrator_test.dart
+++ b/test/dart2_9_suggestors/factory_config_migrator_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2021 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/dart2_9_suggestors/generated_factory_migrator_test.dart
+++ b/test/dart2_9_suggestors/generated_factory_migrator_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2021 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/dart2_9_suggestors/latest_boilerplate_visitor_test.dart
+++ b/test/dart2_9_suggestors/latest_boilerplate_visitor_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2021 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/dart2_suggestors/needs_over_react_library_collector_test.dart
+++ b/test/dart2_suggestors/needs_over_react_library_collector_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/dart2_suggestors/pubspec_over_react_upgrader_test.dart
+++ b/test/dart2_suggestors/pubspec_over_react_upgrader_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/dart2_suggestors/ui_factory_initializer_test.dart
+++ b/test/dart2_suggestors/ui_factory_initializer_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/executables/react16_ci_precheck_test.dart
+++ b/test/executables/react16_ci_precheck_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/executables/react16_upgrade_test.dart
+++ b/test/executables/react16_upgrade_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/react16_suggestors/comment_remover_test.dart
+++ b/test/react16_suggestors/comment_remover_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/react16_suggestors/consumer_overlay_migrator_test.dart
+++ b/test/react16_suggestors/consumer_overlay_migrator_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/react16_suggestors/dependency_override_updater_test.dart
+++ b/test/react16_suggestors/dependency_override_updater_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/react16_suggestors/pubspec_react_updater_test.dart
+++ b/test/react16_suggestors/pubspec_react_updater_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/react16_suggestors/react_dom_render_migrator_test.dart
+++ b/test/react16_suggestors/react_dom_render_migrator_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/react16_suggestors/react_style_maps_updater_test.dart
+++ b/test/react16_suggestors/react_style_maps_updater_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/suggestors_test.dart
+++ b/test/suggestors_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/util/pubspec_upgrader_test.dart
+++ b/test/util/pubspec_upgrader_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2020 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 // Copyright 2019 Workiva Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Adds null safety opt-out comments to Dart entry points to prepare for Dart 2.12+
Please reach out to #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/add_dart2_9_comments`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/add_dart2_9_comments)