### PR TITLE
Update references to the archived slack room #support-client-plat

### DIFF
--- a/skynet.yaml
+++ b/skynet.yaml
@@ -1,6 +1,6 @@
 name: private-unit-tests
 description: Unit tests that require access to our private Pub server.
-contact: 'CPLAT / #support-client-plat'
+contact: 'CPLAT / #support-ui-platform'
 image: drydock.workiva.net/workiva/dart_unit_test_image:1
 size: large
 timeout: eternal

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -1,6 +1,6 @@
 name: private-unit-tests
 description: Unit tests that require access to our private Pub server.
-contact: 'CPLAT / #support-ui-platform'
+contact: 'Frontend Design / #support-ui-platform'
 image: drydock.workiva.net/workiva/dart_unit_test_image:1
 size: large
 timeout: eternal


### PR DESCRIPTION
This batch changes references to the archived support-client-plat slack channel to now reference the support-ui-platform channel.

`replace "#support-client-plat" "#support-ui-platform"`

### QA steps:

CI passing should be sufficient as these changes are documentation changes.

[_Created by Sourcegraph batch change `Workiva/update_slack_channel_fed`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/update_slack_channel_fed)