### PR TITLE
INTL-116: Always use {} around variable names in the generated code

### DIFF
--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -90,10 +90,15 @@ String intlFunctionBody(
 /// 'Interpolated $bar and $baz'
 String intlParameterizedMessage(StringInterpolation node) => node.elements
     .map((e) => e is InterpolationExpression
-        ? '\$${toVariableName(toNestedName(e.toString()))}'
+        ? intlInterpolation(e)
         : (e as InterpolationString).value)
     .toList()
     .join('');
+
+String intlInterpolation(InterpolationExpression e) {
+  var name = toVariableName(toNestedName('$e'));
+  return r'${' + name + '}';
+}
 
 /// Creates the arg array for Intl.message
 /// ex: For the parameterized string 'Interpolated $bar and $baz'

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -168,9 +168,42 @@ void main() {
                 );
               ''',
         );
+      });
+
+      test('one argument interpolation followed by text', () async {
+        await testSuggestor(
+          input: '''
+                import 'package:over_react/over_react.dart';
+
+                mixin FooProps on UiProps {}
+
+                UiFactory<FooProps> Foo = uiFunction(
+                  (props) {
+                    final number = '42';
+
+                    return (Dom.div())('Distance \${number}km');
+                  },
+                  _\$FooConfig, //ignore: undefined_identifier
+                );
+                ''',
+          expectedOutput: '''
+                import 'package:over_react/over_react.dart';
+
+                mixin FooProps on UiProps {}
+
+                UiFactory<FooProps> Foo = uiFunction(
+                  (props) {
+                    final number = '42';
+
+                    return (Dom.div())(TestClassIntl.Foo_intlFunction0(number));
+                  },
+                  _\$FooConfig, //ignore: undefined_identifier
+                );
+              ''',
+        );
 
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String name) => Intl.message('Interpolated \$name', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n\tstatic String Foo_intlFunction0(String number) => Intl.message('Distance \${number}km', args: [number], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -208,7 +241,7 @@ void main() {
               ''',
         );
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \$name \$title', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n\tstatic String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -246,7 +279,7 @@ void main() {
               ''',
         );
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String name) => Intl.message('Interpolated \$name', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n\tstatic String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -288,7 +321,7 @@ void main() {
               ''',
         );
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \$name \$title', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n\tstatic String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -326,7 +359,7 @@ void main() {
               ''',
         );
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String name) => Intl.message('Interpolated \$name', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n\tstatic String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -406,7 +439,7 @@ void main() {
         );
 
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String getName) => Intl.message('His name was \$getName', args: [getName], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n\tstatic String Foo_intlFunction0(String getName) => Intl.message('His name was \${getName}', args: [getName], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -445,7 +478,7 @@ void main() {
         );
 
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String lastName) => Intl.message('Bob\\\'s last name was \$lastName', args: [lastName], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n\tstatic String Foo_intlFunction0(String lastName) => Intl.message('Bob\\\'s last name was \${lastName}', args: [lastName], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
       test('Interpolated with testId string', () async {
@@ -491,7 +524,7 @@ void main() {
         );
 
         String expectedFileContent =
-            "\n\tstatic String versionInfo(String version) => Intl.message('Version \$version', args: [version], name: 'TestClassIntl_versionInfo',);";
+            "\n\tstatic String versionInfo(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_versionInfo',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -546,7 +579,7 @@ void main() {
         );
 
         String expectedFileContent =
-            "\n\tstatic String versionInfo(String version) => Intl.message('Version \$version', args: [version], name: 'TestClassIntl_versionInfo',);";
+            "\n\tstatic String versionInfo(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_versionInfo',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -615,9 +648,9 @@ void main() {
         );
 
         String expectedFileContent1 =
-            "\n\tstatic String foo(String displayName) => Intl.message('Create one from any \$displayName by selecting Save As Template', args: [displayName], name: 'TestClassIntl_foo',);";
+            "\n\tstatic String foo(String displayName) => Intl.message('Create one from any \${displayName} by selecting Save As Template', args: [displayName], name: 'TestClassIntl_foo',);";
         String expectedFileContent2 =
-            "\n\tstatic String bar(String displayName) => Intl.message('Create one from any \$displayName by selecting Save As Template', args: [displayName], name: 'TestClassIntl_bar',);";
+            "\n\tstatic String bar(String displayName) => Intl.message('Create one from any \${displayName} by selecting Save As Template', args: [displayName], name: 'TestClassIntl_bar',);";
         expect(file.readAsStringSync(),
             [expectedFileContent1, expectedFileContent2].join(''));
       });
@@ -660,9 +693,8 @@ void main() {
               ''',
         );
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String fileStr, String refStr) => Intl.message('Now that you\\\'ve transitioned your \$fileStr, you\\\'ll want to freeze \$refStr or update permissions to prevent others from using \$refStr.', args: [fileStr, refStr], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n\tstatic String Foo_intlFunction0(String fileStr, String refStr) => Intl.message('Now that you\\\'ve transitioned your \${fileStr}, you\\\'ll want to freeze \${refStr} or update permissions to prevent others from using \${refStr}.', args: [fileStr, refStr], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
-
       });
     });
 
@@ -697,7 +729,8 @@ void main() {
               ''',
         );
 
-        final expectedFileOutput = '\n\tstatic String get testString => Intl.message(\'Test String\', name: \'TestClassIntl_testString\',);';
+        final expectedFileOutput =
+            '\n\tstatic String get testString => Intl.message(\'Test String\', name: \'TestClassIntl_testString\',);';
         expect(file.readAsStringSync(), expectedFileOutput);
       });
 
@@ -732,7 +765,8 @@ void main() {
                }
               ''',
         );
-        final expectedFileOutput = '\n\tstatic String get testString => Intl.message(\'Test String\', name: \'TestClassIntl_testString\',);';
+        final expectedFileOutput =
+            '\n\tstatic String get testString => Intl.message(\'Test String\', name: \'TestClassIntl_testString\',);';
         expect(file.readAsStringSync(), expectedFileOutput);
       });
 
@@ -761,9 +795,9 @@ void main() {
                 );
                 ''',
         );
-        final expectedFileOutput = '\n\tstatic String get testString => Intl.message(\'Test String\', name: \'TestClassIntl_testString\',);';
-        expect(file.readAsStringSync(),
-            expectedFileOutput);
+        final expectedFileOutput =
+            '\n\tstatic String get testString => Intl.message(\'Test String\', name: \'TestClassIntl_testString\',);';
+        expect(file.readAsStringSync(), expectedFileOutput);
       });
     });
 
@@ -803,7 +837,7 @@ void main() {
         );
 
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String name) => Intl.message('Interpolated \$name', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n\tstatic String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -843,7 +877,7 @@ void main() {
               ''',
         );
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \$name \$title', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n\tstatic String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -883,7 +917,7 @@ void main() {
               ''',
         );
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String name) => Intl.message('Interpolated \$name', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n\tstatic String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -925,7 +959,7 @@ void main() {
               ''',
         );
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \$name \$title', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n\tstatic String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -1007,7 +1041,7 @@ void main() {
         );
 
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String getName) => Intl.message('His name was \$getName', args: [getName], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n\tstatic String Foo_intlFunction0(String getName) => Intl.message('His name was \${getName}', args: [getName], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -1048,7 +1082,7 @@ void main() {
         );
 
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String lastName) => Intl.message('Bob\\\'s last name was \$lastName', args: [lastName], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n\tstatic String Foo_intlFunction0(String lastName) => Intl.message('Bob\\\'s last name was \${lastName}', args: [lastName], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -1091,7 +1125,7 @@ void main() {
         );
 
         String expectedFileContent =
-            "\n\tstatic String versionInfo(String version) => Intl.message('Version \$version', args: [version], name: 'TestClassIntl_versionInfo',);";
+            "\n\tstatic String versionInfo(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_versionInfo',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -1142,7 +1176,7 @@ void main() {
         );
 
         String expectedFileContent =
-            "\n\tstatic String versionInfo(String version) => Intl.message('Version \$version', args: [version], name: 'TestClassIntl_versionInfo',);";
+            "\n\tstatic String versionInfo(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_versionInfo',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
     });

--- a/test/intl_suggestors/utils_test.dart
+++ b/test/intl_suggestors/utils_test.dart
@@ -95,14 +95,14 @@ void main() {
       test('single line', () async {
         final testStr = r"'${singleLine}'";
         final expectedResult =
-            "\n\tstatic String NamePrefix_intlFunction0(String singleLine) => Intl.message('\$singleLine', args: [singleLine], name: 'Namespace_NamePrefix_intlFunction0',);";
+            "\n\tstatic String NamePrefix_intlFunction0(String singleLine) => Intl.message('\${singleLine}', args: [singleLine], name: 'Namespace_NamePrefix_intlFunction0',);";
         runResults(testStr, false, expectedResult);
       });
 
       test('multiline', () async {
         final testStr = r"'''${multiline}'''";
         final expectedResult =
-            "\n\tstatic String NamePrefix_intlFunction0(String multiline) => Intl.message('''\$multiline''', args: [multiline], name: 'Namespace_NamePrefix_intlFunction0',);";
+            "\n\tstatic String NamePrefix_intlFunction0(String multiline) => Intl.message('''\${multiline}''', args: [multiline], name: 'Namespace_NamePrefix_intlFunction0',);";
         runResults(testStr, true, expectedResult);
       });
     });


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
When we generate message functions, the variables may or may not be delimited by the characters around them. So it could be   '$var', but it could be '$varStuffThatIsNotVariable', in which case we fail to compile. To avoid this, always surround variables with curly braces in the generated interpolations.

## Changes
  <!-- What this PR changes to fix the problem. -->

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
