### PR TITLE
Fixes problem with adjacent string and duplicated constant names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [2.7.0](https://github.com/Workiva/over_react_codemod/compare/2.7.0....2.6.0)
 
+- Fix type error with adjacent strings.
+- Prevent duplicate names for constants by falling back to a content-based name if the variable name is a duplicate.
 - Ignore the lint for unnecessary braces in string interpolations in the generated `intl.dart` file.
 - Change the name of migrated constant strings to match the original variable instead of being derived from the value.
 

--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -247,7 +247,7 @@ Future<void> migratePackage(
   final classPredicate = '''import 'package:intl/intl.dart';
 
 //ignore: avoid_classes_with_only_static_members
-//ignore: unnecessary_brace_in_string_interps
+//ignore_for_file: unnecessary_brace_in_string_interps
 
 class $className {
 ''';
@@ -285,7 +285,8 @@ class $className {
     List<String> lines = outputFile.readAsLinesSync();
     final functions = lines.sublist(prologueLength);
     functions.removeWhere((string) => string == '');
-    functions.sort();
+    // TODO: Sort by function, not by line.
+    // functions.sort();
     lines.replaceRange(prologueLength, lines.length, functions);
     lines.add('}');
     outputFile.writeAsStringSync(lines.join('\n'), mode: FileMode.write);

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -73,13 +73,14 @@ void main() {
       expect(err, contains(' change(s) needed.'));
     });
 
-    testCodemod('Output is sorted',
-        script: script,
-        input: inputFiles(additionalFilesInLib: [extraInput()]),
-        expectedOutput: expectedOutputFiles(
-            additionalFilesInLib: [extraOutput()],
-            messages: [...defaultMessages, ...extraMessages]..sort()),
-        args: ['--yes-to-all']);
+    // TODO: Restore when sorting is restored.
+    // testCodemod('Output is sorted',
+    //     script: script,
+    //     input: inputFiles(additionalFilesInLib: [extraInput()]),
+    //     expectedOutput: expectedOutputFiles(
+    //         additionalFilesInLib: [extraOutput()],
+    //         messages: [...defaultMessages, ...extraMessages]..sort()),
+    //     args: ['--yes-to-all']);
 
     testCodemod('Specify a single file',
         // We add some extra files, but we specify just the original, so they shouldn't be included.
@@ -188,9 +189,10 @@ usage() => (mui.Button()..aria.label='Sorts later')('Literal String');''')
   ]);
 }
 
+// TODO: Put these back in the correct order when sorting is re-enabled.
 const List<String> defaultMessages = [
+  "  static String get sortsLater => Intl.message('Sorts later', name: 'TestProjectIntl_sortsLater',);",
   "  static String get literalString => Intl.message('Literal String', name: 'TestProjectIntl_literalString',);",
-  "  static String get sortsLater => Intl.message('Sorts later', name: 'TestProjectIntl_sortsLater',);"
 ];
 
 d.DirectoryDescriptor expectedOutputFiles({

--- a/test/intl_suggestors/constant_migrator_test.dart
+++ b/test/intl_suggestors/constant_migrator_test.dart
@@ -17,13 +17,23 @@ void main() {
   group('Constant Migrator', () {
     final FileSystem fs = MemoryFileSystem();
     late IntlMessages file;
-    late SuggestorTester testSuggestor;
+    late SuggestorTester basicSuggestor;
+
+    // Idempotency isn't a worry for this suggestor, and testing it throws off
+    // checking for duplicates, so disable it for these tests.
+    // TODO: Avoid duplicating this between test files.
+    Future<void> testSuggestor(
+            {required String input, required String expectedOutput}) =>
+        basicSuggestor(
+            input: input,
+            expectedOutput: expectedOutput,
+            testIdempotency: false);
 
     setUp(() async {
       final Directory tmp = await fs.systemTempDirectory.createTemp();
       file = IntlMessages('TestClass', tmp, '');
       file.outputFile.createSync(recursive: true);
-      testSuggestor = getSuggestorTester(
+      basicSuggestor = getSuggestorTester(
         ConstantStringMigrator('TestClassIntl', file),
         resolvedContext: resolvedContext,
       );
@@ -77,6 +87,85 @@ void main() {
         final expectedFileContent =
             '\n  static String get foo => Intl.message(\'I am a user-visible constant\', name: \'TestClassIntl_foo\',);';
         expect(file.readAsStringSync(), expectedFileContent);
+      });
+
+      test('private constant', () async {
+        await testSuggestor(
+          input: '''
+          class Bar {
+            static const _foo = 'I am a user-visible constant';
+          }
+            ''',
+          expectedOutput: '''
+          class Bar { 
+            static final String _foo = TestClassIntl.foo;
+          }
+            ''',
+        );
+        final expectedFileContent =
+            '\n  static String get foo => Intl.message(\'I am a user-visible constant\', name: \'TestClassIntl_foo\',);';
+        expect(file.readAsStringSync(), expectedFileContent);
+      });
+
+      test('duplicate static names', () async {
+        await testSuggestor(
+          input: '''
+          class Bar {
+            static const foo = 'I am a user-visible constant';
+          }
+          class Qux {
+            static const foo = 'Another static';
+          }
+          const foo = 'A different constant';
+            ''',
+          expectedOutput: '''
+          class Bar { 
+            static final String foo = TestClassIntl.foo;
+          }
+          class Qux {
+            static final String foo = TestClassIntl.anotherStatic;
+          }
+
+          final String foo = TestClassIntl.aDifferentConstant;
+          
+            ''',
+        );
+        final expectedFileContent = '''
+  static String get foo => Intl.message(\'I am a user-visible constant\', name: \'TestClassIntl_foo\',);
+  static String get anotherStatic => Intl.message(\'Another static\', name: \'TestClassIntl_anotherStatic\',);
+  static String get aDifferentConstant => Intl.message(\'A different constant\', name: \'TestClassIntl_aDifferentConstant\',);''';
+        expect(file.readAsStringSync().trim(),
+            expectedFileContent.trim()); // Avoid the leading return.
+      });
+
+      test('duplicate static names with duplicated text', () async {
+        await testSuggestor(
+          input: '''
+          class Bar {
+            static const foo = 'I am a user-visible constant';
+          }
+          class Qux {
+            static const foo = 'Another static';
+          }
+          const foo = 'Another static';
+            ''',
+          expectedOutput: '''
+          class Bar { 
+            static final String foo = TestClassIntl.foo;
+          }
+          class Qux {
+            static final String foo = TestClassIntl.anotherStatic;
+          }
+
+          final String foo = TestClassIntl.anotherStatic;
+          
+            ''',
+        );
+        final expectedFileContent = '''
+  static String get foo => Intl.message(\'I am a user-visible constant\', name: \'TestClassIntl_foo\',);
+  static String get anotherStatic => Intl.message(\'Another static\', name: \'TestClassIntl_anotherStatic\',);''';
+        expect(file.readAsStringSync().trim(),
+            expectedFileContent.trim()); // Avoid the leading return.
       });
     });
   });


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
There is a typecast error with adjacent strings.
If two different constants in different places have the same variable name, we get duplicates. So this falls back to a content-based name if the name already exists.



## Changes
  <!-- What this PR changes to fix the problem. -->
Fix the type of the argument. This also requires removing the sort by lines, since that fails for adjacent strings on separate lines.


#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
