### PR TITLE
Be consistent in how we're generating string interpolations 

### DIFF
--- a/lib/src/intl_suggestors/intl_message_syntax.dart
+++ b/lib/src/intl_suggestors/intl_message_syntax.dart
@@ -141,7 +141,11 @@ class MessageSyntax {
 
   String nameForNode(StringLiteral body,
       {String? initialName, bool startAtZero = false}) {
-    var messageText = body.toSource();
+    // If the body is an interpolation, make sure we generate it the same way we will see it in
+    // the final file, otherwise comparisons may fail. Notably, be sure we always use ${} form.
+    var messageText = body is StringInterpolation
+        ? intlParameterizedMessage(body)
+        : body.toSource();
     var functionName = toVariableName(messageText);
     functionName = owner.nameForString(initialName ?? functionName, messageText,
         startAtZero: startAtZero);

--- a/lib/src/intl_suggestors/intl_messages.dart
+++ b/lib/src/intl_suggestors/intl_messages.dart
@@ -89,8 +89,18 @@ Attempting to add a different message with the same name:
   /// Is there already something with this name, but a different messageText?
   bool isNameTaken(String name, String messageText) {
     var method = methods[name];
-    return method != null && methods[name]!.messageText != messageText;
+    if (method == null) return false;
+    if (method.messageText == messageText) return false;
+    return _withoutCurlies(method.messageText) != _withoutCurlies(messageText);
   }
+
+  RegExp _curlyBraces = RegExp('[{}]');
+
+  /// Earlier generated messages, or those hand-written, might not use {} around
+  /// interpolated variables. Newer code always does, but then this might lead
+  /// to a false difference in the strings. Since {} are rare in user text,
+  /// check if strings with the same method name are equal when we remove them.
+  String _withoutCurlies(String text) => text.replaceAll(_curlyBraces, '');
 
   /// Delete our generated file. Used for tests.
   void delete() => outputFile.deleteSync();

--- a/lib/src/intl_suggestors/intl_messages.dart
+++ b/lib/src/intl_suggestors/intl_messages.dart
@@ -89,18 +89,8 @@ Attempting to add a different message with the same name:
   /// Is there already something with this name, but a different messageText?
   bool isNameTaken(String name, String messageText) {
     var method = methods[name];
-    if (method == null) return false;
-    if (method.messageText == messageText) return false;
-    return _withoutCurlies(method.messageText) != _withoutCurlies(messageText);
+    return method != null && methods[name]!.messageText != messageText;
   }
-
-  RegExp _curlyBraces = RegExp('[{}]');
-
-  /// Earlier generated messages, or those hand-written, might not use {} around
-  /// interpolated variables. Newer code always does, but then this might lead
-  /// to a false difference in the strings. Since {} are rare in user text,
-  /// check if strings with the same method name are equal when we remove them.
-  String _withoutCurlies(String text) => text.replaceAll(_curlyBraces, '');
 
   /// Delete our generated file. Used for tests.
   void delete() => outputFile.deleteSync();


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
If we use toSource() on a node that's an interpolation, we usually (unless it would be ambiguous?) get
`   "stuff $variable more stuff"`
But we are careful to always emit interpolations as
`  "stuff ${variable} more stuff"`

When we are checking to see if a message already exists by a name, we compare the messageText. But if it's an interpolation, we were generating it via toSource(), which wouldn't agree. So be consistent in how we're generating it.

Note that this can leave us generating two different messages for the two different forms if there was an existing version that was generated before we started using curly braces. But that can be future work on de-duplication.




## Changes
  <!-- What this PR changes to fix the problem. -->

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
