### PR TITLE
INTL-71 Handle lib filepath exception

### DIFF
--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -304,6 +304,7 @@ Iterable<String> dartFilesToMigrateForPackage(
         .where((file) => !file.path.contains('.sg.g.dart'))
         .where((file) => !file.path.contains('.sg.freezed.dart'))
         .where((file) => !file.path.endsWith('_test.dart'))
+        .where((file) => !file.path.endsWith('_intl.dart'))
         .where(isNotHiddenFile)
         .where(isNotDartHiddenFile)
         .where(isNotWithinTopLevelBuildOutputDir)


### PR DESCRIPTION
## Motivation
  The codemod expects there to be a lib/src directory off of any folder in the given repo with a pubspec.yaml file, which is not always true. The Glob class does not handle filepaths that don't exist (at least until the newer version of Dart that we aren't using yet). This should be resolved.

## Changes
  Adds a try-catch to ignore when the lib directory doesn't exist

#### Release Notes
  Fix bug

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
