### PR TITLE
Handle explicit newlines in strings

### DIFF
--- a/lib/src/intl_suggestors/intl_message_syntax.dart
+++ b/lib/src/intl_suggestors/intl_message_syntax.dart
@@ -95,7 +95,7 @@ class MessageSyntax {
     List<String> args = const [],
     bool isMultiline = false,
   }) {
-    var escapedStr = escapeApos(message);
+    var escapedStr = escapeNewlines(escapeApos(message), isMultiline);
     String delimiter = (isMultiline) ? "'''" : "'";
     return "Intl.message(${delimiter}${escapedStr}${delimiter}, ${args.isNotEmpty ? 'args: ${args}, ' : ''}name: '$name')";
   }
@@ -105,9 +105,13 @@ class MessageSyntax {
   String intlParameterizedMessage(StringInterpolation node) => node.elements
       .map((e) => e is InterpolationExpression
           ? intlInterpolation(e)
-          : (e as InterpolationString).value)
+          : escapeNewlines((e as InterpolationString).value, node.isMultiline))
       .toList()
       .join('');
+
+  String escapeNewlines(String input, bool isMultiline) {
+    return isMultiline ? input : input.replaceAll('\n', r'\n');
+  }
 
   String intlInterpolation(InterpolationExpression e) {
     var name = toVariableName(toNestedName('$e'));

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -78,8 +78,8 @@ bool isValidStringLiteralProp(PropAssignment prop) {
 // -- End Node Validation --
 
 String escapeApos(String s) {
-  var apos = '\'';
-  var backslash = '\\';
+  var apos = "'";
+  var backslash = r'\';
   return s.replaceAll(apos, backslash + apos);
 }
 

--- a/test/intl_suggestors/utils_test.dart
+++ b/test/intl_suggestors/utils_test.dart
@@ -101,6 +101,13 @@ void main() {
         runResults(testStr, false, expectedResult);
       });
 
+      test('single line with explicit newline', () async {
+        final testStr = r"'two\nlines${foo}'";
+        final expectedResult =
+            "  static String NamePrefix_intlFunction0(String foo) => Intl.message('two\\nlines\${foo}', args: [foo], name: 'Namespace_NamePrefix_intlFunction0');";
+        runResults(testStr, false, expectedResult);
+      });
+
       test('multiline', () async {
         final testStr = r"'''${multiline}'''";
         final expectedResult =


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
If there's an explicit newline in a single-line string, we need to escape that in the generated _intl.dart class.
However, that's also a bit of a red flag that there's something odd going on.

## Changes
  <!-- What this PR changes to fix the problem. -->

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
