### PR TITLE
INTL-117: Add a functional test for intl_message_migration

### DIFF
--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -87,10 +87,11 @@ void main(List<String> args) async {
   final parsedArgs = parser.parse(args);
 
   if (parsedArgs['help'] as bool) {
-    stderr.writeln('Migrates string usage to wrap in Intl.message');
+    stderr.writeln(
+        'Migrates literal strings that seem user-visible in the package by wrapping them in Intl.message calls.');
     stderr.writeln();
     stderr.writeln('Usage:');
-    stderr.writeln('    intl_migration [arguments]');
+    stderr.writeln('    intl_message_migration [arguments]');
     stderr.writeln();
     stderr.writeln('Options:');
     stderr.writeln(parser.usage);

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -145,7 +145,7 @@ String intlGetterDef(SimpleStringLiteral node, String namespace) {
   final varName = toVariableName(node.stringValue!);
   final message = intlFunctionBody(node.stringValue!, '${namespace}_$varName',
       isMultiline: node.isMultiline);
-  return '\n\t$intlFunctionPrefix get $varName => $message;';
+  return '\n  $intlFunctionPrefix get $varName => $message;';
 }
 
 /// Returns Intl.message with interpolation
@@ -167,7 +167,7 @@ String intlFunctionDef(
   final message = intlFunctionBody(
       parameterizedMessage, '${namespace}_$functionName',
       args: messageArgs, isMultiline: node.isMultiline);
-  return '\n\t$intlFunctionPrefix $functionName$functionParams => $message;';
+  return '\n  $intlFunctionPrefix $functionName$functionParams => $message;';
 }
 // -- End Intl helpers --
 

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -1,0 +1,141 @@
+// Copyright 2022 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:codemod/src/run_interactive_codemod.dart' show codemodArgParser;
+import 'package:over_react_codemod/src/util/package_util.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+import 'mui_migration_test.dart' show testCodemod;
+
+// Change this to `true` and all of the functional tests in this file will print
+// the stdout/stderr of the codemod processes.
+final _debug = true;
+
+void main() {
+  group('intl_message_migration executable', () {
+    final script = p.join(
+        findPackageRootFor(p.current), 'bin/intl_message_migration.dart');
+
+    testCodemod('--help outputs usage help text and does not run the codemod',
+        script: script,
+        input: inputFiles(),
+        expectedOutput: inputFiles(),
+        expectedExitCode: 0,
+        args: ['--help'], body: (out, err) {
+      expect(
+          err,
+          allOf(
+            contains(codemodArgParser.usage),
+            contains('Migrates literal strings'),
+          ));
+    });
+
+    testCodemod(
+        'applies all patches via --yes-to-all,'
+        'and also correctly runs `pub get` if needed, migrates components,'
+        ' adds MUI imports, and removes WSD imports all in a single run',
+        script: script,
+        input: inputFiles(),
+        expectedOutput: expectedOutputFiles(),
+        args: ['--yes-to-all']);
+
+    testCodemod('--fail-on-changes exits with 0 when no changes needed',
+        script: script,
+        input: expectedOutputFiles(),
+        expectedOutput: expectedOutputFiles(),
+        args: ['--fail-on-changes'], body: (out, err) {
+      expect(out, contains('No changes needed.'));
+    });
+
+    testCodemod(
+        '--fail-on-changes exits with non-zero when changes needed and does not update files',
+        script: script,
+        input: inputFiles(),
+        expectedOutput: inputFiles(),
+        args: ['--fail-on-changes'],
+        expectedExitCode: 1, body: (out, err) {
+      expect(err, contains(' change(s) needed.'));
+    });
+
+    testCodemod('Output is sorted',
+        script: script,
+        input: inputFiles(),
+        expectedOutput: expectedOutputFiles(),
+        args: ['--yes-to-all']);
+  });
+}
+
+d.DirectoryDescriptor inputFiles(
+    {Iterable<d.Descriptor> additionalFilesInLib = const []}) {
+  String rmuiVersionConstraint = '^1.1.1';
+  return d.dir('project', [
+    d.file('pubspec.yaml', /*language=yaml*/ '''
+name: test_project
+environment:
+  sdk: '>=2.11.0 <3.0.0'
+dependencies:
+  react_material_ui:
+    hosted:
+      name: react_material_ui
+      url: https://pub.workiva.org
+    version: $rmuiVersionConstraint'''),
+    d.dir('lib', [
+      ...additionalFilesInLib,
+      d.file('usage.dart',
+          /*language=dart*/ '''import 'package:react_material_ui/react_material_ui.dart' as mui;
+
+usage() => (mui.Button()..aria.label='Sorts later')('Literal String');''')
+    ]),
+  ]);
+}
+
+d.DirectoryDescriptor expectedOutputFiles({
+  Iterable<d.Descriptor> additionalFilesInLib = const [],
+  String rmuiVersionConstraint = '^1.1.1',
+}) =>
+    d.dir('project', [
+      // Note that the codemod doesn't currently add the intl dependency to the pubspec.
+      d.file('pubspec.yaml', /*language=yaml*/ '''
+name: test_project
+environment:
+  sdk: '>=2.11.0 <3.0.0'
+dependencies:
+  react_material_ui:
+    hosted:
+      name: react_material_ui
+      url: https://pub.workiva.org
+    version: $rmuiVersionConstraint'''),
+      d.dir('lib', [
+        ...additionalFilesInLib,
+        d.file('usage.dart', /*language=dart*/ '''
+import 'package:react_material_ui/react_material_ui.dart' as mui;
+import 'package:test_project/src/intl/test_project_intl.dart';
+
+usage() => (mui.Button()..aria.label=TestProjectIntl.sortsLater)(TestProjectIntl.literalString);'''),
+        d.dir('src', [
+          d.dir('intl', [
+            d.file('test_project_intl.dart', /*language=dart*/ '''
+import 'package:intl/intl.dart';
+
+//ignore: avoid_classes_with_only_static_members
+class TestProjectIntl {
+  static String get literalString => Intl.message('Literal String', name: 'TestProjectIntl_literalString',);
+  static String get sortsLater => Intl.message('Sorts later', name: 'TestProjectIntl_sortsLater',);
+}''')
+          ]),
+        ]),
+      ]),
+    ]);

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -22,7 +22,7 @@ import 'mui_migration_test.dart' show testCodemod;
 
 // Change this to `true` and all of the functional tests in this file will print
 // the stdout/stderr of the codemod processes.
-final _debug = true;
+final _debug = false;
 
 void main() {
   group('intl_message_migration executable', () {
@@ -43,10 +43,7 @@ void main() {
           ));
     });
 
-    testCodemod(
-        'applies all patches via --yes-to-all,'
-        'and also correctly runs `pub get` if needed, migrates components,'
-        ' adds MUI imports, and removes WSD imports all in a single run',
+    testCodemod('applies all patches via --yes-to-all,',
         script: script,
         input: inputFiles(),
         expectedOutput: expectedOutputFiles(),

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -89,7 +89,7 @@ someMoreStrings() => (mui.Button()..aria.label=TestProjectIntl.orange)(TestProje
               "  static String get aquamarine => Intl.message('aquamarine', name: 'TestProjectIntl_aquamarine',);"
             ]..sort()),
         args: ['--yes-to-all']);
-  });
+  }, tags: 'wsd');
 }
 
 d.DirectoryDescriptor inputFiles(

--- a/test/intl_suggestors/intl_configs_migrator_test.dart
+++ b/test/intl_suggestors/intl_configs_migrator_test.dart
@@ -61,7 +61,7 @@ void main() {
             ''',
       );
       final expectedFileContent =
-          "\n\tstatic String get testDisplayName => Intl.message('Test Display Name', name: 'TestClassIntl_testDisplayName',);";
+          "\n  static String get testDisplayName => Intl.message('Test Display Name', name: 'TestClassIntl_testDisplayName',);";
       expect(file.readAsStringSync(), expectedFileContent);
     });
 
@@ -85,7 +85,7 @@ void main() {
             ''',
       );
       final expectedFileContent =
-          "\n\tstatic String get testName => Intl.message('Test Name', name: 'TestClassIntl_testName',);";
+          "\n  static String get testName => Intl.message('Test Name', name: 'TestClassIntl_testName',);";
       expect(file.readAsStringSync(), expectedFileContent);
     });
 
@@ -108,7 +108,7 @@ void main() {
             ''',
       );
       final expectedFileContent =
-          "\n\tstatic String get testTitle => Intl.message('Test Title', name: 'TestClassIntl_testTitle',);";
+          "\n  static String get testTitle => Intl.message('Test Title', name: 'TestClassIntl_testTitle',);";
       expect(file.readAsStringSync(), expectedFileContent);
     });
   });

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -62,7 +62,7 @@ void main() {
             ''',
         );
         final expectedFileContent =
-            '\n\tstatic String get viewer => Intl.message(\'viewer\', name: \'TestClassIntl_viewer\',);';
+            '\n  static String get viewer => Intl.message(\'viewer\', name: \'TestClassIntl_viewer\',);';
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -100,7 +100,7 @@ void main() {
         );
 
         final expected =
-            "\n\tstatic String get testString1 => Intl.message('testString1', name: 'TestClassIntl_testString1',);\n\tstatic String get testString2 => Intl.message('testString2', name: 'TestClassIntl_testString2',);";
+            "\n  static String get testString1 => Intl.message('testString1', name: 'TestClassIntl_testString1',);\n  static String get testString2 => Intl.message('testString2', name: 'TestClassIntl_testString2',);";
         expect(file.readAsStringSync(), expected);
       });
 
@@ -203,7 +203,7 @@ void main() {
         );
 
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String number) => Intl.message('Distance \${number}km', args: [number], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n  static String Foo_intlFunction0(String number) => Intl.message('Distance \${number}km', args: [number], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -241,7 +241,7 @@ void main() {
               ''',
         );
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n  static String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -279,7 +279,7 @@ void main() {
               ''',
         );
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n  static String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -321,7 +321,7 @@ void main() {
               ''',
         );
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n  static String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -359,7 +359,7 @@ void main() {
               ''',
         );
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n  static String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -439,7 +439,7 @@ void main() {
         );
 
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String getName) => Intl.message('His name was \${getName}', args: [getName], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n  static String Foo_intlFunction0(String getName) => Intl.message('His name was \${getName}', args: [getName], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -478,7 +478,7 @@ void main() {
         );
 
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String lastName) => Intl.message('Bob\\\'s last name was \${lastName}', args: [lastName], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n  static String Foo_intlFunction0(String lastName) => Intl.message('Bob\\\'s last name was \${lastName}', args: [lastName], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
       test('Interpolated with testId string', () async {
@@ -524,7 +524,7 @@ void main() {
         );
 
         String expectedFileContent =
-            "\n\tstatic String versionInfo(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_versionInfo',);";
+            "\n  static String versionInfo(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_versionInfo',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -579,7 +579,7 @@ void main() {
         );
 
         String expectedFileContent =
-            "\n\tstatic String versionInfo(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_versionInfo',);";
+            "\n  static String versionInfo(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_versionInfo',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -648,9 +648,9 @@ void main() {
         );
 
         String expectedFileContent1 =
-            "\n\tstatic String foo(String displayName) => Intl.message('Create one from any \${displayName} by selecting Save As Template', args: [displayName], name: 'TestClassIntl_foo',);";
+            "\n  static String foo(String displayName) => Intl.message('Create one from any \${displayName} by selecting Save As Template', args: [displayName], name: 'TestClassIntl_foo',);";
         String expectedFileContent2 =
-            "\n\tstatic String bar(String displayName) => Intl.message('Create one from any \${displayName} by selecting Save As Template', args: [displayName], name: 'TestClassIntl_bar',);";
+            "\n  static String bar(String displayName) => Intl.message('Create one from any \${displayName} by selecting Save As Template', args: [displayName], name: 'TestClassIntl_bar',);";
         expect(file.readAsStringSync(),
             [expectedFileContent1, expectedFileContent2].join(''));
       });
@@ -693,7 +693,7 @@ void main() {
               ''',
         );
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String fileStr, String refStr) => Intl.message('Now that you\\\'ve transitioned your \${fileStr}, you\\\'ll want to freeze \${refStr} or update permissions to prevent others from using \${refStr}.', args: [fileStr, refStr], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n  static String Foo_intlFunction0(String fileStr, String refStr) => Intl.message('Now that you\\\'ve transitioned your \${fileStr}, you\\\'ll want to freeze \${refStr} or update permissions to prevent others from using \${refStr}.', args: [fileStr, refStr], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
     });
@@ -730,7 +730,7 @@ void main() {
         );
 
         final expectedFileOutput =
-            '\n\tstatic String get testString => Intl.message(\'Test String\', name: \'TestClassIntl_testString\',);';
+            '\n  static String get testString => Intl.message(\'Test String\', name: \'TestClassIntl_testString\',);';
         expect(file.readAsStringSync(), expectedFileOutput);
       });
 
@@ -766,7 +766,7 @@ void main() {
               ''',
         );
         final expectedFileOutput =
-            '\n\tstatic String get testString => Intl.message(\'Test String\', name: \'TestClassIntl_testString\',);';
+            '\n  static String get testString => Intl.message(\'Test String\', name: \'TestClassIntl_testString\',);';
         expect(file.readAsStringSync(), expectedFileOutput);
       });
 
@@ -796,7 +796,7 @@ void main() {
                 ''',
         );
         final expectedFileOutput =
-            '\n\tstatic String get testString => Intl.message(\'Test String\', name: \'TestClassIntl_testString\',);';
+            '\n  static String get testString => Intl.message(\'Test String\', name: \'TestClassIntl_testString\',);';
         expect(file.readAsStringSync(), expectedFileOutput);
       });
     });
@@ -837,7 +837,7 @@ void main() {
         );
 
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n  static String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -877,7 +877,7 @@ void main() {
               ''',
         );
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n  static String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -917,7 +917,7 @@ void main() {
               ''',
         );
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n  static String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -959,7 +959,7 @@ void main() {
               ''',
         );
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n  static String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -1041,7 +1041,7 @@ void main() {
         );
 
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String getName) => Intl.message('His name was \${getName}', args: [getName], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n  static String Foo_intlFunction0(String getName) => Intl.message('His name was \${getName}', args: [getName], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -1082,7 +1082,7 @@ void main() {
         );
 
         final expectedFileContent =
-            "\n\tstatic String Foo_intlFunction0(String lastName) => Intl.message('Bob\\\'s last name was \${lastName}', args: [lastName], name: 'TestClassIntl_Foo_intlFunction0',);";
+            "\n  static String Foo_intlFunction0(String lastName) => Intl.message('Bob\\\'s last name was \${lastName}', args: [lastName], name: 'TestClassIntl_Foo_intlFunction0',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -1125,7 +1125,7 @@ void main() {
         );
 
         String expectedFileContent =
-            "\n\tstatic String versionInfo(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_versionInfo',);";
+            "\n  static String versionInfo(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_versionInfo',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -1176,7 +1176,7 @@ void main() {
         );
 
         String expectedFileContent =
-            "\n\tstatic String versionInfo(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_versionInfo',);";
+            "\n  static String versionInfo(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_versionInfo',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
     });

--- a/test/intl_suggestors/utils_test.dart
+++ b/test/intl_suggestors/utils_test.dart
@@ -95,14 +95,14 @@ void main() {
       test('single line', () async {
         final testStr = r"'${singleLine}'";
         final expectedResult =
-            "\n\tstatic String NamePrefix_intlFunction0(String singleLine) => Intl.message('\${singleLine}', args: [singleLine], name: 'Namespace_NamePrefix_intlFunction0',);";
+            "\n  static String NamePrefix_intlFunction0(String singleLine) => Intl.message('\${singleLine}', args: [singleLine], name: 'Namespace_NamePrefix_intlFunction0',);";
         runResults(testStr, false, expectedResult);
       });
 
       test('multiline', () async {
         final testStr = r"'''${multiline}'''";
         final expectedResult =
-            "\n\tstatic String NamePrefix_intlFunction0(String multiline) => Intl.message('''\${multiline}''', args: [multiline], name: 'Namespace_NamePrefix_intlFunction0',);";
+            "\n  static String NamePrefix_intlFunction0(String multiline) => Intl.message('''\${multiline}''', args: [multiline], name: 'Namespace_NamePrefix_intlFunction0',);";
         runResults(testStr, true, expectedResult);
       });
     });


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
I noticed that we never actually removed (or fixed) the sorting by line of output messages, which was a problem for multiline strings. None of our tests actually exercised as far as writing the output file, where this happens.

## Changes
  <!-- What this PR changes to fix the problem. -->
Add a functional test, modeled after the mui migration test that actually runs the executable and verifies the output files. Very basic so far.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
