### PR TITLE
INTL-188: Fix incrementing the usage number of duplicate getters

### DIFF
--- a/lib/src/intl_suggestors/intl_message_syntax.dart
+++ b/lib/src/intl_suggestors/intl_message_syntax.dart
@@ -16,7 +16,7 @@ class MessageSyntax {
   /// A template to build property access for intl string
   /// ex: ExampleIntl.exampleString
   String getterCall(StringLiteral node, String namespace, {String? name}) =>
-      '${namespace}.${name ?? nameForNode(node, initialName: name)}';
+      '${namespace}.${nameForNode(node, initialName: name)}';
 
   /// Returns Intl.message for string literal.
   ///

--- a/test/intl_suggestors/constant_migrator_test.dart
+++ b/test/intl_suggestors/constant_migrator_test.dart
@@ -169,6 +169,29 @@ void main() {
         expect(messages.messageContents().trim(),
             expectedFileContent.trim()); // Avoid the leading return.
       });
+
+      test('duplicate getter names increment', () async {
+        await testSuggestor(
+          input: '''
+          const String dueDate = 'Due Date';
+          class Dupe {
+            static const dueDate = 'Due date';
+          }
+            ''',
+          expectedOutput: '''
+          final String dueDate = TestClassIntl.dueDate;
+          class Dupe {
+            static final String dueDate = TestClassIntl.dueDate1;
+          }          
+            ''',
+        );
+        final expectedFileContent = '''
+  static String get dueDate => Intl.message(\'Due Date\', name: \'TestClassIntl_dueDate\');
+  static String get dueDate1 => Intl.message(\'Due date\', name: \'TestClassIntl_dueDate1\');
+''';
+        expect(messages.messageContents().trim(),
+            expectedFileContent.trim()); // Avoid the leading return.
+      });
     });
   });
 }


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
If the codemod runs into two getters named the same thing, it will add a number to the second one (in this example, it would be dueDate -> 'Due Date' and dueDate1 -> 'Due date'). However, the usage was not reflecting the increment.

## Changes
  <!-- What this PR changes to fix the problem. -->
The getter generation passes in an explicit name, because it might be using either the variable name or a name derived from the text. But we were using that name unmodified, instead of using it as the seed to check for an incremented name.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
