### PR TITLE
INTL-165: Re-enable sorting of _intl.dart files

### DIFF
--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -241,7 +241,6 @@ Future<void> migratePackage(
 
   final IntlMessages outputFile =
       IntlMessages(packageName, fs.currentDirectory, package);
-  outputFile.initialize();
 
   final intlPropMigrator = IntlMigrator(outputFile.className, outputFile);
   final constantStringMigrator =

--- a/lib/src/intl_suggestors/intl_messages.dart
+++ b/lib/src/intl_suggestors/intl_messages.dart
@@ -30,6 +30,9 @@ class $className {''';
     _readExisting();
   }
 
+// #### Be able to update an existing file
+// #### Tests for adjacent strings and multi-line.
+
   void _readExisting() {
     if (outputFile.existsSync()) {
       existingContents = outputFile.readAsStringSync();

--- a/lib/src/intl_suggestors/intl_messages.dart
+++ b/lib/src/intl_suggestors/intl_messages.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:file/file.dart';
 import 'package:over_react_codemod/src/intl_suggestors/utils.dart';
 import 'package:path/path.dart' as p;
@@ -12,60 +10,58 @@ import 'package:path/path.dart' as p;
 class IntlMessages {
   final String packageName;
   final File outputFile;
+  late String existingContents;
   final String className;
+  Set<String> methods = {};
 
-  String get classPredicate => '''import 'package:intl/intl.dart';
+  String get prologue => '''import 'package:intl/intl.dart';
 
 //ignore: avoid_classes_with_only_static_members
 //ignore_for_file: unnecessary_brace_in_string_interps
 
-class $className {
-''';
+class $className {''';
 
   IntlMessages(this.packageName, Directory currentDir, String packagePath)
       :
         // TODO: I think packagePath only applies if there's a sub-package.
         outputFile = currentDir.childFile(p.join(
             packagePath, 'lib', 'src', 'intl', '${packageName}_intl.dart')),
-        className = toClassName('${packageName}');
+        className = toClassName('${packageName}') {
+    _readExisting();
+  }
 
-  bool contains(String x) => outputFile.readAsStringSync().contains(x);
-
-  // TODO: Get rid of the pseudo-file operations if possible.
-  String readAsStringSync() => outputFile.readAsStringSync();
-
-  void append(String x) =>
-      outputFile.writeAsStringSync(x, mode: FileMode.append);
-
-  void deleteSync() => outputFile.deleteSync();
-
-  initialize() {
-    bool existingOutputFile = outputFile.existsSync();
-
-    if (!existingOutputFile) {
-      outputFile.createSync(recursive: true);
-      outputFile.writeAsStringSync(classPredicate);
+  void _readExisting() {
+    if (outputFile.existsSync()) {
+      existingContents = outputFile.readAsStringSync();
     } else {
-      final List<String> lines = outputFile.readAsLinesSync();
-      lines.removeLast();
-      String outputContent = lines.join('\n');
-      outputFile.writeAsStringSync(outputContent);
+      existingContents = '';
     }
   }
 
+  // TODO: Get rid of the pseudo-file operations if possible.
+  String messageContents() => _messageContents;
+
+  void addMethod(String method) {
+    methods.add(method);
+    // outputFile.writeAsStringSync(method, mode: FileMode.append);
+  }
+
+  void delete() => outputFile.deleteSync();
+
+  String get contents =>
+      (StringBuffer()..write(prologue)..write(_messageContents)..write('\n}'))
+          .toString();
+
+  // Just the messages, without the prologue or closing brace. Mostly used for testing.
+  String get _messageContents {
+    var buffer = StringBuffer();
+    (methods.toList()..sort()).forEach(buffer.write);
+    return '$buffer';
+  }
+
   write() {
-    if (exitCode != 0 || outputFile.readAsStringSync() == classPredicate) {
-      outputFile.deleteSync();
-    } else {
-      var prologueLength = 6;
-      List<String> lines = outputFile.readAsLinesSync();
-      final functions = lines.sublist(prologueLength);
-      functions.removeWhere((string) => string == '');
-      // TODO: Sort by function, not by line.
-      // functions.sort();
-      lines.replaceRange(prologueLength, lines.length, functions);
-      lines.add('}');
-      outputFile.writeAsStringSync(lines.join('\n'), mode: FileMode.write);
-    }
+    if (methods.isEmpty) return;
+    outputFile.createSync(recursive: true);
+    outputFile.writeAsStringSync(contents);
   }
 }

--- a/lib/src/intl_suggestors/intl_messages.dart
+++ b/lib/src/intl_suggestors/intl_messages.dart
@@ -30,9 +30,7 @@ class $className {''';
     _readExisting();
   }
 
-// #### Be able to update an existing file
-// #### Tests for adjacent strings and multi-line.
-
+  // TODO: Be able to update an existing file.
   void _readExisting() {
     if (outputFile.existsSync()) {
       existingContents = outputFile.readAsStringSync();
@@ -46,7 +44,6 @@ class $className {''';
 
   void addMethod(String method) {
     methods.add(method);
-    // outputFile.writeAsStringSync(method, mode: FileMode.append);
   }
 
   void delete() => outputFile.deleteSync();

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -233,9 +233,7 @@ String removeInterpolationSyntax(String s) =>
 String toNestedName(String s) => removeInterpolationSyntax(s).split('.').last;
 
 void addMethodToClass(IntlMessages outputFile, String content) {
-  if (!outputFile.contains(content)) {
-    outputFile.append(content);
-  }
+  outputFile.addMethod(content);
 }
 
 /// Input: foo_bar_package

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -73,14 +73,13 @@ void main() {
       expect(err, contains(' change(s) needed.'));
     });
 
-    // TODO: Restore when sorting is restored.
-    // testCodemod('Output is sorted',
-    //     script: script,
-    //     input: inputFiles(additionalFilesInLib: [extraInput()]),
-    //     expectedOutput: expectedOutputFiles(
-    //         additionalFilesInLib: [extraOutput()],
-    //         messages: [...defaultMessages, ...extraMessages]..sort()),
-    //     args: ['--yes-to-all']);
+    testCodemod('Output is sorted',
+        script: script,
+        input: inputFiles(additionalFilesInLib: [extraInput()]),
+        expectedOutput: expectedOutputFiles(
+            additionalFilesInLib: [extraOutput()],
+            messages: [...defaultMessages, ...extraMessages]..sort()),
+        args: ['--yes-to-all']);
 
     testCodemod('Specify a single file',
         // We add some extra files, but we specify just the original, so they shouldn't be included.
@@ -191,8 +190,8 @@ usage() => (mui.Button()..aria.label='Sorts later')('Literal String');''')
 
 // TODO: Put these back in the correct order when sorting is re-enabled.
 const List<String> defaultMessages = [
-  "  static String get sortsLater => Intl.message('Sorts later', name: 'TestProjectIntl_sortsLater',);",
   "  static String get literalString => Intl.message('Literal String', name: 'TestProjectIntl_literalString',);",
+  "  static String get sortsLater => Intl.message('Sorts later', name: 'TestProjectIntl_sortsLater',);",
 ];
 
 d.DirectoryDescriptor expectedOutputFiles({

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -78,7 +78,8 @@ void main() {
         input: inputFiles(additionalFilesInLib: [extraInput()]),
         expectedOutput: expectedOutputFiles(
             additionalFilesInLib: [extraOutput()],
-            messages: [...defaultMessages, ...extraMessages]..sort()),
+            messages: [...defaultMessages, ...extraMessages, ...longMessages]
+              ..sort()),
         args: ['--yes-to-all']);
 
     testCodemod('Specify a single file',
@@ -148,7 +149,15 @@ d.FileDescriptor extraInput() {
   return d.file('more_stuff.dart',
       /*language=dart*/ '''import 'package:react_material_ui/react_material_ui.dart' as mui;
 
-someMoreStrings() => (mui.Button()..aria.label='orange')('aquamarine');''');
+someMoreStrings() => (mui.Button()
+  ..aria.label='orange'
+  ..label="""
+A long string
+with multiple
+   lines""")
+    ('aquamarine',
+     'two adjacent '
+     'strings on separate lines');''');
 }
 
 d.FileDescriptor extraOutput() {
@@ -156,12 +165,23 @@ d.FileDescriptor extraOutput() {
       /*language=dart*/ '''import 'package:react_material_ui/react_material_ui.dart' as mui;
 import 'package:test_project/src/intl/test_project_intl.dart';
 
-someMoreStrings() => (mui.Button()..aria.label=TestProjectIntl.orange)(TestProjectIntl.aquamarine);''');
+someMoreStrings() => (mui.Button()
+  ..aria.label=TestProjectIntl.orange
+  ..label=TestProjectIntl.aLongStringwithMultiple)
+    (TestProjectIntl.aquamarine,
+     TestProjectIntl.twoAdjacentStringsOnSeparate);''');
 }
 
 List<String> extraMessages = [
   "  static String get orange => Intl.message('orange', name: 'TestProjectIntl_orange',);",
   "  static String get aquamarine => Intl.message('aquamarine', name: 'TestProjectIntl_aquamarine',);"
+];
+
+List<String> longMessages = [
+  """  static String get twoAdjacentStringsOnSeparate => Intl.message('two adjacent strings on separate lines', name: 'TestProjectIntl_twoAdjacentStringsOnSeparate',);""",
+  """  static String get aLongStringwithMultiple => Intl.message('''A long string
+with multiple
+   lines''', name: 'TestProjectIntl_aLongStringwithMultiple',);""",
 ];
 
 d.DirectoryDescriptor inputFiles(
@@ -188,7 +208,6 @@ usage() => (mui.Button()..aria.label='Sorts later')('Literal String');''')
   ]);
 }
 
-// TODO: Put these back in the correct order when sorting is re-enabled.
 const List<String> defaultMessages = [
   "  static String get literalString => Intl.message('Literal String', name: 'TestProjectIntl_literalString',);",
   "  static String get sortsLater => Intl.message('Sorts later', name: 'TestProjectIntl_sortsLater',);",

--- a/test/intl_suggestors/intl_configs_migrator_test.dart
+++ b/test/intl_suggestors/intl_configs_migrator_test.dart
@@ -30,22 +30,23 @@ void main() {
     // (which is more common for the WSD context), it fails here instead of failing the first test.
     setUpAll(resolvedContext.warmUpAnalysis);
 
-    late IntlMessages file;
+    late IntlMessages messages;
     SuggestorTester? testSuggestor;
 
     setUp(() async {
       final FileSystem fs = MemoryFileSystem();
       final Directory tmp = await fs.systemTempDirectory.createTemp();
-      file = IntlMessages('TestClass', tmp, '');
-      file.outputFile.createSync(recursive: true);
+      messages = IntlMessages('TestClass', tmp, '');
+      messages.outputFile.createSync(recursive: true);
     });
 
     tearDown(() {
-      file.deleteSync();
+      messages.delete();
     });
 
     test('correctly changes display name', () async {
-      testSuggestor = getSuggestorTester(ConfigsMigrator('TestClassIntl', file),
+      testSuggestor = getSuggestorTester(
+          ConfigsMigrator('TestClassIntl', messages),
           resolvedContext: resolvedContext,
           inputUrl: 'test/input/display_name_config.dart');
       await testSuggestor!(
@@ -64,11 +65,12 @@ void main() {
       );
       final expectedFileContent =
           "\n  static String get testDisplayName => Intl.message('Test Display Name', name: 'TestClassIntl_testDisplayName',);";
-      expect(file.readAsStringSync(), expectedFileContent);
+      expect(messages.messageContents(), expectedFileContent);
     });
 
     test('correctly changes name', () async {
-      testSuggestor = getSuggestorTester(ConfigsMigrator('TestClassIntl', file),
+      testSuggestor = getSuggestorTester(
+          ConfigsMigrator('TestClassIntl', messages),
           resolvedContext: resolvedContext,
           inputUrl: 'test/input/name_config.dart');
 
@@ -88,11 +90,12 @@ void main() {
       );
       final expectedFileContent =
           "\n  static String get testName => Intl.message('Test Name', name: 'TestClassIntl_testName',);";
-      expect(file.readAsStringSync(), expectedFileContent);
+      expect(messages.messageContents(), expectedFileContent);
     });
 
     test('correctly changes title', () async {
-      testSuggestor = getSuggestorTester(ConfigsMigrator('TestClassIntl', file),
+      testSuggestor = getSuggestorTester(
+          ConfigsMigrator('TestClassIntl', messages),
           resolvedContext: resolvedContext,
           inputUrl: 'test/input/title_config.dart');
       await testSuggestor!(
@@ -111,7 +114,7 @@ void main() {
       );
       final expectedFileContent =
           "\n  static String get testTitle => Intl.message('Test Title', name: 'TestClassIntl_testTitle',);";
-      expect(file.readAsStringSync(), expectedFileContent);
+      expect(messages.messageContents(), expectedFileContent);
     });
   });
 }

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -16,7 +16,7 @@ void main() {
 
   group('IntlMigrator', () {
     final FileSystem fs = MemoryFileSystem();
-    late IntlMessages file;
+    late IntlMessages messages;
     late SuggestorTester basicSuggestor;
 
     // Idempotency isn't a worry for this suggestor, and testing it throws off
@@ -31,17 +31,17 @@ void main() {
 
     setUp(() async {
       final Directory tmp = await fs.systemTempDirectory.createTemp();
-      file = IntlMessages('TestClass', tmp, '');
+      messages = IntlMessages('TestClass', tmp, '');
       // TODO: It's awkward that this test assumes the file exists, but that it doesn't have the prologue written.
-      file.outputFile.createSync(recursive: true);
+      messages.outputFile.createSync(recursive: true);
       basicSuggestor = getSuggestorTester(
-        IntlMigrator('TestClassIntl', file),
+        IntlMigrator('TestClassIntl', messages),
         resolvedContext: resolvedContext,
       );
     });
 
     tearDown(() {
-      file.deleteSync();
+      messages.delete();
     });
 
     group('Child - StringLiteral', () {
@@ -76,7 +76,7 @@ void main() {
         );
         final expectedFileContent =
             '\n  static String get viewer => Intl.message(\'viewer\', name: \'TestClassIntl_viewer\',);';
-        expect(file.readAsStringSync(), expectedFileContent);
+        expect(messages.messageContents(), expectedFileContent);
       });
 
       test('StringLiteral two children', () async {
@@ -114,7 +114,7 @@ void main() {
 
         final expected =
             "\n  static String get testString1 => Intl.message('testString1', name: 'TestClassIntl_testString1',);\n  static String get testString2 => Intl.message('testString2', name: 'TestClassIntl_testString2',);";
-        expect(file.readAsStringSync(), expected);
+        expect(messages.messageContents(), expected);
       });
 
       test('single number string', () async {
@@ -212,7 +212,7 @@ void main() {
         );
         final expected =
             "\n  static String get thisIsALengthyString => Intl.message('this is a lengthy string, it\\\'s been broken up into several lines which Dart automatically concatenates.', name: 'TestClassIntl_thisIsALengthyString',);";
-        expect(file.readAsStringSync(), expected);
+        expect(messages.messageContents(), expected);
       });
     });
 
@@ -284,7 +284,7 @@ void main() {
 
         final expectedFileContent =
             "\n  static String Foo_intlFunction0(String number) => Intl.message('Distance \${number}km', args: [number], name: 'TestClassIntl_Foo_intlFunction0',);";
-        expect(file.readAsStringSync(), expectedFileContent);
+        expect(messages.messageContents(), expectedFileContent);
       });
 
       test('two different interpolations get different names', () async {
@@ -323,7 +323,7 @@ void main() {
         final expectedFileContent =
             "\n  static String Foo_intlFunction0(String title) => Intl.message('Also interpolated \${title}', args: [title], name: 'TestClassIntl_Foo_intlFunction0',);"
             "\n  static String Foo_intlFunction1(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction1',);";
-        expect(file.readAsStringSync(), expectedFileContent);
+        expect(messages.messageContents(), expectedFileContent);
       });
 
       test('two argument with top level accessors', () async {
@@ -361,7 +361,7 @@ void main() {
         );
         final expectedFileContent =
             "\n  static String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0',);";
-        expect(file.readAsStringSync(), expectedFileContent);
+        expect(messages.messageContents(), expectedFileContent);
       });
 
       test('one argument with nested accessor', () async {
@@ -399,7 +399,7 @@ void main() {
         );
         final expectedFileContent =
             "\n  static String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);";
-        expect(file.readAsStringSync(), expectedFileContent);
+        expect(messages.messageContents(), expectedFileContent);
       });
 
       test('two arguments with nested accessor', () async {
@@ -441,7 +441,7 @@ void main() {
         );
         final expectedFileContent =
             "\n  static String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0',);";
-        expect(file.readAsStringSync(), expectedFileContent);
+        expect(messages.messageContents(), expectedFileContent);
       });
 
       test('one argument with nested accessor and null operator', () async {
@@ -479,7 +479,7 @@ void main() {
         );
         final expectedFileContent =
             "\n  static String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);";
-        expect(file.readAsStringSync(), expectedFileContent);
+        expect(messages.messageContents(), expectedFileContent);
       });
 
       test('Single interpolated element', () async {
@@ -559,7 +559,7 @@ void main() {
 
         final expectedFileContent =
             "\n  static String Foo_intlFunction0(String getName) => Intl.message('His name was \${getName}', args: [getName], name: 'TestClassIntl_Foo_intlFunction0',);";
-        expect(file.readAsStringSync(), expectedFileContent);
+        expect(messages.messageContents(), expectedFileContent);
       });
 
       test('Interpolated with apostrophe', () async {
@@ -598,7 +598,7 @@ void main() {
 
         final expectedFileContent =
             "\n  static String Foo_intlFunction0(String lastName) => Intl.message('Bob\\\'s last name was \${lastName}', args: [lastName], name: 'TestClassIntl_Foo_intlFunction0',);";
-        expect(file.readAsStringSync(), expectedFileContent);
+        expect(messages.messageContents(), expectedFileContent);
       });
       test('Interpolated with testId string', () async {
         await testSuggestor(
@@ -644,7 +644,7 @@ void main() {
 
         String expectedFileContent =
             "\n  static String versionInfo(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_versionInfo',);";
-        expect(file.readAsStringSync(), expectedFileContent);
+        expect(messages.messageContents(), expectedFileContent);
       });
 
       test('Interpolated with testId', () async {
@@ -699,7 +699,7 @@ void main() {
 
         String expectedFileContent =
             "\n  static String versionInfo(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_versionInfo',);";
-        expect(file.readAsStringSync(), expectedFileContent);
+        expect(messages.messageContents(), expectedFileContent);
       });
 
       test('Interpolated with testId in a parent node', () async {
@@ -770,8 +770,8 @@ void main() {
             "\n  static String foo(String displayName) => Intl.message('Create one from any \${displayName} by selecting Save As Template', args: [displayName], name: 'TestClassIntl_foo',);";
         String expectedFileContent2 =
             "\n  static String bar(String displayName) => Intl.message('Create one from any \${displayName} by selecting Save As Template', args: [displayName], name: 'TestClassIntl_bar',);";
-        expect(file.readAsStringSync(),
-            [expectedFileContent1, expectedFileContent2].join(''));
+        expect(messages.messageContents(),
+            [expectedFileContent2, expectedFileContent1].join(''));
       });
 
       test('Home Example', () async {
@@ -813,7 +813,7 @@ void main() {
         );
         final expectedFileContent =
             "\n  static String Foo_intlFunction0(String fileStr, String refStr) => Intl.message('Now that you\\\'ve transitioned your \${fileStr}, you\\\'ll want to freeze \${refStr} or update permissions to prevent others from using \${refStr}.', args: [fileStr, refStr], name: 'TestClassIntl_Foo_intlFunction0',);";
-        expect(file.readAsStringSync(), expectedFileContent);
+        expect(messages.messageContents(), expectedFileContent);
       });
     });
 
@@ -850,7 +850,7 @@ void main() {
 
         final expectedFileOutput =
             '\n  static String get testString => Intl.message(\'Test String\', name: \'TestClassIntl_testString\',);';
-        expect(file.readAsStringSync(), expectedFileOutput);
+        expect(messages.messageContents(), expectedFileOutput);
       });
 
       test('class string literal', () async {
@@ -886,7 +886,7 @@ void main() {
         );
         final expectedFileOutput =
             '\n  static String get testString => Intl.message(\'Test String\', name: \'TestClassIntl_testString\',);';
-        expect(file.readAsStringSync(), expectedFileOutput);
+        expect(messages.messageContents(), expectedFileOutput);
       });
 
       test('uiFunction props => component', () async {
@@ -916,7 +916,7 @@ void main() {
         );
         final expectedFileOutput =
             '\n  static String get testString => Intl.message(\'Test String\', name: \'TestClassIntl_testString\',);';
-        expect(file.readAsStringSync(), expectedFileOutput);
+        expect(messages.messageContents(), expectedFileOutput);
       });
     });
 
@@ -957,7 +957,7 @@ void main() {
 
         final expectedFileContent =
             "\n  static String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);";
-        expect(file.readAsStringSync(), expectedFileContent);
+        expect(messages.messageContents(), expectedFileContent);
       });
 
       test('two argument with top level accessors', () async {
@@ -997,7 +997,7 @@ void main() {
         );
         final expectedFileContent =
             "\n  static String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0',);";
-        expect(file.readAsStringSync(), expectedFileContent);
+        expect(messages.messageContents(), expectedFileContent);
       });
 
       test('one argument with nested accessor', () async {
@@ -1037,7 +1037,7 @@ void main() {
         );
         final expectedFileContent =
             "\n  static String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0',);";
-        expect(file.readAsStringSync(), expectedFileContent);
+        expect(messages.messageContents(), expectedFileContent);
       });
 
       test('two arguments with nested accessor', () async {
@@ -1079,7 +1079,7 @@ void main() {
         );
         final expectedFileContent =
             "\n  static String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0',);";
-        expect(file.readAsStringSync(), expectedFileContent);
+        expect(messages.messageContents(), expectedFileContent);
       });
 
       test('Single interpolated element', () async {
@@ -1161,7 +1161,7 @@ void main() {
 
         final expectedFileContent =
             "\n  static String Foo_intlFunction0(String getName) => Intl.message('His name was \${getName}', args: [getName], name: 'TestClassIntl_Foo_intlFunction0',);";
-        expect(file.readAsStringSync(), expectedFileContent);
+        expect(messages.messageContents(), expectedFileContent);
       });
 
       test('Interpolated with apostrophe', () async {
@@ -1202,7 +1202,7 @@ void main() {
 
         final expectedFileContent =
             "\n  static String Foo_intlFunction0(String lastName) => Intl.message('Bob\\\'s last name was \${lastName}', args: [lastName], name: 'TestClassIntl_Foo_intlFunction0',);";
-        expect(file.readAsStringSync(), expectedFileContent);
+        expect(messages.messageContents(), expectedFileContent);
       });
 
       test('Interpolated with testId string', () async {
@@ -1245,7 +1245,7 @@ void main() {
 
         String expectedFileContent =
             "\n  static String versionInfo(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_versionInfo',);";
-        expect(file.readAsStringSync(), expectedFileContent);
+        expect(messages.messageContents(), expectedFileContent);
       });
 
       test('Interpolated with testId', () async {
@@ -1296,7 +1296,7 @@ void main() {
 
         String expectedFileContent =
             "\n  static String versionInfo(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_versionInfo',);";
-        expect(file.readAsStringSync(), expectedFileContent);
+        expect(messages.messageContents(), expectedFileContent);
       });
     });
   });


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Sorting had been disabled, due to its bad effect on multi-line strings. This adds sorting by function and re-enables it.

## Changes
  <!-- What this PR changes to fix the problem. -->
This relies further on the IntlMessages object, and replaces its direct file manipulation with storing messages and writing the file once at the end. It also cleans up the API for that a little more, removing or renaming file-specific methods. Adds tests for multi-line message strings and adjacent strings on separate lines, and re-enables the sorting test.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
