### PR TITLE
RM-94084 Release over_react_codemod 1.12.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_codemod
-version: 1.12.0
+version: 1.12.1
 homepage: https://github.com/Workiva/over_react_codemod
 
 description: >


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Remove deprecated authors field from pubspec.yaml](https://github.com/Workiva/over_react_codemod/pull/112)
	* [Widen Dependency Ranges Blocking Dart 2.13](https://github.com/Workiva/over_react_codemod/pull/114)


Requested by: @aaronlademann-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react_codemod/compare/1.12.0...Workiva:release_over_react_codemod_1.12.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react_codemod/compare/1.12.0...1.12.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6153708125028352/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6153708125028352/?pull_number=115&repo_name=Workiva%2Fover_react_codemod)