### PR TITLE
Turn on the --migrate-constants option by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [2.9.0](https://github.com/Workiva/over_react_codemod/compare/2.9.0....2.8.0)
+
+- Improve the sorting to be by function/getter name rather than the whole function/getter string.
+- Allow reading an existing _intl.dart file and rewriting it, preserving the existing functions.
+- Turn on the --migrate-constants option by default.
+
+## [2.8.0](https://github.com/Workiva/over_react_codemod/compare/2.8.0....2.7.0)
+
+- Re-enable sorting of the _intl.dart file.
+
 ## [2.7.0](https://github.com/Workiva/over_react_codemod/compare/2.7.0....2.6.0)
 
 - Fix type error with adjacent strings.

--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -81,7 +81,7 @@ final parser = ArgParser()
   ..addFlag(
     _migrateConstants,
     negatable: true,
-    defaultsTo: false,
+    defaultsTo: true,
     help:
         'Should the codemod try to migrate constant Strings that look user-visible',
   )


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Turn on the --migrate-constants option by default

## Changes
  <!-- What this PR changes to fix the problem. -->
Turn on the --migrate-constants option by default

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
