### PR TITLE
INTL-136: Ignore the lint for unnecessary braces in string interpolation in the intl.dart class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.7.0](https://github.com/Workiva/over_react_codemod/compare/2.7.0....2.6.0)
+
+- Ignore the lint for unnecessary braces in string interpolations in the generated `intl.dart` file.
+
+
 ## [2.6.0]](https://github.com/Workiva/over_react_codemod/compare/2.6.0....2.5.0)
 
 - Make the intl\_message\_migration codemod  handle adjacent strings.

--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -244,8 +244,13 @@ Future<void> migratePackage(
   final bool existingOutputFile = outputFile.existsSync();
 
   final className = toClassName('${packageName}');
-  final classPredicate =
-      "import 'package:intl/intl.dart';\n\n//ignore: avoid_classes_with_only_static_members\nclass $className {\n";
+  final classPredicate = '''import 'package:intl/intl.dart';
+
+//ignore: avoid_classes_with_only_static_members
+//ignore: unnecessary_brace_in_string_interps
+
+class $className {
+''';
   if (!existingOutputFile) {
     outputFile.createSync(recursive: true);
     outputFile.writeAsStringSync(classPredicate);

--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -281,11 +281,12 @@ class $className {
   if (exitCode != 0 || outputFile.readAsStringSync() == classPredicate) {
     outputFile.deleteSync();
   } else {
+    var prologueLength = 6;
     List<String> lines = outputFile.readAsLinesSync();
-    final functions = lines.sublist(4);
+    final functions = lines.sublist(prologueLength);
     functions.removeWhere((string) => string == '');
     functions.sort();
-    lines.replaceRange(4, lines.length, functions);
+    lines.replaceRange(prologueLength, lines.length, functions);
     lines.add('}');
     outputFile.writeAsStringSync(lines.join('\n'), mode: FileMode.write);
   }

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -223,6 +223,8 @@ usage() => (mui.Button()..aria.label=TestProjectIntl.sortsLater)(TestProjectIntl
 import 'package:intl/intl.dart';
 
 //ignore: avoid_classes_with_only_static_members
+//ignore: unnecessary_brace_in_string_interps
+
 class TestProjectIntl {
 ${messages.join('\n')}
 }''')


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
This is generated code, we don't need no readability lints.

## Changes
  <!-- What this PR changes to fix the problem. -->
Add a //ignore comment to the top of the file.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
