### PR TITLE
Replace deprecated commands with new dart commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN echo "$GIT_SSH_KEY" > "/root/.ssh/id_rsa"
 RUN chmod 700 /root/.ssh/
 RUN chmod 600 /root/.ssh/id_rsa
 
-RUN pub get
+RUN dart pub get
 
 ARG BUILD_ARTIFACTS_BUILD=/build/pubspec.lock
 FROM scratch

--- a/docs/boilerplate_upgrade.md
+++ b/docs/boilerplate_upgrade.md
@@ -10,14 +10,14 @@ This page contains detailed follow-up instructions for FIXMEs added by the `boil
 To address:
 1. Check on the boilerplate migration status of the library it comes from.
 2. Once the library has released a version that includes updated boilerplate,
-   bump the lower bound of your dependency to that version in your `pubspec.yaml`, and run `pub get`.
+   bump the lower bound of your dependency to that version in your `pubspec.yaml`, and run `dart pub get`.
 3. Re-run the migration script with the following flag:
    
-       pub global run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
+       dart pub global run over_react_codemod:boilerplate_upgrade --convert-classes-with-external-superclasses
 
        You can specify one or more paths or globs to run the codemod on only some files:
-       pub global run over_react_codemod:boilerplate_upgrade path/to/your/file.dart another/file.dart --convert-classes-with-external-superclasses
-       pub global run over_react_codemod:boilerplate_upgrade lib/**.dart --convert-classes-with-external-superclasses
+       dart pub global run over_react_codemod:boilerplate_upgrade path/to/your/file.dart another/file.dart --convert-classes-with-external-superclasses
+       dart pub global run over_react_codemod:boilerplate_upgrade lib/**.dart --convert-classes-with-external-superclasses
    
 4. Once the migration is complete, you should notice that $superclassName has been deprecated. 
    Follow the deprecation instructions to consume the replacement by either updating your usage to
@@ -44,11 +44,11 @@ To complete the migration (for instance, for a class named `FooProps`), you can:
 3. Replace all your current usage of the deprecated `FooProps` with `FooPropsV2`.
 4. Add a `hide FooPropsV2` clause to all places where it is exported, and then run:
      
-       pub global run over_react_codemod:boilerplate_upgrade
+       dart pub global run over_react_codemod:boilerplate_upgrade
 
        You can specify one or more paths or globs to run the codemod on only some files:
-       pub global run over_react_codemod:boilerplate_upgrade path/to/your/file.dart another/file.dart
-       pub global run over_react_codemod:boilerplate_upgrade lib/**.dart
+       dart pub global run over_react_codemod:boilerplate_upgrade path/to/your/file.dart another/file.dart
+       dart pub global run over_react_codemod:boilerplate_upgrade lib/**.dart
      
 5.
     1. If `FooProps` had consumers outside this repo, and it was intentionally made public, remove the `hide` clause you added in step 4 so that the new mixin created from `FooPropsV2` will be a viable replacement for `FooProps`.
@@ -64,11 +64,11 @@ However, it has the drawback of having to keep deprecated code up to date.
 To complete the migration (for instance, for a class named `FooProps`), you can: 
 1. Remove the fixme comment and perform the migration as if the component were private:     
 
-    pub global run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private
+    dart pub global run over_react_codemod:boilerplate_upgrade --treat-all-components-as-private
 
     You can specify one or more paths or globs to run the codemod on only some files:
-    pub global run over_react_codemod:boilerplate_upgrade path/to/your/file.dart another/file.dart --treat-all-components-as-private
-    pub global run over_react_codemod:boilerplate_upgrade lib/**.dart --treat-all-components-as-private
+    dart pub global run over_react_codemod:boilerplate_upgrade path/to/your/file.dart another/file.dart --treat-all-components-as-private
+    dart pub global run over_react_codemod:boilerplate_upgrade lib/**.dart --treat-all-components-as-private
 
 1. Make the concrete props class (`FooProps`) private, and make a public copy of it. In the public copy, mix in all generated classes, and expose the meta constant.
 
@@ -132,11 +132,11 @@ To complete the migration, you should:
    and follow the steps outlined there to complete the migration.
 2. Re-run the migration script:
    
-       pub global run over_react_codemod:boilerplate_upgrade
+       dart pub global run over_react_codemod:boilerplate_upgrade
 
        You can specify one or more paths or globs to run the codemod on only some files:
-       pub global run over_react_codemod:boilerplate_upgrade path/to/your/file.dart another/file.dart
-       pub global run over_react_codemod:boilerplate_upgrade lib/**.dart
+       dart pub global run over_react_codemod:boilerplate_upgrade path/to/your/file.dart another/file.dart
+       dart pub global run over_react_codemod:boilerplate_upgrade lib/**.dart
 
 ## Non-Component2
 > FIXME: `FooProps` could not be auto-migrated to the new over_react boilerplate because `FooComponent` does not extend from `UiComponent2`.
@@ -145,8 +145,8 @@ To complete the migration, you should:
 1. [Convert the component to extend from UiComponent2](https://github.com/Workiva/over_react/blob/master/doc/ui_component2_transition.md)
 1. Re-run the boilerplate migration script:
     
-       pub global run over_react_codemod:boilerplate_upgrade 
+       dart pub global run over_react_codemod:boilerplate_upgrade 
 
        You can specify one or more paths or globs to run the codemod on only some files:
-       pub global run over_react_codemod:boilerplate_upgrade path/to/your/file.dart another/file.dart
-       pub global run over_react_codemod:boilerplate_upgrade lib/**.dart
+       dart pub global run over_react_codemod:boilerplate_upgrade path/to/your/file.dart another/file.dart
+       dart pub global run over_react_codemod:boilerplate_upgrade lib/**.dart

--- a/test/dependency_validator/ignore_updaters/v2_updater_test.dart
+++ b/test/dependency_validator/ignore_updaters/v2_updater_test.dart
@@ -103,7 +103,7 @@ main() {
                 '  exclude:\n'
                 '    # a comment above an excluded directory\n'
                 '    - app\n'
-                '  ignore: \n'
+                '  ignore:\n'
                 '    - $addedDependency\n'
                 '');
       });
@@ -147,7 +147,7 @@ main() {
                 '  exclude:\n'
                 '    # a comment above an excluded directory\n'
                 '    - app\n'
-                '  ignore: \n'
+                '  ignore:\n'
                 '    - $addedDependency\n'
                 '\n'
                 'dependency_overrides:\n'


### PR DESCRIPTION
This Sourcegraph batch replaces deprecated commands from the Dart SDK with the new ones.
All new CLI commands now live under the main `dart` executable. See this issue for the details
https://github.com/dart-lang/sdk/issues/46100

This PR might need to be checked or tweaked for possible errors in the arguments to 
`dart analyze` and `dart format` since they take slightly different arguments than the original.
In most cases for analyze all the arguments can be removed and it can just be `dart analyze`.

Some of the argument changes were difficult to match and replace in an automated way. Since
there are only a few places that might break, it'll be easier to let the batch create the PR
and then manually adjust them.

### Argument changes for dartfmt -> dart format
`-w` should be removed automatically since overwriting files is now the default. But, if you spot one, remove it.
`--dry-run` is not a supported argument now. Replace with `--set-exit-if-changed -o none`

repos that look like they will need updates for dart format
- abide
- abide_archived
- bender.dart
- unscripted (unused repo)

### Argument changes for dartanalyzer -> dart analyze
`--no-hints` and `--no-lints` are removed

repos that look like they will need updates for dart analyze
- user_analytics


### QA steps:

- CI passing is a great start since these commands are usually called in the dockerfile, shell scripts, or skynet
- Check the changeset and if there are scripts that are only run locally and not in CI, try running them locally to verify they work
- If the PR has changes to `dart analyze` or `dart format` check the arguments
- Lastly, look for replacements that matched in the wrong place and should be undone or fixed

[_Created by Sourcegraph batch change `Workiva/dart_commands`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_commands)