### PR TITLE
CPLAT-16174 Fix dynamic calls involving toBuilder() being detected as unresolved usages

### DIFF
--- a/lib/src/util/component_usage.dart
+++ b/lib/src/util/component_usage.dart
@@ -570,7 +570,7 @@ FluentComponentUsage? getComponentUsage(InvocationExpression node) {
     builder = functionExpression;
   }
 
-  // Methods name that might look like builders to the name regexes, but we want to exclude.
+  // Method names that might look like builders to the name regexes, but we want to exclude.
   // Excluding these known usages is easier than trying to differentiate unresolved calls
   // from dynamic calls.
   const methodNameBlockList = {

--- a/test/util/component_usage_migrator_test.dart
+++ b/test/util/component_usage_migrator_test.dart
@@ -24,6 +24,10 @@ final sharedContext = SharedAnalysisContext.overReact;
 
 main() {
   group('ComponentUsageMigrator', () {
+    setUpAll(() async {
+      await SharedAnalysisContext.overReact.warmUpAnalysis();
+    });
+
     group('throws when a component usage is not resolved', () {
       test('', () async {
         const unresolvedUsages = [

--- a/test/util/component_usage_test.dart
+++ b/test/util/component_usage_test.dart
@@ -78,6 +78,35 @@ void main() {
               });
             });
           });
+
+          // The not-resolved test case for this test is slightly redundant with
+          // some of the cases in the next group, but the resolved case is important here.
+          test('when containing a blocked method name (unless unresolved)',
+              () async {
+            const testCase = BuilderTestCase(
+              source: 'toBuilder()',
+              imports: fooComponents,
+              componentName: 'Foo',
+              unresolvedComponentName: 'toBuilder',
+              factoryName: 'toBuilder',
+              propsName: 'FooProps',
+              isDom: false,
+              isSvg: false,
+            );
+            final source = '(${testCase.source})()';
+
+            final expressionNode = await parseInvocation(source,
+                imports: testCase.imports, isResolved: isResolved);
+            final componentUsage = getComponentUsage(expressionNode);
+
+            if (isResolved) {
+              checkComponentUsage(componentUsage, testCase, source);
+            } else {
+              expect(componentUsage, isNull,
+                  reason:
+                      'should not be detected as a usage when not resolved');
+            }
+          });
         });
 
         group(
@@ -830,16 +859,16 @@ void checkComponentUsage(FluentComponentUsage? componentUsage,
 }
 
 class BuilderTestCase {
-  String source;
-  String imports;
-  String componentName;
-  String? unresolvedComponentName;
-  String factoryName;
-  String propsName;
-  bool isDom;
-  bool isSvg;
+  final String source;
+  final String imports;
+  final String componentName;
+  final String? unresolvedComponentName;
+  final String factoryName;
+  final String propsName;
+  final bool isDom;
+  final bool isSvg;
 
-  BuilderTestCase({
+  const BuilderTestCase({
     required this.source,
     required this.imports,
     required this.componentName,
@@ -867,13 +896,14 @@ class BarComponent extends UiComponent2<BarProps> {
 }
 FooProps getFooBuilder() => Foo();
 FooProps getBuilderForFoo() => Foo();
+FooProps toBuilder() => Foo();
 ''';
 
 /// An enumeration of all the supported OverReact component builders that can be detected
 /// using [FluentComponentUsage], and used to target code when formatting.
 ///
 /// Keys are descriptions, and values are [BuilderTestCase]s.
-final buildersToTest = {
+const buildersToTest = {
   'DOM factory': BuilderTestCase(
     source: 'Dom.h1()',
     imports: fooComponents,

--- a/test/util/component_usage_test.dart
+++ b/test/util/component_usage_test.dart
@@ -80,25 +80,32 @@ void main() {
           });
         });
 
-        test(
-            'returns null for invocations that aren\'t fluent interface usages',
+        group(
+            'returns null for invocations that are not fluent interface usages:',
             () {
-          Future<void> verifyUsage(String source, String reason) async {
-            final expressionNode =
-                await parseInvocation(source, isResolved: isResolved);
-            var componentUsage = getComponentUsage(expressionNode);
-            expect(componentUsage, isNull, reason: '$source is $reason');
-          }
-
           const {
             'Dom.h1()': 'not full invocation',
             'Foo()': 'not full invocation',
             'fooFactory()': 'not full invocation',
             'foo()': 'not a valid builder',
             'foo.bar()': 'not a valid builder',
+            'foo().bar()': 'not a valid builder',
+            'foo.bar.baz()': 'not a valid builder',
             'foo()()': 'not a valid builder',
             '_foo()()': 'not a valid builder',
-          }.forEach(verifyUsage);
+            'toBuilder()': 'blocked method name',
+            'toBuilder()()': 'blocked method name',
+            'foo.toBuilder()': 'blocked method name',
+            'foo().toBuilder()': 'blocked method name',
+            'foo.bar.toBuilder()': 'blocked method name',
+          }.forEach((source, reason) {
+            test('`$source`', () async {
+              final expressionNode =
+                  await parseInvocation(source, isResolved: isResolved);
+              var componentUsage = getComponentUsage(expressionNode);
+              expect(componentUsage, isNull, reason: '$source is $reason');
+            });
+          });
         });
       }
 


### PR DESCRIPTION
## Motivation
There are some usages of built_value's `Built.toBuilder` method that cause issues detected as component usages.

Take, for example, the expression in the following function:
```dart
void example(Built b) {
  b.toBuilder();
}
```
When the `toBuilder` usages are resolved, the `getComponentUsage` is usually able to use the static type information available to determine that they're not OverReact component usages, since the result of the `toBuilder()` call isn't a subtype of `UiProps`, so `getComponentUsage` returns `null`.


However, if toBuilder is called on a `dynamic` object, such as in this example:
```dart
void example(dynamic b) {
  b.toBuilder();
}
```
then `getComponentUsage` doesn't have any static information on what type `toBuilder` returns (similar to if this call wasn't fully resolved due to some analysis issue), so it falls back to using the name of the method to determine if it looks like a component builder (by seeing if the name contains the string "builder").

## Changes
I started trying to detect dynamic calls and ignore those cases, but unfortunately, it's pretty difficult to tell the difference between members accessed on dynamic expressions and an unresolved member accesses.

So, I opted to specifically check for methods named `toBuilder` (only when the AST is unresolved) and just exclude them as a workaround.

I also added tests, and updated a helper method to reflect the gotcha with dynamic member accesses I mentioned above.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - Verify that running `mui_migration` with this branch of the codemod activated against workflow_client works without throwing errors
            - To activate this branch globally, check out the branch, and within `over_react_codemod` run `pub global activate -s path .`
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
