### PR TITLE
Fix intl_message_migration issue with Windows 

### DIFF
--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -16,8 +16,6 @@
 /// suggestor.
 library over_react_codemod.src.constants;
 
-import 'dart:io';
-
 const String generatedPrefix = r'$';
 const String privatePrefix = r'_';
 const String privateGeneratedPrefix = '$privatePrefix$generatedPrefix';
@@ -137,5 +135,3 @@ final RegExp dependencyOverrideRegExp = RegExp(
   r'^dependency_overrides:\s*$',
   multiLine: true,
 );
-
-final String slash = Platform.pathSeparator;


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
This crashes on Windows constructing a path of the form /c:usersmissingpathseparators/.

## Changes
  <!-- What this PR changes to fix the problem. -->
The problem was passing a path to glob of the from <slash>c:<slash>etc. I think the leading slash may have been causing it to be interpreted as a non-Windows path, even though it would have been platform-specific.  But I just converted everything to use package:path rather than using our own split/join logic. Also cleaned up a couple of bits of iterable usage to use literals, and added a toList in another place to avoid possible repeated evaluations.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
