### PR TITLE
INTL-115: Make the intl_message_migration also look for likely user-visible String constants

### DIFF
--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -220,11 +220,14 @@ void main(List<String> args) async {
 
     final intlPropMigrator = IntlMigrator(className, outputFile);
     final displayNameMigrator = ConfigsMigrator(className, outputFile);
+    final constantStringMigrator =
+        ConstantStringMigrator(className, outputFile);
     final importMigrator =
         (FileContext context) => intlImporter(context, packageName, className);
 
     exitCode = await runCodemodSequences(packageDartPath, [
       [intlPropMigrator],
+      [constantStringMigrator],
       [displayNameMigrator],
       [importMigrator]
     ]);

--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -38,6 +38,7 @@ const _verboseFlag = 'verbose';
 const _yesToAllFlag = 'yes-to-all';
 const _failOnChangesFlag = 'fail-on-changes';
 const _stderrAssumeTtyFlag = 'stderr-assume-tty';
+const _migrateConstants = 'migrate-constants';
 const _allCodemodFlags = {
   _verboseFlag,
   _yesToAllFlag,
@@ -77,6 +78,13 @@ void main(List<String> args) async {
       _stderrAssumeTtyFlag,
       negatable: false,
       help: 'Forces ansi color highlighting of stderr. Useful for debugging.',
+    )
+    ..addFlag(
+      _migrateConstants,
+      negatable: true,
+      defaultsTo: false,
+      help:
+          'Should the codemod try to migrate constant Strings that look user-visible',
     )
     ..addMultiOption(
       'migrators',
@@ -227,7 +235,7 @@ void main(List<String> args) async {
 
     exitCode = await runCodemodSequences(packageDartPath, [
       [intlPropMigrator],
-      [constantStringMigrator],
+      if (parsedArgs[_migrateConstants]) [constantStringMigrator],
       [displayNameMigrator],
       [importMigrator]
     ]);

--- a/lib/src/intl_suggestors/intl_migrator.dart
+++ b/lib/src/intl_suggestors/intl_migrator.dart
@@ -1,9 +1,54 @@
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:codemod/codemod.dart';
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:file/file.dart';
 import 'package:over_react_codemod/src/intl_suggestors/utils.dart';
 import 'package:over_react_codemod/src/util/component_usage.dart';
 import 'package:over_react_codemod/src/util/component_usage_migrator.dart';
+
+/// Mark const string variables whose first character is uppercase for internationalization. e.g.
+///
+///   const String cancel = 'Cancel';
+///
+/// Turns it into
+///
+///   final String cancel = <IntlClassName>.cancel;
+class ConstantStringMigrator extends GeneralizingAstVisitor
+    with AstVisitingSuggestor {
+  final File _outputFile;
+  final String _className;
+
+  ConstantStringMigrator(this._className, this._outputFile);
+
+  @override
+  visitVariableDeclaration(VariableDeclaration node) {
+    // We expect it to be const and have an initializer that's a simple string.
+    if (node.isConst &&
+        node.initializer != null &&
+        node.initializer is SimpleStringLiteral) {
+      SimpleStringLiteral literal = node.initializer as SimpleStringLiteral;
+      var string = literal.stringValue;
+      // I don't see how the parent could possibly be null, but if it's true, bail out.
+      if (node.parent == null || string == null || string.length <= 1) return;
+      // Otherwise use the parent to find the area to replace, because we want to replace
+      // the full declaration. Re-assure the compiler that we're positive it's not null.
+      var start = node.parent!.offset;
+      var end = node.parent!.end;
+      var firstLetter = string.substring(0, 1);
+      var secondLetter = string.substring(1, 2);
+      // Is the first character uppercase, excluding strings that start with two of the same
+      // uppercase character, which has a good chance of being a date format (e.g. 'MM/dd/YYYY').
+      if (firstLetter != secondLetter &&
+          firstLetter.toLowerCase() != firstLetter) {
+        final functionCall = intlStringAccess(literal, _className);
+        final functionDef = intlGetterDef(literal, _className);
+        yieldPatch('final String ${node.name} = $functionCall', start, end);
+        addMethodToClass(_outputFile, functionDef);
+      }
+    }
+  }
+}
 
 class IntlMigrator extends ComponentUsageMigrator {
   final File _outputFile;
@@ -40,7 +85,8 @@ class IntlMigrator extends ComponentUsageMigrator {
     super.migrateUsage(usage);
     final namePrefix =
         usage.node.thisOrAncestorOfType<ClassDeclaration>()?.name.name ??
-                usage.node.thisOrAncestorOfType<VariableDeclaration>()?.name.name ?? 'null';
+            usage.node.thisOrAncestorOfType<VariableDeclaration>()?.name.name ??
+            'null';
 
     //Props
     final stringLiteralProps =

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -25,7 +25,7 @@ import 'mui_migration_test.dart' show testCodemod;
 final _debug = false;
 
 // The help text may have different amount of whitespace depending on the names
-// of the options, so collapse all whitespace to a
+// of the options, so collapse all whitespace to a single space before comparing.
 String condenseWhitespace(String input) =>
     input.split(RegExp(r"\s+")).join(" ");
 

--- a/test/intl_suggestors/constant_migrator_test.dart
+++ b/test/intl_suggestors/constant_migrator_test.dart
@@ -1,0 +1,81 @@
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:over_react_codemod/src/intl_suggestors/intl_migrator.dart';
+import 'package:test/test.dart';
+
+import '../resolved_file_context.dart';
+import '../util.dart';
+
+void main() {
+  final resolvedContext = SharedAnalysisContext.overReact;
+
+  // Warm up analysis in a setUpAll so that if getting the resolved AST times out
+  // (which is more common for the WSD context), it fails here instead of failing the first test.
+  setUpAll(resolvedContext.warmUpAnalysis);
+
+  group('Constant Migrator', () {
+    final FileSystem fs = MemoryFileSystem();
+    late File file;
+    late SuggestorTester testSuggestor;
+
+    setUp(() async {
+      final Directory tmp = await fs.systemTempDirectory.createTemp();
+      file = tmp.childFile('TestClassIntl')..createSync(recursive: true);
+      testSuggestor = getSuggestorTester(
+        ConstantStringMigrator('TestClassIntl', file),
+        resolvedContext: resolvedContext,
+      );
+    });
+
+    tearDown(() {
+      file.deleteSync();
+    });
+
+    group('Constants', () {
+      test('standlalone constant', () async {
+        await testSuggestor(
+          input: '''
+            const foo = 'I am a user-visible constant';
+            ''',
+          expectedOutput: '''
+            final String foo = TestClassIntl.iAmAUservisibleConstant;
+            ''',
+        );
+        final expectedFileContent =
+            '\n\tstatic String get iAmAUservisibleConstant => Intl.message(\'I am a user-visible constant\', name: \'TestClassIntl_iAmAUservisibleConstant\',);';
+        expect(file.readAsStringSync(), expectedFileContent);
+      });
+
+      test('non-matching standlalone constant', () async {
+        await testSuggestor(
+          input: '''
+            const foo = 'probably-not';
+            ''',
+          expectedOutput: '''
+            const foo = 'probably-not';
+            ''',
+        );
+        final expectedFileContent = '';
+        expect(file.readAsStringSync(), expectedFileContent);
+      });
+
+      test('static constant', () async {
+        await testSuggestor(
+          input: '''
+          class Bar {
+            static const foo = 'I am a user-visible constant';
+          }
+            ''',
+          expectedOutput: '''
+          class Bar { 
+            static final String foo = TestClassIntl.iAmAUservisibleConstant;
+          }
+            ''',
+        );
+        final expectedFileContent =
+            '\n\tstatic String get iAmAUservisibleConstant => Intl.message(\'I am a user-visible constant\', name: \'TestClassIntl_iAmAUservisibleConstant\',);';
+        expect(file.readAsStringSync(), expectedFileContent);
+      });
+    });
+  });
+}

--- a/test/intl_suggestors/constant_migrator_test.dart
+++ b/test/intl_suggestors/constant_migrator_test.dart
@@ -46,7 +46,7 @@ void main() {
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
-      test('non-matching standlalone constant', () async {
+      test('non-matching standalone constant', () async {
         await testSuggestor(
           input: '''
             const foo = 'probably-not';

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -662,7 +662,6 @@ void main() {
         final expectedFileContent =
             "\n\tstatic String Foo_intlFunction0(String fileStr, String refStr) => Intl.message('Now that you\\\'ve transitioned your \$fileStr, you\\\'ll want to freeze \$refStr or update permissions to prevent others from using \$refStr.', args: [fileStr, refStr], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
-
       });
     });
 
@@ -697,7 +696,8 @@ void main() {
               ''',
         );
 
-        final expectedFileOutput = '\n\tstatic String get testString => Intl.message(\'Test String\', name: \'TestClassIntl_testString\',);';
+        final expectedFileOutput =
+            '\n\tstatic String get testString => Intl.message(\'Test String\', name: \'TestClassIntl_testString\',);';
         expect(file.readAsStringSync(), expectedFileOutput);
       });
 
@@ -732,7 +732,8 @@ void main() {
                }
               ''',
         );
-        final expectedFileOutput = '\n\tstatic String get testString => Intl.message(\'Test String\', name: \'TestClassIntl_testString\',);';
+        final expectedFileOutput =
+            '\n\tstatic String get testString => Intl.message(\'Test String\', name: \'TestClassIntl_testString\',);';
         expect(file.readAsStringSync(), expectedFileOutput);
       });
 
@@ -761,9 +762,9 @@ void main() {
                 );
                 ''',
         );
-        final expectedFileOutput = '\n\tstatic String get testString => Intl.message(\'Test String\', name: \'TestClassIntl_testString\',);';
-        expect(file.readAsStringSync(),
-            expectedFileOutput);
+        final expectedFileOutput =
+            '\n\tstatic String get testString => Intl.message(\'Test String\', name: \'TestClassIntl_testString\',);';
+        expect(file.readAsStringSync(), expectedFileOutput);
       });
     });
 


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
There are lots of 
   String const cancel => 'Cancel';
that are likely user-visible. Look for these, as const strings that start with an upper case level. Exclude the common case of date formats, which may start with doubled upper-case letters, e.g. 'MM/dd/YYYY'

## Changes
  <!-- What this PR changes to fix the problem. -->

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
