### PR TITLE
INTL-139: intl_message_migration: Split out explicit file access, step towards running repeatedly

### DIFF
--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -241,6 +241,7 @@ Future<void> migratePackage(
 
   final IntlMessages outputFile =
       IntlMessages(packageName, fs.currentDirectory, package);
+  outputFile.initialize();
 
   final intlPropMigrator = IntlMigrator(outputFile.className, outputFile);
   final constantStringMigrator =
@@ -260,6 +261,7 @@ Future<void> migratePackage(
       codemodArgs);
 
   processedPackages.add(package);
+
   outputFile.write();
 }
 

--- a/lib/src/intl_suggestors/intl_configs_migrator.dart
+++ b/lib/src/intl_suggestors/intl_configs_migrator.dart
@@ -1,14 +1,14 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:codemod/codemod.dart';
-import 'package:file/file.dart';
+import 'package:over_react_codemod/src/intl_suggestors/intl_messages.dart';
 import 'package:over_react_codemod/src/intl_suggestors/utils.dart';
 
 const varsToCheck = ['displayName', 'name', 'title'];
 
 class ConfigsMigrator extends RecursiveAstVisitor with AstVisitingSuggestor {
   final String _className;
-  final File _outputFile;
+  final IntlMessages _outputFile;
 
   ConfigsMigrator(this._className, this._outputFile);
 

--- a/lib/src/intl_suggestors/intl_messages.dart
+++ b/lib/src/intl_suggestors/intl_messages.dart
@@ -1,0 +1,53 @@
+import 'dart:io';
+
+import 'package:file/file.dart';
+import 'package:over_react_codemod/src/intl_suggestors/utils.dart';
+import 'package:path/path.dart' as p;
+
+class IntlMessages {
+  final String packageName;
+  final File outputFile;
+  final String className;
+
+  String get classPredicate =>
+      "import 'package:intl/intl.dart';\n\n//ignore: avoid_classes_with_only_static_members\nclass $className {\n";
+
+  IntlMessages(this.packageName, Directory currentDir, String packagePath)
+      :
+        // What's going on with this? Wouldn't currentDir and packagePath have to agree anyway?
+        outputFile = currentDir.childFile(p.join(
+            packagePath, 'lib', 'src', 'intl', '${packageName}_intl.dart')),
+        className = toClassName('${packageName}');
+
+  contains(String x) => outputFile.contents.contains(x);
+
+  append(String x) => outputFile.writeAsStringSync(x, mode: FileMode.append);
+
+  flirp() {
+    bool existingOutputFile = outputFile.existsSync();
+
+    if (!existingOutputFile) {
+      outputFile.createSync(recursive: true);
+      outputFile.writeAsStringSync(classPredicate);
+    } else {
+      final List<String> lines = outputFile.readAsLinesSync();
+      lines.removeLast();
+      String outputContent = lines.join('\n');
+      outputFile.writeAsStringSync(outputContent);
+    }
+  }
+
+  write() {
+    if (exitCode != 0 || outputFile.readAsStringSync() == classPredicate) {
+      outputFile.deleteSync();
+    } else {
+      List<String> lines = outputFile.readAsLinesSync();
+      final functions = lines.sublist(4);
+      functions.removeWhere((string) => string == '');
+      functions.sort();
+      lines.replaceRange(4, lines.length, functions);
+      lines.add('}');
+      outputFile.writeAsStringSync(lines.join('\n'), mode: FileMode.write);
+    }
+  }
+}

--- a/lib/src/intl_suggestors/intl_messages.dart
+++ b/lib/src/intl_suggestors/intl_messages.dart
@@ -4,6 +4,11 @@ import 'package:file/file.dart';
 import 'package:over_react_codemod/src/intl_suggestors/utils.dart';
 import 'package:path/path.dart' as p;
 
+/// Represents the generated file with the Intl class.
+///
+/// Right now this just wraps the file, but in the future it can be more
+/// abstract to make it easier to add new messages to existing files and
+/// otherwise programmatically modify it.
 class IntlMessages {
   final String packageName;
   final File outputFile;
@@ -14,16 +19,22 @@ class IntlMessages {
 
   IntlMessages(this.packageName, Directory currentDir, String packagePath)
       :
-        // What's going on with this? Wouldn't currentDir and packagePath have to agree anyway?
+        // TODO: I think packagePath only applies if there's a sub-package.
         outputFile = currentDir.childFile(p.join(
             packagePath, 'lib', 'src', 'intl', '${packageName}_intl.dart')),
         className = toClassName('${packageName}');
 
-  contains(String x) => outputFile.contents.contains(x);
+  bool contains(String x) => outputFile.readAsStringSync().contains(x);
 
-  append(String x) => outputFile.writeAsStringSync(x, mode: FileMode.append);
+  // TODO: Get rid of the pseudo-file operations if possible.
+  String readAsStringSync() => outputFile.readAsStringSync();
 
-  flirp() {
+  void append(String x) =>
+      outputFile.writeAsStringSync(x, mode: FileMode.append);
+
+  void deleteSync() => outputFile.deleteSync();
+
+  initialize() {
     bool existingOutputFile = outputFile.existsSync();
 
     if (!existingOutputFile) {

--- a/lib/src/intl_suggestors/intl_migrator.dart
+++ b/lib/src/intl_suggestors/intl_migrator.dart
@@ -1,7 +1,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:codemod/codemod.dart';
-import 'package:file/file.dart';
+import 'package:over_react_codemod/src/intl_suggestors/intl_messages.dart';
 import 'package:over_react_codemod/src/intl_suggestors/utils.dart';
 import 'package:over_react_codemod/src/util/component_usage.dart';
 import 'package:over_react_codemod/src/util/component_usage_migrator.dart';
@@ -15,10 +15,10 @@ import 'package:over_react_codemod/src/util/component_usage_migrator.dart';
 ///   final String cancel = <IntlClassName>.cancel;
 class ConstantStringMigrator extends GeneralizingAstVisitor
     with AstVisitingSuggestor {
-  final File _outputFile;
+  final IntlMessages _messages;
   final String _className;
 
-  ConstantStringMigrator(this._className, this._outputFile);
+  ConstantStringMigrator(this._className, this._messages);
 
   @override
   visitVariableDeclaration(VariableDeclaration node) {
@@ -43,14 +43,14 @@ class ConstantStringMigrator extends GeneralizingAstVisitor
         final functionCall = intlStringAccess(literal, _className);
         final functionDef = intlGetterDef(literal, _className);
         yieldPatch('final String ${node.name} = $functionCall', start, end);
-        addMethodToClass(_outputFile, functionDef);
+        addMethodToClass(_messages, functionDef);
       }
     }
   }
 }
 
 class IntlMigrator extends ComponentUsageMigrator {
-  final File _outputFile;
+  final IntlMessages _outputFile;
   final String _className;
 
   int functionIndex = 0;

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -2,7 +2,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:file/file.dart';
+import 'package:over_react_codemod/src/intl_suggestors/intl_messages.dart';
 import 'package:over_react_codemod/src/util/component_usage.dart';
 import 'package:over_react_codemod/src/util/element_type_helpers.dart';
 
@@ -228,9 +228,9 @@ String removeInterpolationSyntax(String s) =>
 ///
 String toNestedName(String s) => removeInterpolationSyntax(s).split('.').last;
 
-void addMethodToClass(File outputFile, String content) {
-  if (!outputFile.readAsStringSync().contains(content)) {
-    outputFile.writeAsStringSync(content, mode: FileMode.append);
+void addMethodToClass(IntlMessages outputFile, String content) {
+  if (!outputFile.contains(content)) {
+    outputFile.append(content);
   }
 }
 

--- a/test/intl_suggestors/constant_migrator_test.dart
+++ b/test/intl_suggestors/constant_migrator_test.dart
@@ -1,5 +1,6 @@
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'package:over_react_codemod/src/intl_suggestors/intl_messages.dart';
 import 'package:over_react_codemod/src/intl_suggestors/intl_migrator.dart';
 import 'package:test/test.dart';
 
@@ -15,12 +16,13 @@ void main() {
 
   group('Constant Migrator', () {
     final FileSystem fs = MemoryFileSystem();
-    late File file;
+    late IntlMessages file;
     late SuggestorTester testSuggestor;
 
     setUp(() async {
       final Directory tmp = await fs.systemTempDirectory.createTemp();
-      file = tmp.childFile('TestClassIntl')..createSync(recursive: true);
+      file = IntlMessages('TestClass', tmp, '');
+      file.outputFile.createSync(recursive: true);
       testSuggestor = getSuggestorTester(
         ConstantStringMigrator('TestClassIntl', file),
         resolvedContext: resolvedContext,

--- a/test/intl_suggestors/intl_configs_migrator_test.dart
+++ b/test/intl_suggestors/intl_configs_migrator_test.dart
@@ -16,6 +16,7 @@ import 'package:analyzer/error/error.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:over_react_codemod/src/intl_suggestors/intl_configs_migrator.dart';
+import 'package:over_react_codemod/src/intl_suggestors/intl_messages.dart';
 import 'package:test/test.dart';
 
 import '../resolved_file_context.dart';
@@ -29,13 +30,14 @@ void main() {
     // (which is more common for the WSD context), it fails here instead of failing the first test.
     setUpAll(resolvedContext.warmUpAnalysis);
 
-    late File file;
+    late IntlMessages file;
     SuggestorTester? testSuggestor;
 
     setUp(() async {
       final FileSystem fs = MemoryFileSystem();
       final Directory tmp = await fs.systemTempDirectory.createTemp();
-      file = tmp.childFile('TestClassIntl')..createSync(recursive: true);
+      file = IntlMessages('TestClass', tmp, '');
+      file.outputFile.createSync(recursive: true);
     });
 
     tearDown(() {

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -1,5 +1,6 @@
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
+import 'package:over_react_codemod/src/intl_suggestors/intl_messages.dart';
 import 'package:over_react_codemod/src/intl_suggestors/intl_migrator.dart';
 import 'package:test/test.dart';
 
@@ -15,7 +16,7 @@ void main() {
 
   group('IntlMigrator', () {
     final FileSystem fs = MemoryFileSystem();
-    late File file;
+    late IntlMessages file;
     late SuggestorTester basicSuggestor;
 
     // Idempotency isn't a worry for this suggestor, and testing it throws off
@@ -30,7 +31,9 @@ void main() {
 
     setUp(() async {
       final Directory tmp = await fs.systemTempDirectory.createTemp();
-      file = tmp.childFile('TestClassIntl')..createSync(recursive: true);
+      file = IntlMessages('TestClass', tmp, '');
+      // TODO: It's awkward that this test assumes the file exists, but that it doesn't have the prologue written.
+      file.outputFile.createSync(recursive: true);
       basicSuggestor = getSuggestorTester(
         IntlMigrator('TestClassIntl', file),
         resolvedContext: resolvedContext,


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Right now the executable and various methods explicitly reference the output file for the Intl methods. It would be better if there was an abstraction there that would parse the existing file and allow modifying it and rewriting it. For example, that would make it easier to sort by methods, rather than by lines (as is done now, and breaks for multi-line strings).

## Changes
  <!-- What this PR changes to fix the problem. -->
This just extracts out the file access logic, with minimal changes.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
