### PR TITLE
INTL-132: intl_message_migration should only do the lib directory by default, allow specifying others

### DIFF
--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -348,6 +348,7 @@ Iterable<String> dartFilesToMigrate() => Glob('**.dart', recursive: true)
     .where(isNotDartHiddenFile)
     .where(isNotWithinTopLevelBuildOutputDir)
     .where(isNotWithinTopLevelToolDir)
+    .where((file) => isWithinTopLevelDir(file, 'lib'))
     .map((e) => e.path);
 
 Iterable<String> dartFilesToMigrateForPackage(
@@ -368,6 +369,7 @@ Iterable<String> dartFilesToMigrateForPackage(
         .where(isNotDartHiddenFile)
         .where(isNotWithinTopLevelBuildOutputDir)
         .where(isNotWithinTopLevelToolDir)
+        .where((file) => isWithinTopLevelDir(file, 'lib'))
         .where((file) => !processedPackages.contains(file.path))
         .map((e) => e.path)
         .toList();

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import 'package:codemod/src/run_interactive_codemod.dart' show codemodArgParser;
+import 'package:over_react_codemod/src/executables/intl_message_migration.dart';
 import 'package:over_react_codemod/src/util/package_util.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -101,6 +102,45 @@ someMoreStrings() => (mui.Button()..aria.label='orange')('aquamarine');''')
       expect(err, contains('Only part files were specified'));
     });
   }, tags: 'wsd');
+
+  group('limit paths', () {
+    var all = ['lib/src/a.dart', 'lib/b.dart', 'lib/src/a/c.dart'];
+    test('single file', () {
+      var allowed = ['lib/src/a.dart'];
+      expect(limitPaths(all, allowed: allowed), allowed);
+    });
+
+    test('multiples all match', () {
+      var allowed = ['lib/b.dart', 'lib/src/a.dart'];
+      expect(
+          limitPaths(all, allowed: allowed), ['lib/src/a.dart', 'lib/b.dart']);
+    });
+    test('multiples some match', () {
+      var allowed = ['lib/nothere.dart', 'lib/src/a/c.dart'];
+      expect(limitPaths(all, allowed: allowed), ['lib/src/a/c.dart']);
+    });
+    test('directory match', () {
+      var allowed = ['lib/src'];
+      expect(limitPaths(all, allowed: allowed),
+          ['lib/src/a.dart', 'lib/src/a/c.dart']);
+    });
+
+    test('directory plus file', () {
+      var allowed = ['lib/src', 'test/foo.dart'];
+      var allFiles = [...all, 'test/foo.dart', 'test/other.dart'];
+      expect(limitPaths(allFiles, allowed: allowed),
+          ['lib/src/a.dart', 'lib/src/a/c.dart', 'test/foo.dart']);
+    });
+    test('no match for file', () {
+      var allowed = ['lib/src/nothere.dart'];
+      expect(limitPaths(all, allowed: allowed), isEmpty);
+    });
+
+    test('no match for directory', () {
+      var allowed = ['lib/src/nothere'];
+      expect(limitPaths(all, allowed: allowed), isEmpty);
+    });
+  });
 }
 
 /// An extra input file we can use.


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

Typically with the intl_message_migration codemod we only want it to process the lib/ directory, so make that the default. Allow putting directory names, not just file names on the command line so we can make it handle other directories if desired. The biggest case for handling sub-directories is a single repo with multiple packages, but we can (and typically do) handle that by running the codemod separately on each sub-package.

## Changes
  <!-- What this PR changes to fix the problem. -->

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
