### PR TITLE
Do not internationalize SCREAMING_CAPS constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Improve reporting of parse errors in generated code for intl_message_migration
 - Fix a regression where we were getting strings with surrounding quotes from the node,
   and not stripping leading numbers as a result.
+- Don't convert SCREAMING_CAPS_CONSTANTS in intl_message_migration
 
 ## [2.9.0](https://github.com/Workiva/over_react_codemod/compare/2.9.0....2.8.0)
 

--- a/lib/src/intl_suggestors/intl_migrator.dart
+++ b/lib/src/intl_suggestors/intl_migrator.dart
@@ -38,6 +38,8 @@ class ConstantStringMigrator extends GeneralizingAstVisitor
       var end = node.parent!.end;
       var firstLetter = string.substring(0, 1);
       var secondLetter = string.substring(1, 2);
+      // If it looks like a CONSTANT_FROM_SOME_OTHER_LIBRARY don't convert it.
+      if (string.toUpperCase() == string) return;
       // Is the first character uppercase, excluding strings that start with two of the same
       // uppercase character, which has a good chance of being a date format (e.g. 'MM/dd/YYYY').
       if (firstLetter != secondLetter &&

--- a/test/intl_suggestors/constant_migrator_test.dart
+++ b/test/intl_suggestors/constant_migrator_test.dart
@@ -71,6 +71,19 @@ void main() {
         expect(messages.messageContents(), expectedFileContent);
       });
 
+      test('SCREAMING_CAPS_ARE_IGNORED', () async {
+        await testSuggestor(
+          input: '''
+            const foo = 'DO_NOT_CONVERT_ME';
+            ''',
+          expectedOutput: '''
+            const foo = 'DO_NOT_CONVERT_ME';
+            ''',
+        );
+        final expectedFileContent = '';
+        expect(messages.messageContents(), expectedFileContent);
+      });
+
       test('static constant', () async {
         await testSuggestor(
           input: '''


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
We should not internationalize things that are all uppercase. They are most likely constants and not user strings.

## Changes
  <!-- What this PR changes to fix the problem. -->
Check for that.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
