### PR TITLE
Upgrade dependency_validator

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: pub get --no-precompile
 
       - name: Validate dependencies
-        run: pub run dependency_validator -i dart_style,meta,over_react,pedantic
+        run: dart run dependency_validator
         if: always() && steps.install.outcome == 'success'
 
       - name: Validate formatting

--- a/lib/src/dependency_validator_suggestors/ignore_updaters/v1_updater.dart
+++ b/lib/src/dependency_validator_suggestors/ignore_updaters/v1_updater.dart
@@ -22,7 +22,7 @@ import 'package:codemod/codemod.dart';
 /// pub run dependency validator
 ///
 /// // After (with `dependency` equal to "a_dependency")
-/// pub run dependency_validator -i a_dependency
+/// dart run dependency_validator
 /// ```
 ///
 /// See: [dependency_validator V1](https://github.com/Workiva/dependency_validator/blob/9554150b6473a7f822be65c863642b94653ea0d0/README.md)
@@ -34,7 +34,7 @@ class V1DependencyValidatorUpdater {
   Stream<Patch> call(FileContext context) async* {
     final fileContent = context.sourceText;
 
-    const command = 'pub run dependency_validator';
+    const command = 'dart run dependency_validator
 
     final commandPattern = RegExp('${RegExp.escape(command)}(.*)');
     final ignoreArgPattern = RegExp(r"(?:-i ?|--ignore[= ])([^ ']+)");

--- a/test/dependency_validator/ignore_updaters/v1_updater_test.dart
+++ b/test/dependency_validator/ignore_updaters/v1_updater_test.dart
@@ -17,7 +17,7 @@ import 'package:test/test.dart';
 
 import '../../util.dart';
 
-const depValidatorCommand = 'pub run dependency_validator';
+const depValidatorCommand = 'dart run dependency_validator
 
 Map<String, String Function(String command)> contexts = {
   'basic-dockerfile': basicDockerFile,


### PR DESCRIPTION
Summary
---
Client Platform is updating dependencies! Read more details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades


This batch is to find and open PRs to upgrade dependency_validator to v2.

Additional manual work that might be needed (CP will do):
 [ ] Run dependency_validator to repos that aren't running it,
   but do have the dependency. 
 [ ] Fix CI due to removing an ignore that was actually needed.

For more info, reach out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/update_dep_validator`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/update_dep_validator)