### PR TITLE
INTL-137: intl_message_migration uses the variable name for constant strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.7.0]](https://github.com/Workiva/over_react_codemod/compare/2.7.0....2.6.0)
+
+- Change the name of migrated constant strings to match the original variable instead of being derived from the value.
+
+
 ## [2.6.0]](https://github.com/Workiva/over_react_codemod/compare/2.6.0....2.5.0)
 
 - Make the intl\_message\_migration codemod  handle adjacent strings.

--- a/lib/src/intl_suggestors/intl_migrator.dart
+++ b/lib/src/intl_suggestors/intl_migrator.dart
@@ -40,8 +40,10 @@ class ConstantStringMigrator extends GeneralizingAstVisitor
       // uppercase character, which has a good chance of being a date format (e.g. 'MM/dd/YYYY').
       if (firstLetter != secondLetter &&
           firstLetter.toLowerCase() != firstLetter) {
-        final functionCall = intlStringAccess(literal, _className);
-        final functionDef = intlGetterDef(literal, _className);
+        final functionCall =
+            intlStringAccess(literal, _className, name: node.name.toString());
+        final functionDef =
+            intlGetterDef(literal, _className, name: node.name.toString());
         yieldPatch('final String ${node.name} = $functionCall', start, end);
         addMethodToClass(_outputFile, functionDef);
       }

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -149,8 +149,8 @@ String intlFunctionArguments(StringInterpolation node) {
 
 /// A template to build property access for intl string
 /// ex: ExampleIntl.exampleString
-String intlStringAccess(StringLiteral node, String namespace) =>
-    '${namespace}.${toVariableName(stringContent(node)!)}';
+String intlStringAccess(StringLiteral node, String namespace, {String? name}) =>
+    '${namespace}.${name ?? toVariableName(stringContent(node)!)}';
 
 /// A template to build function call intl interpolated string
 /// ex: ExampleIntl.exampleString(sting1, string2)
@@ -165,11 +165,15 @@ String intlFunctionCall(
   return '$namespace.$functionName$functionArgs';
 }
 
-/// Returns Intl.message for string literal
+/// Returns Intl.message for string literal.
+///
+/// The optional [name] parameter lets us provide a name rather than generating
+/// one from the string.
+///
 /// ex: static String get fooBar => Intl.message('Foo Bar','name: FooBarIntl_fooBar',);
-String intlGetterDef(StringLiteral node, String namespace) {
+String intlGetterDef(StringLiteral node, String namespace, {String? name}) {
   String text = stringContent(node)!;
-  final varName = toVariableName(text);
+  final varName = name ?? toVariableName(text);
   final message = intlFunctionBody(text, '${namespace}_$varName',
       isMultiline: isMultiline(node));
   return '\n  $intlFunctionPrefix get $varName => $message;';

--- a/test/intl_suggestors/constant_migrator_test.dart
+++ b/test/intl_suggestors/constant_migrator_test.dart
@@ -38,11 +38,11 @@ void main() {
             const foo = 'I am a user-visible constant';
             ''',
           expectedOutput: '''
-            final String foo = TestClassIntl.iAmAUservisibleConstant;
+            final String foo = TestClassIntl.foo;
             ''',
         );
         final expectedFileContent =
-            '\n  static String get iAmAUservisibleConstant => Intl.message(\'I am a user-visible constant\', name: \'TestClassIntl_iAmAUservisibleConstant\',);';
+            '\n  static String get foo => Intl.message(\'I am a user-visible constant\', name: \'TestClassIntl_foo\',);';
         expect(file.readAsStringSync(), expectedFileContent);
       });
 
@@ -68,12 +68,12 @@ void main() {
             ''',
           expectedOutput: '''
           class Bar { 
-            static final String foo = TestClassIntl.iAmAUservisibleConstant;
+            static final String foo = TestClassIntl.foo;
           }
             ''',
         );
         final expectedFileContent =
-            '\n  static String get iAmAUservisibleConstant => Intl.message(\'I am a user-visible constant\', name: \'TestClassIntl_iAmAUservisibleConstant\',);';
+            '\n  static String get foo => Intl.message(\'I am a user-visible constant\', name: \'TestClassIntl_foo\',);';
         expect(file.readAsStringSync(), expectedFileContent);
       });
     });


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
If we have
`
const String someButtonText = 'Do Something';
`
we currently produce 
`
final String someButtonText = Intl.doSomething;
`
It might be preferable to produce
`
final String someButtonText = Intl.someButtonText;
`


## Changes
  <!-- What this PR changes to fix the problem. -->
Changes the intl_message_migration to preserve the original String constant name, when --migrate-constants is used.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
