### PR TITLE
INTL-114: Comment out the code for adding a FIXME on the label attribute

### DIFF
--- a/lib/src/intl_suggestors/intl_migrator.dart
+++ b/lib/src/intl_suggestors/intl_migrator.dart
@@ -4,7 +4,6 @@ import 'package:file/file.dart';
 import 'package:over_react_codemod/src/intl_suggestors/utils.dart';
 import 'package:over_react_codemod/src/util/component_usage.dart';
 import 'package:over_react_codemod/src/util/component_usage_migrator.dart';
-import 'package:over_react_codemod/src/util/element_type_helpers.dart';
 
 class IntlMigrator extends ComponentUsageMigrator {
   final File _outputFile;
@@ -71,19 +70,25 @@ class IntlMigrator extends ComponentUsageMigrator {
     super.flagCommon(usage);
     // Flag the case of the label attribute, which may be user-visible or may not, depending
     // on the value of hideLabel.
-    if (usage.builderType == null) return;
-    if (!(usage.builderType!.isOrIsSubtypeOfClassFromPackage(
-        'FormComponentDisplayPropsMixin', 'web_skin_dart'))) {
-      return;
-    }
 
-    for (final prop in usage.cascadedProps) {
-      var left = prop.leftHandSide;
-      if (left is PropertyAccess && left.propertyName.toString() == 'label') {
-        yieldBuilderMemberFixmePatch(prop,
-            'The "label" property may or may not be user-visible, check hideLabel');
-      }
-    }
+    // This is commented out, because it turns out we should be internationalizing the
+    // label attribute, even if hideLabel is true, because it is visible to screen readers.
+    // Leaving the code here in case it's useful as an example for other properties we may
+    // need to customize.
+
+    // if (usage.builderType == null) return;
+    // if (!(usage.builderType!.isOrIsSubtypeOfClassFromPackage(
+    //     'FormComponentDisplayPropsMixin', 'web_skin_dart'))) {
+    //   return;
+    // }
+
+    // for (final prop in usage.cascadedProps) {
+    //   var left = prop.leftHandSide;
+    //   if (left is PropertyAccess && left.propertyName.toString() == 'label') {
+    //     yieldBuilderMemberFixmePatch(prop,
+    //         'The "label" property may or may not be user-visible, check hideLabel');
+    //   }
+    // }
   }
 
   void migrateChildStringLiteral(


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
It turns out that even if the `hideLabel` attribute is true on `FormComponentDisplayPropsMixin`, we should
still internationalize the string, because it can be visible to screen readers. This will be superseded by Aria labels,
but if it's still in the code we should still be localizing it.

## Changes
  <!-- What this PR changes to fix the problem. -->
Comments out the code for removing that. I didn't delete it, because it might be useful as an example of how to flag things 
if we have other attributes that are a problem.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
