### PR TITLE
INTL-68 Fix multiline string issue

### DIFF
--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -78,9 +78,11 @@ String intlFunctionBody(
   String message,
   String name, {
   List<String> args = const [],
+  bool isMultiline = false,
 }) {
   var escapedStr = escapeApos(message);
-  return "Intl.message('${escapedStr}', ${args.isNotEmpty ? 'args: ${args}, ' : ''}name: '$name',)";
+  String delimiter = (isMultiline) ? "'''" : "'";
+  return "Intl.message(${delimiter}${escapedStr}${delimiter}, ${args.isNotEmpty ? 'args: ${args}, ' : ''}name: '$name',)";
 }
 
 // --- Start Intl.message parts
@@ -136,7 +138,8 @@ String intlFunctionCall(
 /// ex: static String get fooBar => Intl.message('Foo Bar','name: FooBarIntl_fooBar',);
 String intlGetterDef(SimpleStringLiteral node, String namespace) {
   final varName = toVariableName(node.stringValue!);
-  final message = intlFunctionBody(node.stringValue!, '${namespace}_$varName');
+  final message = intlFunctionBody(node.stringValue!, '${namespace}_$varName',
+      isMultiline: node.isMultiline);
   return '\n\t$intlFunctionPrefix get $varName => $message;';
 }
 
@@ -157,10 +160,8 @@ String intlFunctionDef(
   final parameterizedMessage = intlParameterizedMessage(node);
   final messageArgs = intlMessageArgs(node);
   final message = intlFunctionBody(
-    parameterizedMessage,
-    '${namespace}_$functionName',
-    args: messageArgs,
-  );
+      parameterizedMessage, '${namespace}_$functionName',
+      args: messageArgs, isMultiline: node.isMultiline);
   return '\n\t$intlFunctionPrefix $functionName$functionParams => $message;';
 }
 // -- End Intl helpers --


### PR DESCRIPTION
Remove file line sorting and conditionally add quotes based on multiline status.

## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

## Changes
  <!-- What this PR changes to fix the problem. -->
* Removed intl file line sorting. This was "shuffling" multiline strings.
* Conditionally add `'` or `'''` to the beginning and end of strings based on multiline status.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
