### PR TITLE
INTL-128: intl_message_migration should handle adjacent strings, exclude strings with no alphabetics

### DIFF
--- a/lib/src/intl_suggestors/intl_migrator.dart
+++ b/lib/src/intl_suggestors/intl_migrator.dart
@@ -28,6 +28,7 @@ class IntlMigrator extends ComponentUsageMigrator {
 
   @override
   bool shouldMigrateUsage(FluentComponentUsage usage) =>
+      // TODO: Handle adjacent strings with an interpolation.
       usage.cascadedProps.any((prop) =>
           isValidStringLiteralProp(prop) ||
           isValidStringInterpolationProp(prop)) ||
@@ -57,7 +58,7 @@ class IntlMigrator extends ComponentUsageMigrator {
     final childNodes = usage.children.map((child) => child.node);
     //Migrate String Literals
     childNodes
-        .whereType<SimpleStringLiteral>()
+        .whereType<StringLiteral>()
         .forEach((node) => migrateChildStringLiteral(node));
 
     //Migrate String Interpolations
@@ -92,7 +93,7 @@ class IntlMigrator extends ComponentUsageMigrator {
   }
 
   void migrateChildStringLiteral(
-    SimpleStringLiteral node,
+    StringLiteral node,
   ) {
     if (isValidStringLiteralNode(node)) {
       final functionCall = intlStringAccess(node, _className);

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -19,7 +19,9 @@ bool isValidStringInterpolationNode(AstNode node) {
   return true;
 }
 
-final RegExp isAlphabetic = RegExp('[a-zA-Z]');
+bool hasNoAlphabeticCharacters(String s) => !_alphabeticPattern.hasMatch(s);
+
+final RegExp _alphabeticPattern = RegExp('[a-zA-Z]');
 
 /// The text under [node] if it's some kind of string literal, null if it's not.
 String? stringContent(AstNode node) {
@@ -48,7 +50,7 @@ bool isValidStringLiteralNode(AstNode node) {
   if (quotedCamelCase(text)) return false;
   if (text.trim().length == 1) return false;
   // If there are no alphabetic characters, we can't do anything useful.
-  if (!isAlphabetic.hasMatch(text)) return false;
+  if (hasNoAlphabeticCharacters(text)) return false;
   // Uri.parse is too accepting. Also check common schemes that might make sense.
   var mightBeAUrl = Uri.tryParse(text);
   if (mightBeAUrl != null &&

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -19,14 +19,38 @@ bool isValidStringInterpolationNode(AstNode node) {
   return true;
 }
 
+final RegExp isAlphabetic = RegExp('[a-zA-Z]');
+
+/// The text under [node] if it's some kind of string literal, null if it's not.
+String? stringContent(AstNode node) {
+  if (node is SimpleStringLiteral) return node.value;
+  if (node is AdjacentStrings) {
+    if (!node.strings.toList().every((x) => x is SimpleStringLiteral))
+      return null;
+    return [for (var s in node.strings) (s as SimpleStringLiteral).value]
+        .join('');
+  }
+  return null;
+}
+
+/// Is this a multiline string literal?
+bool isMultiline(AstNode node) {
+  // TODO: Can we have multiline adjacent strings? And if we can, would someone actually do that?
+  if (node is SimpleStringLiteral) return node.isMultiline;
+  return false;
+}
+
 bool isValidStringLiteralNode(AstNode node) {
-  if (node is! SimpleStringLiteral) return false;
-  if (node.value.isEmpty) return false;
-  if (double.tryParse(node.value) != null) return false;
-  if (quotedCamelCase(node.value)) return false;
-  if (node.value.trim().length == 1) return false;
+  String? text = stringContent(node);
+  if (text == null) return false;
+  if (text.isEmpty) return false;
+  if (double.tryParse(text) != null) return false;
+  if (quotedCamelCase(text)) return false;
+  if (text.trim().length == 1) return false;
+  // If there are no alphabetic characters, we can't do anything useful.
+  if (!isAlphabetic.hasMatch(text)) return false;
   // Uri.parse is too accepting. Also check common schemes that might make sense.
-  var mightBeAUrl = Uri.tryParse(node.value);
+  var mightBeAUrl = Uri.tryParse(text);
   if (mightBeAUrl != null &&
       ['http', 'https', 'wurl', 'mailTo'].contains(mightBeAUrl.scheme)) {
     return false;
@@ -123,8 +147,8 @@ String intlFunctionArguments(StringInterpolation node) {
 
 /// A template to build property access for intl string
 /// ex: ExampleIntl.exampleString
-String intlStringAccess(SimpleStringLiteral node, String namespace) =>
-    '${namespace}.${toVariableName(node.stringValue!)}';
+String intlStringAccess(StringLiteral node, String namespace) =>
+    '${namespace}.${toVariableName(stringContent(node)!)}';
 
 /// A template to build function call intl interpolated string
 /// ex: ExampleIntl.exampleString(sting1, string2)
@@ -141,10 +165,11 @@ String intlFunctionCall(
 
 /// Returns Intl.message for string literal
 /// ex: static String get fooBar => Intl.message('Foo Bar','name: FooBarIntl_fooBar',);
-String intlGetterDef(SimpleStringLiteral node, String namespace) {
-  final varName = toVariableName(node.stringValue!);
-  final message = intlFunctionBody(node.stringValue!, '${namespace}_$varName',
-      isMultiline: node.isMultiline);
+String intlGetterDef(StringLiteral node, String namespace) {
+  String text = stringContent(node)!;
+  final varName = toVariableName(text);
+  final message = intlFunctionBody(text, '${namespace}_$varName',
+      isMultiline: isMultiline(node));
   return '\n  $intlFunctionPrefix get $varName => $message;';
 }
 

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -134,6 +134,73 @@ void main() {
             ''',
         );
       });
+
+      test('single punctuation string', () async {
+        await testSuggestor(
+          input: '''
+            import 'package:over_react/over_react.dart';
+
+            mixin FooProps on UiProps {}
+
+            UiFactory<FooProps> Foo = uiFunction(
+              (props) {
+
+                return (Dom.div())('[]');
+              },
+              _\$FooConfig, //ignore: undefined_identifier
+            );
+            ''',
+          expectedOutput: '''
+            import 'package:over_react/over_react.dart';
+
+            mixin FooProps on UiProps {}
+
+            UiFactory<FooProps> Foo = uiFunction(
+              (props) {
+
+                return (Dom.div())('[]');
+              },
+              _\$FooConfig, //ignore: undefined_identifier
+            );
+            ''',
+        );
+      });
+
+      test('adjacent strings', () async {
+        await testSuggestor(
+          input: '''
+            import 'package:over_react/over_react.dart';
+
+            mixin FooProps on UiProps {}
+
+            UiFactory<FooProps> Foo = uiFunction(
+              (props) {
+
+                return (Dom.div())('this is a lengthy string, '
+                'it\\\'s been broken up into several lines '
+                'which Dart automatically concatenates.' );
+              },
+              _\$FooConfig, //ignore: undefined_identifier
+            );
+            ''',
+          expectedOutput: '''
+            import 'package:over_react/over_react.dart';
+
+            mixin FooProps on UiProps {}
+
+            UiFactory<FooProps> Foo = uiFunction(
+              (props) {
+
+                return (Dom.div())(TestClassIntl.thisIsALengthyString);
+              },
+              _\$FooConfig, //ignore: undefined_identifier
+            );
+            ''',
+        );
+        final expected =
+            "\n  static String get thisIsALengthyString => Intl.message('this is a lengthy string, it\\\'s been broken up into several lines which Dart automatically concatenates.', name: 'TestClassIntl_thisIsALengthyString',);";
+        expect(file.readAsStringSync(), expected);
+      });
     });
 
     group('Child - StringInterpolation', () {


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
The codemod should be able to handle adjacent strings, which are concatenated by dart.
e.g.
'This string is long enough that we split it up into '
'multiple lines, using separate strings instead of a triple-quoted string'.

Also, this adds an extra check to exclude strings that don't have any alphabetic characters from translation, motivated by running across strings like '[]'.

## Changes
  <!-- What this PR changes to fix the problem. -->

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
