### PR TITLE
Use platform separator for paths

### DIFF
--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -16,6 +16,8 @@
 /// suggestor.
 library over_react_codemod.src.constants;
 
+import 'dart:io';
+
 const String generatedPrefix = r'$';
 const String privatePrefix = r'_';
 const String privateGeneratedPrefix = '$privatePrefix$generatedPrefix';
@@ -135,3 +137,5 @@ final RegExp dependencyOverrideRegExp = RegExp(
   r'^dependency_overrides:\s*$',
   multiLine: true,
 );
+
+final String slash = Platform.pathSeparator;

--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -157,11 +157,11 @@ void main(List<String> args) async {
   // TODO - reference analyzer issue for this once it's created
   final packageRoots = dartPaths.map(findPackageRootFor).toSet().toList();
   packageRoots.sort((packageA, packageB) =>
-      packageB.split('${slash}').length - packageA.split('${slash}').length);
+      packageB.split(slash).length - packageA.split(slash).length);
 
   Map<String, String> packageNameLookup = Map.fromIterable(
     pubspecYamlPaths(),
-    key: (path) => findPackageRootFor(path).split('${slash}').last,
+    key: (path) => findPackageRootFor(path).split(slash).last,
     value: (path) {
       final pubspec = fs.file(path);
       List<String> pubspecLines = pubspec.readAsLinesSync();
@@ -187,7 +187,7 @@ void main(List<String> args) async {
   for (String package in packageRoots) {
     _log.info('Starting migration for $package');
 
-    final packageRoot = package.split('${slash}').last;
+    final packageRoot = package.split(slash).last;
     final packageName = packageNameLookup[packageRoot] ?? 'fix_me_bad_name';
     _log.info('Starting migration for $packageName');
     final packageDartPath =

--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -15,6 +15,7 @@
 import 'dart:io';
 import 'package:file/file.dart';
 import 'package:file/local.dart';
+import 'package:over_react_codemod/src/constants.dart';
 import 'package:over_react_codemod/src/intl_suggestors/intl_configs_migrator.dart';
 import 'package:over_react_codemod/src/intl_suggestors/intl_importer.dart';
 import 'package:over_react_codemod/src/intl_suggestors/intl_migrator.dart';
@@ -156,11 +157,11 @@ void main(List<String> args) async {
   // TODO - reference analyzer issue for this once it's created
   final packageRoots = dartPaths.map(findPackageRootFor).toSet().toList();
   packageRoots.sort((packageA, packageB) =>
-      packageB.split('/').length - packageA.split('/').length);
+      packageB.split('${slash}').length - packageA.split('${slash}').length);
 
   Map<String, String> packageNameLookup = Map.fromIterable(
     pubspecYamlPaths(),
-    key: (path) => findPackageRootFor(path).split('/').last,
+    key: (path) => findPackageRootFor(path).split('${slash}').last,
     value: (path) {
       final pubspec = fs.file(path);
       List<String> pubspecLines = pubspec.readAsLinesSync();
@@ -186,7 +187,7 @@ void main(List<String> args) async {
   for (String package in packageRoots) {
     _log.info('Starting migration for $package');
 
-    final packageRoot = package.split('/').last;
+    final packageRoot = package.split('${slash}').last;
     final packageName = packageNameLookup[packageRoot] ?? 'fix_me_bad_name';
     _log.info('Starting migration for $packageName');
     final packageDartPath =
@@ -194,7 +195,7 @@ void main(List<String> args) async {
     sortPartsLast(packageDartPath);
 
     final File outputFile = fs.currentDirectory
-        .childFile('${package}/lib/src/intl/${packageName}_intl.dart');
+        .childFile('${package}${slash}lib${slash}src${slash}intl${slash}${packageName}_intl.dart');
     final bool existingOutputFile = outputFile.existsSync();
 
     final className = toClassName('${packageName}');
@@ -292,7 +293,7 @@ Iterable<String> dartFilesToMigrate() => Glob('**.dart', recursive: true)
 
 Iterable<String> dartFilesToMigrateForPackage(
         String package, Set<String> processedPackages) =>
-    Glob('/$package/lib/*/**.dart', recursive: true)
+    Glob('${slash}$package${slash}lib${slash}*${slash}**.dart', recursive: true)
         .listSync()
         .whereType<File>()
         .where((file) => !file.path.contains('.sg.g.dart'))


### PR DESCRIPTION
## Purpose

The command line tools break on Windows machines due to hardcoded `/` in file paths.


## Solution

Use `Platform.pathSeparator` in place of `/` so it works on Windows, which uses `\`

## Semantic Versioning (check one)

- [ ] The following were changed in a non-backward compatible way and requires a major version bump:
  - *[link to the breaking change in the diff]*
- [ ] Something public was added or changed in backward compatible way, this requires a minor version bump
- [x] No public changes nor new features (backwards-compatible refactor or bug fix), so this can be included in a patch release

## How to QA

- Clone this repo and checkout the `slash-fixes` branch
- In the root of this project globally activate your local copy `dart pub global activate --source path .`
- Try running the command that this tool provides in the root of the a repo to run the intl codemod
  - `dart pub global run over_react_codemod:intl_message_migration --yes-to-all`
