### PR TITLE
INTL-127: Fix intl_message_migration function numbering

### DIFF
--- a/lib/src/intl_suggestors/intl_migrator.dart
+++ b/lib/src/intl_suggestors/intl_migrator.dart
@@ -9,6 +9,9 @@ class IntlMigrator extends ComponentUsageMigrator {
   final File _outputFile;
   final String _className;
 
+  int functionIndex = 0;
+  int nextFunctionIndex() => functionIndex++;
+
   IntlMigrator(this._className, this._outputFile);
 
   @override
@@ -54,15 +57,16 @@ class IntlMigrator extends ComponentUsageMigrator {
         migratePropStringInterpolation(prop, namePrefix, index));
 
     //Children
-    final childNodes = usage.children.map((child) => child.node);
+    final childNodes = usage.children.map((child) => child.node).toList();
     //Migrate String Literals
     childNodes
         .whereType<SimpleStringLiteral>()
         .forEach((node) => migrateChildStringLiteral(node));
 
     //Migrate String Interpolations
-    childNodes.whereType<StringInterpolation>().forEachIndexed((index, node) =>
-        migrateChildStringInterpolation(node, namePrefix, index));
+    childNodes
+        .whereType<StringInterpolation>()
+        .forEach((node) => migrateChildStringInterpolation(node, namePrefix));
   }
 
   @override
@@ -103,11 +107,9 @@ class IntlMigrator extends ComponentUsageMigrator {
   }
 
   void migrateChildStringInterpolation(
-    StringInterpolation node,
-    String namePrefix,
-    int index,
-  ) {
+      StringInterpolation node, String namePrefix) {
     if (isValidStringInterpolationNode(node)) {
+      var index = nextFunctionIndex();
       final functionCall =
           intlFunctionCall(node, _className, namePrefix, index);
       final functionDef = intlFunctionDef(node, _className, namePrefix, index);

--- a/lib/src/intl_suggestors/intl_migrator.dart
+++ b/lib/src/intl_suggestors/intl_migrator.dart
@@ -1,5 +1,4 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:collection/collection.dart' show IterableExtension;
 import 'package:file/file.dart';
 import 'package:over_react_codemod/src/intl_suggestors/utils.dart';
 import 'package:over_react_codemod/src/util/component_usage.dart';
@@ -52,9 +51,9 @@ class IntlMigrator extends ComponentUsageMigrator {
     final stringInterpolationProps = usage.cascadedProps
         .where((prop) => isValidStringInterpolationProp(prop));
 
-    stringLiteralProps.forEach((prop) => migratePropStringLiteral(prop));
-    stringInterpolationProps.forEachIndexed((index, prop) =>
-        migratePropStringInterpolation(prop, namePrefix, index));
+    stringLiteralProps.forEach(migratePropStringLiteral);
+    stringInterpolationProps
+        .forEach((prop) => migratePropStringInterpolation(prop, namePrefix));
 
     //Children
     final childNodes = usage.children.map((child) => child.node).toList();
@@ -133,10 +132,10 @@ class IntlMigrator extends ComponentUsageMigrator {
   void migratePropStringInterpolation(
     PropAssignment prop,
     String namePrefix,
-    int index,
   ) {
     if (isValidStringInterpolationProp(prop)) {
       final rhs = prop.rightHandSide as StringInterpolation;
+      final index = nextFunctionIndex();
       final functionCall = intlFunctionCall(rhs, _className, namePrefix, index);
       final functionDef = intlFunctionDef(rhs, _className, namePrefix, index);
       yieldPropPatch(prop, newRhs: functionCall);

--- a/lib/src/util/package_util.dart
+++ b/lib/src/util/package_util.dart
@@ -123,9 +123,10 @@ Iterable<String> ancestorsOfPath(String path) sync* {
 bool isNotWithinTopLevelBuildOutputDir(File file) =>
     !isWithinTopLevelDir(file, 'build');
 
-/// Returns whether [file] is within a top-level `tool` directory of a package root.
+/// Returns whether [file] is within a top-level `tool` or `dev_tools` directory of a package root.
 bool isNotWithinTopLevelToolDir(File file) =>
-    !isWithinTopLevelDir(file, 'tool');
+    !isWithinTopLevelDir(file, 'tool') &&
+    !isWithinTopLevelDir(file, 'dev_tools');
 
 /// Returns whether [file] is within a top-level [topLevelDir] directory
 /// (e.g., `bin`, `lib`, `web`) of a package root.

--- a/lib/src/util/package_util.dart
+++ b/lib/src/util/package_util.dart
@@ -123,10 +123,9 @@ Iterable<String> ancestorsOfPath(String path) sync* {
 bool isNotWithinTopLevelBuildOutputDir(File file) =>
     !isWithinTopLevelDir(file, 'build');
 
-/// Returns whether [file] is within a top-level `tool` or `dev_tools` directory of a package root.
+/// Returns whether [file] is within a top-level `tool` directory of a package root.
 bool isNotWithinTopLevelToolDir(File file) =>
-    !isWithinTopLevelDir(file, 'tool') &&
-    !isWithinTopLevelDir(file, 'dev_tools');
+    !isWithinTopLevelDir(file, 'tool');
 
 /// Returns whether [file] is within a top-level [topLevelDir] directory
 /// (e.g., `bin`, `lib`, `web`) of a package root.

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -657,6 +657,7 @@ void main() {
 
       test('Home Example', () async {
         await testSuggestor(
+          testIdempotency: false,
           input: '''
               import 'package:over_react/over_react.dart';
 

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -244,15 +244,15 @@ void main() {
                   final name = 'bob';
                   final title = 'Test Title';
 
-                  return (Dom.div()..label=TestClassIntl.Foo_intlFunction1(title))(TestClassIntl.Foo_intlFunction0(name));
+                  return (Dom.div()..label=TestClassIntl.Foo_intlFunction0(title))(TestClassIntl.Foo_intlFunction1(name));
                 },
                 _\$FooConfig, //ignore: undefined_identifier
               );
               ''',
         );
         final expectedFileContent =
-            "\n  static String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);"
-            "\n  static String Foo_intlFunction1(String title) => Intl.message('Also interpolated \${title}', args: [title], name: 'TestClassIntl_Foo_intlFunction1',);";
+            "\n  static String Foo_intlFunction0(String title) => Intl.message('Also interpolated \${title}', args: [title], name: 'TestClassIntl_Foo_intlFunction0',);"
+            "\n  static String Foo_intlFunction1(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction1',);";
         expect(file.readAsStringSync(), expectedFileContent);
       });
 

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -217,6 +217,45 @@ void main() {
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
+      test('two different interpolations get different names', () async {
+        await testSuggestor(
+          input: '''
+              import 'package:over_react/over_react.dart';
+
+              mixin FooProps on UiProps {}
+
+              UiFactory<FooProps> Foo = uiFunction(
+                (props) {
+                  final name = 'bob';
+                  final title = 'Test Title';
+
+                  return (Dom.div()..label='Also interpolated \$title')('Interpolated \${name}');
+                },
+                _\$FooConfig, //ignore: undefined_identifier
+              );
+              ''',
+          expectedOutput: '''
+              import 'package:over_react/over_react.dart';
+
+              mixin FooProps on UiProps {}
+
+              UiFactory<FooProps> Foo = uiFunction(
+                (props) {
+                  final name = 'bob';
+                  final title = 'Test Title';
+
+                  return (Dom.div()..label=TestClassIntl.Foo_intlFunction1(title))(TestClassIntl.Foo_intlFunction0(name));
+                },
+                _\$FooConfig, //ignore: undefined_identifier
+              );
+              ''',
+        );
+        final expectedFileContent =
+            "\n  static String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);"
+            "\n  static String Foo_intlFunction1(String title) => Intl.message('Also interpolated \${title}', args: [title], name: 'TestClassIntl_Foo_intlFunction1',);";
+        expect(file.readAsStringSync(), expectedFileContent);
+      });
+
       test('two argument with top level accessors', () async {
         await testSuggestor(
           input: '''

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -16,12 +16,22 @@ void main() {
   group('IntlMigrator', () {
     final FileSystem fs = MemoryFileSystem();
     late File file;
-    late SuggestorTester testSuggestor;
+    late SuggestorTester basicSuggestor;
+
+    // Idempotency isn't a worry for this suggestor, and testing it throws off
+    // using a global counter for numbering messages whose name isn't otherwise
+    // unique, so skip that check.
+    Future<void> testSuggestor(
+            {required String input, required String expectedOutput}) =>
+        basicSuggestor(
+            input: input,
+            expectedOutput: expectedOutput,
+            testIdempotency: false);
 
     setUp(() async {
       final Directory tmp = await fs.systemTempDirectory.createTemp();
       file = tmp.childFile('TestClassIntl')..createSync(recursive: true);
-      testSuggestor = getSuggestorTester(
+      basicSuggestor = getSuggestorTester(
         IntlMigrator('TestClassIntl', file),
         resolvedContext: resolvedContext,
       );
@@ -657,7 +667,6 @@ void main() {
 
       test('Home Example', () async {
         await testSuggestor(
-          testIdempotency: false,
           input: '''
               import 'package:over_react/over_react.dart';
 


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
  When we have a message we can't get a better name for, we call it intlFunction0, intlFunction1, etc. But it turns out it's often (always?) 0, even when this leads to duplicates. It's trying to use the child numbering of the nodes, but I'm suspicious they might have different parents but still fall in the same larger name.



## Changes
  <!-- What this PR changes to fix the problem. -->
The exact numbering isn't very important, so change this to just use a counter in the suggestor class, so the numbering is globally unique within a codemod run.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
