### PR TITLE
INTL-113 : ignore initial variable names in creating selectors

### DIFF
--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -16,9 +16,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/source/line_info.dart';
 import 'package:codemod/codemod.dart';
 import 'package:collection/collection.dart';
-import 'package:logging/logging.dart';
 
-final _log = Logger('intlImporter');
 
 Stream<Patch> intlImporter(
     FileContext context, String projectName, String className) async* {

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -17,7 +17,6 @@ import 'package:analyzer/source/line_info.dart';
 import 'package:codemod/codemod.dart';
 import 'package:collection/collection.dart';
 
-
 Stream<Patch> intlImporter(
     FileContext context, String projectName, String className) async* {
   final libraryResult = await context.getResolvedLibrary();

--- a/lib/src/intl_suggestors/intl_message_syntax.dart
+++ b/lib/src/intl_suggestors/intl_message_syntax.dart
@@ -146,9 +146,10 @@ class MessageSyntax {
     // Needing condition initialName.endsWith('_intlFunction') bcz when any node has addTestId we need to give that
     // priority, and will not override the node name.
     if (body is StringInterpolation && (initialName == null || initialName.endsWith('_intlFunction'))) {
-      var strings = body.elements.where((each) => each is InterpolationString).map((each) => each.toSource()).toList();
+
+      var strings = body.elements.where((each) => each is InterpolationString).map((each) => (each as InterpolationString).value).toList();
       var data=strings.join(' ').trim();
-      if(data.isNotEmpty){
+      if(data.isNotEmpty && !data.contains("'")){
         String name = toVariableName(data);
         if(name.trim().isNotEmpty){
           var functionName = owner.nameForString(name, messageText,

--- a/lib/src/intl_suggestors/intl_message_syntax.dart
+++ b/lib/src/intl_suggestors/intl_message_syntax.dart
@@ -52,18 +52,10 @@ class MessageSyntax {
   /// A template to build a function name for Intl message
   /// ex: Foo_bar
   String functionNameFor(
-    StringInterpolation node,
-    String namePrefix,
-  ) {
-    // checks for newline in string
-    var ignoreNewLineString = node.toSource();
-    if (ignoreNewLineString.contains(r'\n')) {
-      return '${namePrefix}_intlFunction';
-    }
-    return '${getTestId(null, node) ?? '${namePrefix}_intlFunction'}';
-  }
-
-
+      StringInterpolation node,
+      String namePrefix,
+      ) =>
+      '${getTestId(null, node) ?? '${namePrefix}_intlFunction'}';
 
   /// Returns Intl.message with interpolation
   /// ex: static String Foo_bar(String baz) => Intl.message(
@@ -147,20 +139,22 @@ class MessageSyntax {
     return '(${args.join(', ')})';
   }
 
-
   String nameForNode(StringLiteral body,
       {String? initialName, bool startAtZero = false}) {
     var messageText = body.toSource();
-    var functionName;
+
+    //Strings from constant fields will not pass below condition so initialName will be unchanged.
     if (body is StringInterpolation) {
       var strings = body.elements.where((each) => each is InterpolationString).map((each) => each.toSource()).toList();
       var data=strings.join(' ').replaceAll("'", '').trim();
-      if(data.isNotEmpty && data.contains(' ')){
-        functionName=toVariableName(data);
-        initialName=functionName;
+      if(data.isNotEmpty){
+        var name = toVariableName(data);
+        var functionName = owner.nameForString(name, messageText,
+            startAtZero: startAtZero);
+        return functionName;
       }
     }
-      functionName = toVariableName(messageText);
+    var functionName = toVariableName(messageText);
     functionName = owner.nameForString(initialName ?? functionName, messageText,
         startAtZero: startAtZero);
     return functionName;

--- a/lib/src/intl_suggestors/intl_message_syntax.dart
+++ b/lib/src/intl_suggestors/intl_message_syntax.dart
@@ -135,13 +135,7 @@ class MessageSyntax {
     return '(${args.join(', ')})';
   }
 
-  /// For a string interpolation, get all the non-interpolated parts in a string,
-  /// separated by spaces.
-  String textFromInterpolation(StringInterpolation body) => body.elements
-      .whereType<InterpolationString>()
-      .map((each) => each.value)
-      .join(' ')
-      .trim();
+
 
   String nameForNode(StringLiteral body,
       {String? initialName=null, bool startAtZero = false}) {
@@ -150,8 +144,10 @@ class MessageSyntax {
         : body.toSource();
     // The case where there is no text after this should be checked in
     // isValidStringInterpolationNode and so it should never happen here.
-    return owner.nameForString(initialName ?? toVariableName(messageText), messageText,
-         startAtZero: startAtZero);
+return owner.nameForString(
+          initialName ?? toVariableName(messageText), messageText,
+          startAtZero: startAtZero);
+
 
   }
 

--- a/lib/src/intl_suggestors/intl_message_syntax.dart
+++ b/lib/src/intl_suggestors/intl_message_syntax.dart
@@ -142,16 +142,19 @@ class MessageSyntax {
   String nameForNode(StringLiteral body,
       {String? initialName, bool startAtZero = false}) {
     var messageText = body.toSource();
-
     //Strings from constant fields will not pass below condition so initialName will be unchanged.
-    if (body is StringInterpolation) {
+    // Needing condition initialName.endsWith('_intlFunction') bcz when any node has addTestId we need to give that
+    // priority, and will not override the node name.
+    if (body is StringInterpolation && (initialName == null || initialName.endsWith('_intlFunction'))) {
       var strings = body.elements.where((each) => each is InterpolationString).map((each) => each.toSource()).toList();
-      var data=strings.join(' ').replaceAll("'", '').trim();
+      var data=strings.join(' ').trim();
       if(data.isNotEmpty){
-        var name = toVariableName(data);
-        var functionName = owner.nameForString(name, messageText,
-            startAtZero: startAtZero);
-        return functionName;
+        String name = toVariableName(data);
+        if(name.trim().isNotEmpty){
+          var functionName = owner.nameForString(name, messageText,
+              startAtZero: false);
+          return functionName;
+        }
       }
     }
     var functionName = toVariableName(messageText);

--- a/lib/src/intl_suggestors/intl_message_syntax.dart
+++ b/lib/src/intl_suggestors/intl_message_syntax.dart
@@ -41,7 +41,6 @@ class MessageSyntax {
     String namePrefix,
   ) {
     final baseName = functionNameFor(node, namePrefix);
-    print("Name prefix $namePrefix");
     // TODO: This is very messy to accomodate names starting at intlFunction0
     // for backward compatibilitys.
     final functionName = nameForNode(node,
@@ -146,7 +145,6 @@ class MessageSyntax {
     //Strings from constant fields will not pass below condition so initialName will be unchanged.
     // Needing condition initialName.endsWith('_intlFunction') bcz when any node has addTestId we need to give that
     // priority, and will not override the node name.
-    //(initialName == null || initialName.endsWith('_intlFunction'))
     if (body is StringInterpolation &&
         (initialName == null || initialName.endsWith('_intlFunction'))) {
       var strings = body.elements

--- a/lib/src/intl_suggestors/intl_message_syntax.dart
+++ b/lib/src/intl_suggestors/intl_message_syntax.dart
@@ -54,8 +54,13 @@ class MessageSyntax {
   String functionNameFor(
     StringInterpolation node,
     String namePrefix,
-  ) =>
-      '${getTestId(null, node) ?? '${namePrefix}_intlFunction'}';
+  ) {
+    var ignoreNewLineString = node.toSource();
+    if (ignoreNewLineString.contains(r'\n')) {
+      return '${namePrefix}_intlFunction';
+    }
+    return '${getTestId(null, node) ?? '${namePrefix}_intlFunction'}';
+  }
 
   /// Returns Intl.message with interpolation
   /// ex: static String Foo_bar(String baz) => Intl.message(
@@ -139,9 +144,30 @@ class MessageSyntax {
     return '(${args.join(', ')})';
   }
 
+  // This will ignore the first few interpolated variable
+  /// Input: $numHiddenPills additional values not shown'
+  /// Output: static String additionalValuesNotShown(String numHiddenPills)
+  String ignoreInterpolatedVariable(String messageText) {
+    if (messageText.startsWith("'") && messageText.endsWith("'")) {
+      messageText = messageText.substring(1, messageText.length - 1);
+    }
+    if (messageText.startsWith('\$') && messageText.contains(' ')) {
+      String toRemoveFromName = messageText
+          .trim()
+          .substring(messageText.indexOf('\$'), messageText.indexOf(" "));
+      messageText = messageText.replaceFirst(toRemoveFromName, "").trim();
+    }
+    return messageText;
+  }
+
   String nameForNode(StringLiteral body,
       {String? initialName, bool startAtZero = false}) {
     var messageText = body.toSource();
+    var removingInterpolatedVariable = ignoreInterpolatedVariable(messageText);
+    if (removingInterpolatedVariable.isNotEmpty &&
+        removingInterpolatedVariable.contains(' ')) {
+      initialName = toVariableName(removingInterpolatedVariable);
+    }
     var functionName = toVariableName(messageText);
     functionName = owner.nameForString(initialName ?? functionName, messageText,
         startAtZero: startAtZero);

--- a/lib/src/intl_suggestors/intl_message_syntax.dart
+++ b/lib/src/intl_suggestors/intl_message_syntax.dart
@@ -123,8 +123,6 @@ class MessageSyntax {
     return '(${args.join(', ')})';
   }
 
-
-
   String nameForNode(StringLiteral body,
       {String? initialName, bool startAtZero = false}) {
     var messageText = body is StringInterpolation
@@ -132,11 +130,8 @@ class MessageSyntax {
         : body.toSource();
     // The case where there is no text after this should be checked in
     // isValidStringInterpolationNode and so it should never happen here.
-return owner.nameForString(
-          initialName ?? toVariableName(messageText), messageText,
-          startAtZero: startAtZero);
-
-
+    return owner.nameForString(
+        initialName ?? toVariableName(messageText), messageText,
+        startAtZero: startAtZero);
   }
-
 }

--- a/lib/src/intl_suggestors/intl_message_syntax.dart
+++ b/lib/src/intl_suggestors/intl_message_syntax.dart
@@ -41,6 +41,7 @@ class MessageSyntax {
     String namePrefix,
   ) {
     final baseName = functionNameFor(node, namePrefix);
+    print("Name prefix $namePrefix");
     // TODO: This is very messy to accomodate names starting at intlFunction0
     // for backward compatibilitys.
     final functionName = nameForNode(node,
@@ -52,9 +53,9 @@ class MessageSyntax {
   /// A template to build a function name for Intl message
   /// ex: Foo_bar
   String functionNameFor(
-      StringInterpolation node,
-      String namePrefix,
-      ) =>
+    StringInterpolation node,
+    String namePrefix,
+  ) =>
       '${getTestId(null, node) ?? '${namePrefix}_intlFunction'}';
 
   /// Returns Intl.message with interpolation
@@ -145,15 +146,19 @@ class MessageSyntax {
     //Strings from constant fields will not pass below condition so initialName will be unchanged.
     // Needing condition initialName.endsWith('_intlFunction') bcz when any node has addTestId we need to give that
     // priority, and will not override the node name.
-    if (body is StringInterpolation && (initialName == null || initialName.endsWith('_intlFunction'))) {
-
-      var strings = body.elements.where((each) => each is InterpolationString).map((each) => (each as InterpolationString).value).toList();
-      var data=strings.join(' ').trim();
-      if(data.isNotEmpty && !data.contains("'")){
+    //(initialName == null || initialName.endsWith('_intlFunction'))
+    if (body is StringInterpolation &&
+        (initialName == null || initialName.endsWith('_intlFunction'))) {
+      var strings = body.elements
+          .where((each) => each is InterpolationString)
+          .map((each) => (each as InterpolationString).value)
+          .toList();
+      var data = strings.join(' ').trim();
+      if (data.isNotEmpty) {
         String name = toVariableName(data);
-        if(name.trim().isNotEmpty){
-          var functionName = owner.nameForString(name, messageText,
-              startAtZero: false);
+        if (name.trim().isNotEmpty) {
+          var functionName =
+              owner.nameForString(name, messageText, startAtZero: false);
           return functionName;
         }
       }

--- a/lib/src/intl_suggestors/intl_message_syntax.dart
+++ b/lib/src/intl_suggestors/intl_message_syntax.dart
@@ -1,5 +1,4 @@
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:intl/intl.dart';
 import 'package:over_react_codemod/src/intl_suggestors/intl_messages.dart';
 import 'package:over_react_codemod/src/intl_suggestors/utils.dart';
 
@@ -41,20 +40,10 @@ class MessageSyntax {
     String namespace,
     String namePrefix,
   ) {
-    // Generating function name directly by String content rather then testId or appending _intlFunction
     final functionName = nameForNode(node);
     final functionArgs = intlFunctionArguments(node);
     return '$namespace.$functionName$functionArgs';
   }
-
-  //TODO: We can remove this method definition `getTestId` as we are using string content now to generate intl function name.
-  /// A template to build a function name for Intl message
-  /// ex: Foo_bar
-  String functionNameFor(
-    StringInterpolation node,
-    String namePrefix,
-  ) =>
-      '${getTestId(null, node) ?? '${namePrefix}_intlFunction'}';
 
   /// Returns Intl.message with interpolation
   /// ex: static String Foo_bar(String baz) => Intl.message(
@@ -64,7 +53,6 @@ class MessageSyntax {
   ///                                           );
   String functionDefinition(
       StringInterpolation node, String namespace, String namePrefix) {
-    // Generating function name directly by String content rather then testId or appending _intlFunction
     final functionName = nameForNode(node);
     final functionParams = intlFunctionParameters(node);
     final parameterizedMessage = intlParameterizedMessage(node);
@@ -138,7 +126,7 @@ class MessageSyntax {
 
 
   String nameForNode(StringLiteral body,
-      {String? initialName=null, bool startAtZero = false}) {
+      {String? initialName, bool startAtZero = false}) {
     var messageText = body is StringInterpolation
         ? textFromInterpolation(body)
         : body.toSource();

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -19,6 +19,7 @@ String textFromInterpolation(StringInterpolation body) => body.elements
     .map((each) => each.value)
     .join(' ')
     .trim();
+
 bool isValidStringInterpolationNode(AstNode node) {
   if (node is! StringInterpolation) return false;
   //We do not need to localize single values.  This should be handled by the

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -142,8 +142,16 @@ String toVariableName(String str) {
   if (str.startsWith("'") && str.endsWith("'")) {
     str = str.substring(1, str.length - 1);
   }
+  // This will ignore the first few interpolated variable
+
+  /// Input: $numHiddenPills additional values not shown'
+  /// Output: static String additionalValuesNotShown(String numHiddenPills)
+  if (str.startsWith('\$')) {
+    String toRemoveFromName = str.trim().substring(str.indexOf("\$"), str.indexOf(" "));
+    str = str.replaceFirst(toRemoveFromName, "").trim();
+  }
   String strippedName =
-      str.replaceFirst(RegExp(r'^[0-9]*'), '').replaceAll("'", '').trim();
+  str.replaceFirst(RegExp(r'^[0-9]*'), '').replaceAll("'", '').trim();
   var fiveAtMost =
       strippedName.split(' ').where((each) => each.isNotEmpty).toList();
   fiveAtMost =
@@ -191,8 +199,15 @@ String? getTestId(String? testId, AstNode node) {
         }
       }
     }
-  }
+  } else if(isValidStringInterpolationNode(node)) {
+    AstNode astNode = node;
+    var astString=astNode.toString();
+    testId=toVariableName(astString);
 
+    if(testId.isEmpty){
+      return null;
+    }
+  }
   if (node.parent != null) {
     return getTestId(testId, node.parent!);
   } else {

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -142,16 +142,8 @@ String toVariableName(String str) {
   if (str.startsWith("'") && str.endsWith("'")) {
     str = str.substring(1, str.length - 1);
   }
-  // This will ignore the first few interpolated variable
-
-  /// Input: $numHiddenPills additional values not shown'
-  /// Output: static String additionalValuesNotShown(String numHiddenPills)
-  if (str.startsWith('\$')) {
-    String toRemoveFromName = str.trim().substring(str.indexOf("\$"), str.indexOf(" "));
-    str = str.replaceFirst(toRemoveFromName, "").trim();
-  }
   String strippedName =
-  str.replaceFirst(RegExp(r'^[0-9]*'), '').replaceAll("'", '').trim();
+      str.replaceFirst(RegExp(r'^[0-9]*'), '').replaceAll("'", '').trim();
   var fiveAtMost =
       strippedName.split(' ').where((each) => each.isNotEmpty).toList();
   fiveAtMost =
@@ -199,12 +191,12 @@ String? getTestId(String? testId, AstNode node) {
         }
       }
     }
-  } else if(isValidStringInterpolationNode(node)) {
+  } else if (isValidStringInterpolationNode(node)) {
     AstNode astNode = node;
-    var astString=astNode.toString();
-    testId=toVariableName(astString);
+    var astString = astNode.toString();
+    testId = toVariableName(astString);
 
-    if(testId.isEmpty){
+    if (testId.isEmpty) {
       return null;
     }
   }

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -9,6 +9,16 @@ import 'package:over_react_codemod/src/util/element_type_helpers.dart';
 import 'constants.dart';
 
 // -- Node Validation --
+
+/// For a string interpolation, get all the non-interpolated parts in a string,
+/// separated by spaces.
+String textFromInterpolation(StringInterpolation body) {
+  return body.elements
+      .whereType<InterpolationString>()
+      .map((each) => each.value)
+      .join(' ')
+      .trim();
+}
 bool isValidStringInterpolationNode(AstNode node) {
   if (node is! StringInterpolation) return false;
   //We do not need to localize single values.  This should be handled by the
@@ -16,6 +26,8 @@ bool isValidStringInterpolationNode(AstNode node) {
   if (node.elements.length == 3 &&
       node.elements.first.toString() == node.elements.last.toString())
     return false;
+  var result=textFromInterpolation(node);
+  if(!result.contains(RegExp('[a-zA-Z0-9]')) || result.isEmpty) return false;
   return true;
 }
 

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -8,16 +8,17 @@ import 'package:over_react_codemod/src/util/element_type_helpers.dart';
 
 import 'constants.dart';
 
-RegExp alphabetMatcher = RegExp('[a-zA-Z]');
 // -- Node Validation --
+// Checks the text under [node] has any alphabetic value, ignore if it's not.
+RegExp alphabetMatcher = RegExp('[a-zA-Z]');
 
 /// For a string interpolation, get all the non-interpolated parts in a string,
 /// separated by spaces.
 String textFromInterpolation(StringInterpolation body) => body.elements
-      .whereType<InterpolationString>()
-      .map((each) => each.value)
-      .join(' ')
-      .trim();
+    .whereType<InterpolationString>()
+    .map((each) => each.value)
+    .join(' ')
+    .trim();
 bool isValidStringInterpolationNode(AstNode node) {
   if (node is! StringInterpolation) return false;
   //We do not need to localize single values.  This should be handled by the
@@ -25,7 +26,7 @@ bool isValidStringInterpolationNode(AstNode node) {
   if (node.elements.length == 3 &&
       node.elements.first.toString() == node.elements.last.toString())
     return false;
-  var result=textFromInterpolation(node);
+  var result = textFromInterpolation(node);
   return result.isNotEmpty && result.contains(alphabetMatcher);
 }
 

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -192,15 +192,7 @@ String? getTestId(String? testId, AstNode node) {
       }
     }
   }
-  // else if (isValidStringInterpolationNode(node)) {
-  //   AstNode astNode = node;
-  //   var astString = astNode.toString();
-  //   testId = toVariableName(astString);
-  //
-  //   if (testId.isEmpty) {
-  //     return null;
-  //   }
-  // }
+
   if (node.parent != null) {
     return getTestId(testId, node.parent!);
   } else {

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -8,7 +8,7 @@ import 'package:over_react_codemod/src/util/element_type_helpers.dart';
 
 import 'constants.dart';
 
-var result;
+RegExp alphabetMatcher = RegExp('[a-zA-Z]');
 // -- Node Validation --
 
 /// For a string interpolation, get all the non-interpolated parts in a string,
@@ -25,8 +25,8 @@ bool isValidStringInterpolationNode(AstNode node) {
   if (node.elements.length == 3 &&
       node.elements.first.toString() == node.elements.last.toString())
     return false;
-   result=textFromInterpolation(node);
-  return result.isNotEmpty && result.contains(RegExp('[a-zA-Z]'));
+  var result=textFromInterpolation(node);
+  return result.isNotEmpty && result.contains(alphabetMatcher);
 }
 
 bool hasNoAlphabeticCharacters(String s) => !_alphabeticPattern.hasMatch(s);

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -174,6 +174,7 @@ String toCamelCase(String str) {
   return capitalizationResult.replaceAll(' ', '');
 }
 
+//TODO: We can remove this method definition `getTestId` as we are using string content now to generate intl function name.
 String? getTestId(String? testId, AstNode node) {
   if (testId != null) return testId;
   if (node is InvocationExpression) {

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -8,17 +8,16 @@ import 'package:over_react_codemod/src/util/element_type_helpers.dart';
 
 import 'constants.dart';
 
+var result;
 // -- Node Validation --
 
 /// For a string interpolation, get all the non-interpolated parts in a string,
 /// separated by spaces.
-String textFromInterpolation(StringInterpolation body) {
-  return body.elements
+String textFromInterpolation(StringInterpolation body) => body.elements
       .whereType<InterpolationString>()
       .map((each) => each.value)
       .join(' ')
       .trim();
-}
 bool isValidStringInterpolationNode(AstNode node) {
   if (node is! StringInterpolation) return false;
   //We do not need to localize single values.  This should be handled by the
@@ -26,9 +25,8 @@ bool isValidStringInterpolationNode(AstNode node) {
   if (node.elements.length == 3 &&
       node.elements.first.toString() == node.elements.last.toString())
     return false;
-  var result=textFromInterpolation(node);
-  if(!result.contains(RegExp('[a-zA-Z0-9]')) || result.isEmpty) return false;
-  return true;
+   result=textFromInterpolation(node);
+  return result.isNotEmpty && result.contains(RegExp('[a-zA-Z]'));
 }
 
 bool hasNoAlphabeticCharacters(String s) => !_alphabeticPattern.hasMatch(s);
@@ -184,33 +182,6 @@ String toCamelCase(String str) {
 
   /// Finally remove the spaces
   return capitalizationResult.replaceAll(' ', '');
-}
-
-//TODO: We can remove this method definition `getTestId` as we are using string content now to generate intl function name.
-String? getTestId(String? testId, AstNode node) {
-  if (testId != null) return testId;
-  if (node is InvocationExpression) {
-    var component = getComponentUsage(node);
-    if (component != null) {
-      for (final method in component.cascadedMethodInvocations) {
-        if (method.methodName.name == 'addTestId') {
-          final expression = method.node.argumentList.arguments.first;
-          testId = toVariableName(expression
-              .toString()
-              .replaceAll("'", '')
-              .split('.')
-              .last
-              .replaceAll('TestId', ''));
-        }
-      }
-    }
-  }
-
-  if (node.parent != null) {
-    return getTestId(testId, node.parent!);
-  } else {
-    return null;
-  }
 }
 
 /// Exclude cases we know shouldn't be localized, even though that attribute

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -191,15 +191,16 @@ String? getTestId(String? testId, AstNode node) {
         }
       }
     }
-  } else if (isValidStringInterpolationNode(node)) {
-    AstNode astNode = node;
-    var astString = astNode.toString();
-    testId = toVariableName(astString);
-
-    if (testId.isEmpty) {
-      return null;
-    }
   }
+  // else if (isValidStringInterpolationNode(node)) {
+  //   AstNode astNode = node;
+  //   var astString = astNode.toString();
+  //   testId = toVariableName(astString);
+  //
+  //   if (testId.isEmpty) {
+  //     return null;
+  //   }
+  // }
   if (node.parent != null) {
     return getTestId(testId, node.parent!);
   } else {

--- a/lib/src/mui_suggestors/mui_importer.dart
+++ b/lib/src/mui_suggestors/mui_importer.dart
@@ -16,11 +16,9 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/source/line_info.dart';
 import 'package:codemod/codemod.dart';
 import 'package:collection/collection.dart';
-import 'package:logging/logging.dart';
 
 import 'constants.dart';
 
-final _log = Logger('muiImporter');
 
 /// A suggestor that adds imports in libraries that reference
 /// the [muiNs] import namespace (including in parts) but don't yet import it.

--- a/lib/src/mui_suggestors/mui_importer.dart
+++ b/lib/src/mui_suggestors/mui_importer.dart
@@ -16,10 +16,11 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/source/line_info.dart';
 import 'package:codemod/codemod.dart';
 import 'package:collection/collection.dart';
+import 'package:logging/logging.dart';
 
 import 'constants.dart';
 
-
+final _log = Logger('muiImporter');
 /// A suggestor that adds imports in libraries that reference
 /// the [muiNs] import namespace (including in parts) but don't yet import it.
 Stream<Patch> muiImporter(FileContext context) async* {

--- a/lib/src/mui_suggestors/unused_wsd_import_remover.dart
+++ b/lib/src/mui_suggestors/unused_wsd_import_remover.dart
@@ -15,9 +15,7 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/syntactic_entity.dart';
 import 'package:codemod/codemod.dart';
-import 'package:logging/logging.dart';
 
-final _log = Logger('unusedWsdImportRemover');
 
 /// A suggestor that removes unused imports for WSD.
 Stream<Patch> unusedWsdImportRemover(FileContext context) async* {

--- a/lib/src/mui_suggestors/unused_wsd_import_remover.dart
+++ b/lib/src/mui_suggestors/unused_wsd_import_remover.dart
@@ -15,8 +15,9 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/syntactic_entity.dart';
 import 'package:codemod/codemod.dart';
+import 'package:logging/logging.dart';
 
-
+final _log = Logger('unusedWsdImportRemover');
 /// A suggestor that removes unused imports for WSD.
 Stream<Patch> unusedWsdImportRemover(FileContext context) async* {
   final unitResult = await context.getResolvedUnit();

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -23,7 +23,6 @@ import 'mui_migration_test.dart' show testCodemod;
 
 // Change this to `true` and all of the functional tests in this file will print
 // the stdout/stderr of the codemod processes.
-final _debug = false;
 
 // The help text may have different amount of whitespace depending on the names
 // of the options, so collapse all whitespace to a single space before comparing.

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -21,9 +21,6 @@ import 'package:test_descriptor/test_descriptor.dart' as d;
 
 import 'mui_migration_test.dart' show testCodemod;
 
-// Change this to `true` and all of the functional tests in this file will print
-// the stdout/stderr of the codemod processes.
-
 // The help text may have different amount of whitespace depending on the names
 // of the options, so collapse all whitespace to a single space before comparing.
 String condenseWhitespace(String input) =>

--- a/test/intl_suggestors/intl_messages_test.dart
+++ b/test/intl_suggestors/intl_messages_test.dart
@@ -65,6 +65,24 @@ void main() {
       var derivedName = messages.syntax.nameForNode(argument);
       expect(derivedName, 'adjacentStringsOnTwoLines');
     });
+
+    test('ignore interpolated variable from start',(){
+      var method = " static String testString(string inputString)=>Intl.message('\$test this String',args[inputString],name:'TestProjectIntl_testString'); ";
+      var classSource = 'class Foo { $method }';
+      var parsed = parseString(content: classSource);
+      var intlClass = parsed.unit.declarations.first as ClassDeclaration;
+      var methodDeclarations =
+      intlClass.members.toList().cast<MethodDeclaration>();
+      var argument = ((methodDeclarations.first.body.childEntities.toList()[1]
+      as MethodInvocation)
+          .argumentList
+          .arguments
+          .first as StringLiteral);
+      messages = IntlMessages('TestProject', output: intlFile);
+      var ignoreInterpolatedVariableFromStart=messages.syntax.nameForNode(argument);
+      expect(ignoreInterpolatedVariableFromStart, 'thisString');
+
+    });
   });
   group('round-trip', () {
     late Directory tmp;

--- a/test/intl_suggestors/intl_messages_test.dart
+++ b/test/intl_suggestors/intl_messages_test.dart
@@ -53,19 +53,25 @@ void main() {
         ' strings' ' on' ' two ' 'lines' ' eh' , name: 'TestProjectIntl_adjacentStringsOnTwoLines');""";
       var classSource = 'class Foo { $method }';
       var parsed = parseString(content: classSource);
+      print("parsed $parsed");
       var intlClass = parsed.unit.declarations.first as ClassDeclaration;
+      print("intlClass $intlClass");
       var methodDeclarations =
           intlClass.members.toList().cast<MethodDeclaration>();
+      print("methodDeclarations $methodDeclarations");
       var argument = ((methodDeclarations.first.body.childEntities.toList()[1]
               as MethodInvocation)
           .argumentList
           .arguments
           .first as StringLiteral);
       messages = IntlMessages('TestProject', output: intlFile);
+      print("argumnet $argument messages $messages");
       var derivedName = messages.syntax.nameForNode(argument);
+      print("derived name $derivedName");
       expect(derivedName, 'adjacentStringsOnTwoLines');
     });
   });
+
   group('round-trip', () {
     late Directory tmp;
     late File intlFile;

--- a/test/intl_suggestors/intl_messages_test.dart
+++ b/test/intl_suggestors/intl_messages_test.dart
@@ -53,21 +53,16 @@ void main() {
         ' strings' ' on' ' two ' 'lines' ' eh' , name: 'TestProjectIntl_adjacentStringsOnTwoLines');""";
       var classSource = 'class Foo { $method }';
       var parsed = parseString(content: classSource);
-      print("parsed $parsed");
       var intlClass = parsed.unit.declarations.first as ClassDeclaration;
-      print("intlClass $intlClass");
       var methodDeclarations =
           intlClass.members.toList().cast<MethodDeclaration>();
-      print("methodDeclarations $methodDeclarations");
       var argument = ((methodDeclarations.first.body.childEntities.toList()[1]
               as MethodInvocation)
           .argumentList
           .arguments
           .first as StringLiteral);
       messages = IntlMessages('TestProject', output: intlFile);
-      print("argumnet $argument messages $messages");
       var derivedName = messages.syntax.nameForNode(argument);
-      print("derived name $derivedName");
       expect(derivedName, 'adjacentStringsOnTwoLines');
     });
   });

--- a/test/intl_suggestors/intl_messages_test.dart
+++ b/test/intl_suggestors/intl_messages_test.dart
@@ -65,24 +65,6 @@ void main() {
       var derivedName = messages.syntax.nameForNode(argument);
       expect(derivedName, 'adjacentStringsOnTwoLines');
     });
-
-    test('ignore interpolated variable from start',(){
-      var method = " static String testString(string inputString)=>Intl.message('\$test this String',args[inputString],name:'TestProjectIntl_testString'); ";
-      var classSource = 'class Foo { $method }';
-      var parsed = parseString(content: classSource);
-      var intlClass = parsed.unit.declarations.first as ClassDeclaration;
-      var methodDeclarations =
-      intlClass.members.toList().cast<MethodDeclaration>();
-      var argument = ((methodDeclarations.first.body.childEntities.toList()[1]
-      as MethodInvocation)
-          .argumentList
-          .arguments
-          .first as StringLiteral);
-      messages = IntlMessages('TestProject', output: intlFile);
-      var ignoreInterpolatedVariableFromStart=messages.syntax.nameForNode(argument);
-      expect(ignoreInterpolatedVariableFromStart, 'thisString');
-
-    });
   });
   group('round-trip', () {
     late Directory tmp;

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -242,7 +242,7 @@ void main() {
                   (props) {
                     final name = 'bob';
 
-                    return (Dom.div())(TestClassIntl.Foo_intlFunction0(name));
+                    return (Dom.div())(TestClassIntl.interpolated(name));
                   },
                   _\$FooConfig, //ignore: undefined_identifier
                 );
@@ -275,7 +275,7 @@ void main() {
                   (props) {
                     final number = '42';
 
-                    return (Dom.div())(TestClassIntl.Foo_intlFunction0(number));
+                    return (Dom.div())(TestClassIntl.distanceKm(number));
                   },
                   _\$FooConfig, //ignore: undefined_identifier
                 );
@@ -283,7 +283,7 @@ void main() {
         );
 
         final expectedFileContent =
-            "\n  static String Foo_intlFunction0(String number) => Intl.message('Distance \${number}km', args: [number], name: 'TestClassIntl_Foo_intlFunction0');";
+            "\n  static String distanceKm(String number) => Intl.message('Distance \${number}km', args: [number], name: 'TestClassIntl_distanceKm');";
         expect(messages.messageContents(), expectedFileContent);
       });
 
@@ -314,15 +314,15 @@ void main() {
                   final name = 'bob';
                   final title = 'Test Title';
 
-                  return (Dom.div()..label=TestClassIntl.Foo_intlFunction0(title))(TestClassIntl.Foo_intlFunction1(name));
+                  return (Dom.div()..label=TestClassIntl.alsoInterpolated(title))(TestClassIntl.interpolated(name));
                 },
                 _\$FooConfig, //ignore: undefined_identifier
               );
               ''',
         );
         final expectedFileContent =
-            "\n  static String Foo_intlFunction0(String title) => Intl.message('Also interpolated \${title}', args: [title], name: 'TestClassIntl_Foo_intlFunction0');"
-            "\n  static String Foo_intlFunction1(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction1');";
+            "\n  static String alsoInterpolated(String title) => Intl.message('Also interpolated \${title}', args: [title], name: 'TestClassIntl_alsoInterpolated');"
+            "\n  static String interpolated(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_interpolated');";
         expect(messages.messageContents(), expectedFileContent);
       });
 
@@ -353,14 +353,14 @@ void main() {
                   final name = 'bob';
                   final title = 'Test Title';
 
-                  return (Dom.div())(TestClassIntl.Foo_intlFunction0(name, title));
+                  return (Dom.div())(TestClassIntl.interpolated(name, title));
                 },
                 _\$FooConfig, //ignore: undefined_identifier
               );
               ''',
         );
         final expectedFileContent =
-            "\n  static String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0');";
+            "\n  static String interpolated(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_interpolated');";
         expect(messages.messageContents(), expectedFileContent);
       });
 
@@ -391,14 +391,14 @@ void main() {
               UiFactory<FooProps> Foo = uiFunction(
                 (props) {
 
-                  return (Dom.div())(TestClassIntl.Foo_intlFunction0(props.name));
+                  return (Dom.div())(TestClassIntl.interpolated(props.name));
                 },
                 _\$FooConfig, //ignore: undefined_identifier
               );
               ''',
         );
         final expectedFileContent =
-            "\n  static String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0');";
+            "\n  static String interpolated(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_interpolated');";
         expect(messages.messageContents(), expectedFileContent);
       });
 
@@ -432,7 +432,7 @@ void main() {
                 (props) {
 
                   return (Dom.div())(
-                    TestClassIntl.Foo_intlFunction0(props.name, props.title)
+                    TestClassIntl.interpolated(props.name, props.title)
                   );
                 },
                 _\$FooConfig, //ignore: undefined_identifier
@@ -440,7 +440,7 @@ void main() {
               ''',
         );
         final expectedFileContent =
-            "\n  static String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0');";
+            "\n  static String interpolated(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_interpolated');";
         expect(messages.messageContents(), expectedFileContent);
       });
 
@@ -550,7 +550,7 @@ void main() {
                     return 'test name';
                   }
                   
-                  return (Dom.div())(TestClassIntl.Foo_intlFunction0(getName()));
+                  return (Dom.div())(TestClassIntl.hisNameWas(getName()));
                 },
                 _\$FooConfig, //ignore: undefined_identifier
               );
@@ -558,7 +558,7 @@ void main() {
         );
 
         final expectedFileContent =
-            "\n  static String Foo_intlFunction0(String getName) => Intl.message('His name was \${getName}', args: [getName], name: 'TestClassIntl_Foo_intlFunction0');";
+            "\n  static String hisNameWas(String getName) => Intl.message('His name was \${getName}', args: [getName], name: 'TestClassIntl_hisNameWas');";
         expect(messages.messageContents(), expectedFileContent);
       });
 
@@ -948,7 +948,7 @@ void main() {
                     final name = 'bob';
 
                     return (Dom.div()
-                      ..label = TestClassIntl.Foo_intlFunction0(name))();
+                      ..label = TestClassIntl.interpolated(name))();
                   },
                   _\$FooConfig, //ignore: undefined_identifier
                 );
@@ -956,7 +956,7 @@ void main() {
         );
 
         final expectedFileContent =
-            "\n  static String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0');";
+            "\n  static String interpolated(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_interpolated');";
         expect(messages.messageContents(), expectedFileContent);
       });
 
@@ -989,14 +989,14 @@ void main() {
                   final title = 'Test Title';
 
                   return (Dom.div()
-                    ..label = TestClassIntl.Foo_intlFunction0(name, title))();
+                    ..label = TestClassIntl.interpolated(name, title))();
                 },
                 _\$FooConfig, //ignore: undefined_identifier
               );
               ''',
         );
         final expectedFileContent =
-            "\n  static String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0');";
+            "\n  static String interpolated(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_interpolated');";
         expect(messages.messageContents(), expectedFileContent);
       });
 
@@ -1029,14 +1029,14 @@ void main() {
                 (props) {
 
                   return (Dom.div()
-                    ..label = TestClassIntl.Foo_intlFunction0(props.name))();
+                    ..label = TestClassIntl.interpolated(props.name))();
                 },
                 _\$FooConfig, //ignore: undefined_identifier
               );
               ''',
         );
         final expectedFileContent =
-            "\n  static String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0');";
+            "\n  static String interpolated(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_interpolated');";
         expect(messages.messageContents(), expectedFileContent);
       });
 
@@ -1071,14 +1071,14 @@ void main() {
                 (props) {
 
                   return (Dom.div()
-                    ..label = TestClassIntl.Foo_intlFunction0(props.name, props.title))();
+                    ..label = TestClassIntl.interpolated(props.name, props.title))();
                 },
                 _\$FooConfig, //ignore: undefined_identifier
               );
               ''',
         );
         final expectedFileContent =
-            "\n  static String Foo_intlFunction0(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_Foo_intlFunction0');";
+            "\n  static String interpolated(String name, String title) => Intl.message('Interpolated \${name} \${title}', args: [name, title], name: 'TestClassIntl_interpolated');";
         expect(messages.messageContents(), expectedFileContent);
       });
 
@@ -1152,7 +1152,7 @@ void main() {
                   }
                   
                   return (Dom.div()
-                    ..label = TestClassIntl.Foo_intlFunction0(getName()))();
+                    ..label = TestClassIntl.hisNameWas(getName()))();
                 },
                 _\$FooConfig, //ignore: undefined_identifier
               );
@@ -1160,7 +1160,7 @@ void main() {
         );
 
         final expectedFileContent =
-            "\n  static String Foo_intlFunction0(String getName) => Intl.message('His name was \${getName}', args: [getName], name: 'TestClassIntl_Foo_intlFunction0');";
+            "\n  static String hisNameWas(String getName) => Intl.message('His name was \${getName}', args: [getName], name: 'TestClassIntl_hisNameWas');";
         expect(messages.messageContents(), expectedFileContent);
       });
 

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -634,7 +634,7 @@ void main() {
                   return (Dom.p() 
                     ..addTestId('truss.aboutWdeskModal.versionInfo')
                     )(
-                      TestClassIntl.versionInfo(props.version),
+                      TestClassIntl.version(props.version),
                     );
                 },
                 _\$FooConfig, //ignore: undefined_identifier
@@ -643,7 +643,7 @@ void main() {
         );
 
         String expectedFileContent =
-            "\n  static String versionInfo(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_versionInfo');";
+            "\n  static String version(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_version');";
         expect(messages.messageContents(), expectedFileContent);
       });
 
@@ -689,7 +689,7 @@ void main() {
                   return (Dom.p() 
                     ..addTestId(TestClassTestIds.versionInfo)
                   )(
-                    TestClassIntl.versionInfo(props.version),
+                    TestClassIntl.version(props.version),
                   );
                 },
                 _\$FooConfig, //ignore: undefined_identifier
@@ -698,7 +698,7 @@ void main() {
         );
 
         String expectedFileContent =
-            "\n  static String versionInfo(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_versionInfo');";
+            "\n  static String version(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_version');";
         expect(messages.messageContents(), expectedFileContent);
       });
 
@@ -752,11 +752,11 @@ void main() {
                   ..addTestId(TestClassTestIds.emptyView)
                   )(
                    (Dom.p()..addTestId('foo'))(
-                      TestClassIntl.foo(props.displayName),
+                      TestClassIntl.createOneFromAnyBy(props.displayName),
                     ),
                     (Dom.p()..addTestId('bar'))(
                       (Dom.p())(
-                        TestClassIntl.bar(props.displayName),
+                        TestClassIntl.createOneFromAnyBy1(props.displayName),
                       ),
                     ),
                   );
@@ -767,11 +767,11 @@ void main() {
         );
 
         String expectedFileContent1 =
-            "\n  static String foo(String displayName) => Intl.message('Create one from any \${displayName} by selecting Save As Template', args: [displayName], name: 'TestClassIntl_foo');";
+            "\n  static String createOneFromAnyBy(String displayName) => Intl.message('Create one from any \${displayName} by selecting Save As Template', args: [displayName], name: 'TestClassIntl_createOneFromAnyBy');";
         String expectedFileContent2 =
-            "\n  static String bar(String displayName) => Intl.message('Create one from any \${displayName} by selecting Save As Template', args: [displayName], name: 'TestClassIntl_bar');";
+            "\n  static String createOneFromAnyBy1(String displayName) => Intl.message('Create one from any \${displayName} by selecting Save As Template', args: [displayName], name: 'TestClassIntl_createOneFromAnyBy1');";
         expect(messages.messageContents(),
-            [expectedFileContent2, expectedFileContent1].join(''));
+            [expectedFileContent1, expectedFileContent2].join(''));
       });
 
       test('Home Example', () async {
@@ -1236,7 +1236,7 @@ void main() {
                                  
                   return (Dom.p() 
                     ..addTestId('truss.aboutWdeskModal.versionInfo')
-                    ..label = TestClassIntl.versionInfo(props.version))();
+                    ..label = TestClassIntl.version(props.version))();
                 },
                 _\$FooConfig, //ignore: undefined_identifier
               );
@@ -1244,7 +1244,7 @@ void main() {
         );
 
         String expectedFileContent =
-            "\n  static String versionInfo(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_versionInfo');";
+            "\n  static String version(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_version');";
         expect(messages.messageContents(), expectedFileContent);
       });
 
@@ -1287,7 +1287,7 @@ void main() {
                                  
                   return (Dom.p() 
                     ..addTestId(TestClassTestIds.versionInfo)
-                    ..label = TestClassIntl.versionInfo(props.version))();
+                    ..label = TestClassIntl.version(props.version))();
                 },
                 _\$FooConfig, //ignore: undefined_identifier
               );
@@ -1295,7 +1295,7 @@ void main() {
         );
 
         String expectedFileContent =
-            "\n  static String versionInfo(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_versionInfo');";
+            "\n  static String version(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_version');";
         expect(messages.messageContents(), expectedFileContent);
       });
     });

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -179,7 +179,7 @@ void main() {
         );
       });
 
-// here we can call the ignore intrepolated variable string
+      // here we can call the ignore interpolated variable string
       test('single interpolated variable', () async {
         await testSuggestor(
           input: '''
@@ -195,8 +195,7 @@ void main() {
                   _\$FooConfig, //ignore: undefined_identifier
                 );
                 ''',
-          expectedOutput:
-          '''
+          expectedOutput: '''
             import 'package:over_react/over_react.dart';
 
             mixin FooProps on UiProps {}
@@ -228,8 +227,7 @@ void main() {
                   _\$FooConfig, //ignore: undefined_identifier
                 );
                 ''',
-          expectedOutput:
-          '''
+          expectedOutput: '''
             import 'package:over_react/over_react.dart';
 
             mixin FooProps on UiProps {}
@@ -354,7 +352,6 @@ void main() {
         expect(messages.messageContents(), expectedFileContent);
       });
 
-
       test('string in between interpolated variable', () async {
         await testSuggestor(
           input: '''
@@ -396,7 +393,6 @@ void main() {
             "\n  static String interpolated(String name, String title) => Intl.message('\${name} Interpolated \${title}', args: [name, title], name: 'TestClassIntl_interpolated');";
         expect(messages.messageContents(), expectedFileContent);
       });
-
 
       test('two different interpolations get different names', () async {
         await testSuggestor(

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -589,7 +589,7 @@ void main() {
                 
                   final lastName = 'Paulsen';
                   
-                  return (Dom.div())(TestClassIntl.Foo_intlFunction0(lastName));
+                  return (Dom.div())(TestClassIntl.bobsLastNameWas(lastName));
                 },
                 _\$FooConfig, //ignore: undefined_identifier
               );
@@ -597,7 +597,7 @@ void main() {
         );
 
         final expectedFileContent =
-            "\n  static String Foo_intlFunction0(String lastName) => Intl.message('Bob\\\'s last name was \${lastName}', args: [lastName], name: 'TestClassIntl_Foo_intlFunction0');";
+            "\n  static String bobsLastNameWas(String lastName) => Intl.message('Bob\\\'s last name was \${lastName}', args: [lastName], name: 'TestClassIntl_bobsLastNameWas');";
         expect(messages.messageContents(), expectedFileContent);
       });
       test('Interpolated with testId string', () async {
@@ -804,7 +804,7 @@ void main() {
                   final refStr = 'Test Title';
 
                   return (Dom.div())(
-                    TestClassIntl.Foo_intlFunction0(fileStr, refStr),
+                    TestClassIntl.nowThatYouveTransitionedYour(fileStr, refStr),
                   );
                 },
                 _\$FooConfig, //ignore: undefined_identifier
@@ -812,7 +812,7 @@ void main() {
               ''',
         );
         final expectedFileContent =
-            "\n  static String Foo_intlFunction0(String fileStr, String refStr) => Intl.message('Now that you\\\'ve transitioned your \${fileStr}, you\\\'ll want to freeze \${refStr} or update permissions to prevent others from using \${refStr}.', args: [fileStr, refStr], name: 'TestClassIntl_Foo_intlFunction0');";
+            "\n  static String nowThatYouveTransitionedYour(String fileStr, String refStr) => Intl.message('Now that you\\\'ve transitioned your \${fileStr}, you\\\'ll want to freeze \${refStr} or update permissions to prevent others from using \${refStr}.', args: [fileStr, refStr], name: 'TestClassIntl_nowThatYouveTransitionedYour');";
         expect(messages.messageContents(), expectedFileContent);
       });
     });
@@ -1193,7 +1193,7 @@ void main() {
                   final lastName = 'Paulsen';
                   
                   return (Dom.div()
-                    ..label = TestClassIntl.Foo_intlFunction0(lastName))();
+                    ..label = TestClassIntl.bobsLastNameWas(lastName))();
                 },
                 _\$FooConfig, //ignore: undefined_identifier
               );
@@ -1201,7 +1201,7 @@ void main() {
         );
 
         final expectedFileContent =
-            "\n  static String Foo_intlFunction0(String lastName) => Intl.message('Bob\\\'s last name was \${lastName}', args: [lastName], name: 'TestClassIntl_Foo_intlFunction0');";
+            "\n  static String bobsLastNameWas(String lastName) => Intl.message('Bob\\\'s last name was \${lastName}', args: [lastName], name: 'TestClassIntl_bobsLastNameWas');";
         expect(messages.messageContents(), expectedFileContent);
       });
 

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -471,14 +471,14 @@ void main() {
               UiFactory<FooProps> Foo = uiFunction(
                 (props) {
 
-                  return (Dom.div())(TestClassIntl.Foo_intlFunction0(props.name ?? \'test\'));
+                  return (Dom.div())(TestClassIntl.interpolated(props.name ?? \'test\'));
                 },
                 _\$FooConfig, //ignore: undefined_identifier
               );
               ''',
         );
         final expectedFileContent =
-            "\n  static String Foo_intlFunction0(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_Foo_intlFunction0');";
+            "\n  static String interpolated(String name) => Intl.message('Interpolated \${name}', args: [name], name: 'TestClassIntl_interpolated');";
         expect(messages.messageContents(), expectedFileContent);
       });
 

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -179,6 +179,73 @@ void main() {
         );
       });
 
+// here we can call the ignore intrepolated variable string
+      test('single interpolated variable', () async {
+        await testSuggestor(
+          input: '''
+                import 'package:over_react/over_react.dart';
+
+                mixin FooProps on UiProps {}
+
+                UiFactory<FooProps> Foo = uiFunction(
+                  (props) {
+                     final name = 'bob';
+                    return (Dom.div())('\${name}');
+                  },
+                  _\$FooConfig, //ignore: undefined_identifier
+                );
+                ''',
+          expectedOutput:
+          '''
+            import 'package:over_react/over_react.dart';
+
+            mixin FooProps on UiProps {}
+
+            UiFactory<FooProps> Foo = uiFunction(
+              (props) {
+                 final name = 'bob';
+                return (Dom.div())('\${name}');
+              },
+              _\$FooConfig, //ignore: undefined_identifier
+            );
+            ''',
+        );
+      });
+
+      test('special character in between two interpolated variables', () async {
+        await testSuggestor(
+          input: '''
+                import 'package:over_react/over_react.dart';
+
+                mixin FooProps on UiProps {}
+
+                UiFactory<FooProps> Foo = uiFunction(
+                  (props) {
+                     final name = 'bob';
+                     final age='42';
+                    return (Dom.div())('\${name} : \${age}');
+                  },
+                  _\$FooConfig, //ignore: undefined_identifier
+                );
+                ''',
+          expectedOutput:
+          '''
+            import 'package:over_react/over_react.dart';
+
+            mixin FooProps on UiProps {}
+
+            UiFactory<FooProps> Foo = uiFunction(
+              (props) {
+                 final name = 'bob';
+                 final age='42';
+                return (Dom.div())('\${name} : \${age}');
+              },
+              _\$FooConfig, //ignore: undefined_identifier
+            );
+            ''',
+        );
+      });
+
       test('adjacent strings', () async {
         await testSuggestor(
           input: '''
@@ -286,6 +353,50 @@ void main() {
             "\n  static String distanceKm(String number) => Intl.message('Distance \${number}km', args: [number], name: 'TestClassIntl_distanceKm');";
         expect(messages.messageContents(), expectedFileContent);
       });
+
+
+      test('string in between interpolated variable', () async {
+        await testSuggestor(
+          input: '''
+              import 'package:over_react/over_react.dart';
+
+              mixin FooProps on UiProps {
+                String name;
+                String title;
+              }
+
+              UiFactory<FooProps> Foo = uiFunction(
+                (props) {
+
+                  return (Dom.div())('\${props.name} Interpolated \${props.title}');
+                },
+                _\$FooConfig, //ignore: undefined_identifier
+              );
+              ''',
+          expectedOutput: '''
+              import 'package:over_react/over_react.dart';
+
+              mixin FooProps on UiProps {
+                String name;
+                String title;
+              }
+
+              UiFactory<FooProps> Foo = uiFunction(
+                (props) {
+
+                  return (Dom.div())(
+                    TestClassIntl.interpolated(props.name, props.title)
+                  );
+                },
+                _\$FooConfig, //ignore: undefined_identifier
+              );
+              ''',
+        );
+        final expectedFileContent =
+            "\n  static String interpolated(String name, String title) => Intl.message('\${name} Interpolated \${title}', args: [name, title], name: 'TestClassIntl_interpolated');";
+        expect(messages.messageContents(), expectedFileContent);
+      });
+
 
       test('two different interpolations get different names', () async {
         await testSuggestor(
@@ -1202,49 +1313,6 @@ void main() {
 
         final expectedFileContent =
             "\n  static String bobsLastNameWas(String lastName) => Intl.message('Bob\\\'s last name was \${lastName}', args: [lastName], name: 'TestClassIntl_bobsLastNameWas');";
-        expect(messages.messageContents(), expectedFileContent);
-      });
-
-      test('Interpolated with testId string', () async {
-        await testSuggestor(
-          input: '''
-              import 'package:over_react/over_react.dart';
-
-              mixin FooProps on UiProps {
-                String version;
-              }
-
-              UiFactory<FooProps> Foo = uiFunction(
-                (props) {
-
-                  return (Dom.p()
-                    ..addTestId('truss.aboutWdeskModal.versionInfo')
-                    ..label = 'Version \${props.version}')();
-                },
-                _\$FooConfig, //ignore: undefined_identifier
-              );
-              ''',
-          expectedOutput: '''
-              import 'package:over_react/over_react.dart';
-
-              mixin FooProps on UiProps {
-                String version;
-              }
-
-              UiFactory<FooProps> Foo = uiFunction(
-                (props) {
-                                 
-                  return (Dom.p() 
-                    ..addTestId('truss.aboutWdeskModal.versionInfo')
-                    ..label = TestClassIntl.version(props.version))();
-                },
-                _\$FooConfig, //ignore: undefined_identifier
-              );
-              ''',
-        );
-
-        String expectedFileContent =
-            "\n  static String version(String version) => Intl.message('Version \${version}', args: [version], name: 'TestClassIntl_version');";
         expect(messages.messageContents(), expectedFileContent);
       });
 

--- a/test/intl_suggestors/utils_test.dart
+++ b/test/intl_suggestors/utils_test.dart
@@ -98,24 +98,23 @@ void main() {
         expect(parsedExpression is StringInterpolation, isTrue);
         var parsedInterpolation = parsedExpression as StringInterpolation;
         expect(parsedInterpolation.isMultiline, isMultiline);
-        var data= textFromInterpolation(parsedInterpolation);
-        if(data.isEmpty){
-          data=expectedResult;
-          expect(testStr,expectedResult);
+        var data = textFromInterpolation(parsedInterpolation);
+        if (data.isEmpty) {
+          data = expectedResult;
+          expect(testStr, expectedResult);
         }
-        expect(testStr,expectedResult);
+        expect(testStr, expectedResult);
       }
+
       test('single line', () async {
         final testStr = r"'${singleLine}'";
-        final expectedResult =
-            r"'${singleLine}'";
+        final expectedResult = r"'${singleLine}'";
         ignoreSingleLineAndMultiline(testStr, false, expectedResult);
       });
 
       test('multiline', () async {
         final testStr = r"'''${multiline}'''";
-        final expectedResult =
-            r"'''${multiline}'''";
+        final expectedResult = r"'''${multiline}'''";
         ignoreSingleLineAndMultiline(testStr, true, expectedResult);
       });
       //We are ignoring the \n or new line in String and Taking till five words in method name.

--- a/test/intl_suggestors/utils_test.dart
+++ b/test/intl_suggestors/utils_test.dart
@@ -129,6 +129,11 @@ void main() {
     });
 
     group('toVariableName', () {
+      test('test this string', () {
+        var inputString = '\$test this string';
+        var result = toVariableName(inputString);
+        expect(result, 'thisString');
+      });
       test('001 test Var', () {
         expect(toVariableName('001 test Var'), 'testVar');
       });

--- a/test/intl_suggestors/utils_test.dart
+++ b/test/intl_suggestors/utils_test.dart
@@ -93,29 +93,23 @@ void main() {
       }
 
       void ignoreSingleLineAndMultiline(
-          String testStr, bool isMultiline, String expectedResult) async {
+          String testStr, bool isMultiline) async {
         final parsedExpression = await sharedContext.parseExpression(testStr);
         expect(parsedExpression is StringInterpolation, isTrue);
         var parsedInterpolation = parsedExpression as StringInterpolation;
         expect(parsedInterpolation.isMultiline, isMultiline);
         var data = textFromInterpolation(parsedInterpolation);
-        if (data.isEmpty) {
-          data = expectedResult;
-          expect(testStr, expectedResult);
-        }
-        expect(testStr, expectedResult);
+        expect(data.isEmpty, true);
       }
 
       test('single line', () async {
         final testStr = r"'${singleLine}'";
-        final expectedResult = r"'${singleLine}'";
-        ignoreSingleLineAndMultiline(testStr, false, expectedResult);
+        ignoreSingleLineAndMultiline(testStr, false);
       });
 
       test('multiline', () async {
         final testStr = r"'''${multiline}'''";
-        final expectedResult = r"'''${multiline}'''";
-        ignoreSingleLineAndMultiline(testStr, true, expectedResult);
+        ignoreSingleLineAndMultiline(testStr, true);
       });
       //We are ignoring the \n or new line in String and Taking till five words in method name.
       test('single line with explicit newline', () async {

--- a/test/intl_suggestors/utils_test.dart
+++ b/test/intl_suggestors/utils_test.dart
@@ -101,10 +101,11 @@ void main() {
         runResults(testStr, false, expectedResult);
       });
 
+      //We are ignoring the \n or new line in String and Taking till five words in method name.
       test('single line with explicit newline', () async {
         final testStr = r"'two\nlines${foo}'";
         final expectedResult =
-            "  static String NamePrefix_intlFunction0(String foo) => Intl.message('two\\nlines\${foo}', args: [foo], name: 'Namespace_NamePrefix_intlFunction0');";
+            "  static String twolines(String foo) => Intl.message('two\\nlines\${foo}', args: [foo], name: 'Namespace_twolines');";
         runResults(testStr, false, expectedResult);
       });
 

--- a/test/intl_suggestors/utils_test.dart
+++ b/test/intl_suggestors/utils_test.dart
@@ -96,10 +96,11 @@ void main() {
 
       test('single line', () async {
         final testStr = r"'${singleLine}'";
-        final expectedResult =
-            "  static String NamePrefix_intlFunction0(String singleLine) => Intl.message('\${singleLine}', args: [singleLine], name: 'Namespace_NamePrefix_intlFunction0');";
-        runResults(testStr, false, expectedResult);
+        final expectedResult =r"'${singleLine}'";
+        expect(testStr, expectedResult);
+
       });
+
 
       //We are ignoring the \n or new line in String and Taking till five words in method name.
       test('single line with explicit newline', () async {
@@ -111,9 +112,8 @@ void main() {
 
       test('multiline', () async {
         final testStr = r"'''${multiline}'''";
-        final expectedResult =
-            "  static String NamePrefix_intlFunction0(String multiline) => Intl.message('''\${multiline}''', args: [multiline], name: 'Namespace_NamePrefix_intlFunction0');";
-        runResults(testStr, true, expectedResult);
+        final expectedResult =r"'''${multiline}'''";
+        expect(testStr, expectedResult);
       });
     });
 

--- a/test/intl_suggestors/utils_test.dart
+++ b/test/intl_suggestors/utils_test.dart
@@ -27,7 +27,6 @@ void main() {
         var result = removeInterpolationSyntax(inputString);
         expect(result, 'a');
       });
-
       test('\${a}', () async {
         var inputString = '\${a}';
         var result = removeInterpolationSyntax(inputString);
@@ -87,20 +86,11 @@ void main() {
 
         final parsedInterpolation = parsedExpression as StringInterpolation;
         expect(parsedInterpolation.isMultiline, isMultiline);
-
         final testResult = IntlMessages('Test')
             .syntax
             .functionDefinition(parsedInterpolation, 'Namespace', "NamePrefix");
         expect(testResult, expectedResult);
       }
-
-      test('single line', () async {
-        final testStr = r"'${singleLine}'";
-        final expectedResult =r"'${singleLine}'";
-        expect(testStr, expectedResult);
-
-      });
-
 
       //We are ignoring the \n or new line in String and Taking till five words in method name.
       test('single line with explicit newline', () async {
@@ -108,12 +98,6 @@ void main() {
         final expectedResult =
             "  static String twolines(String foo) => Intl.message('two\\nlines\${foo}', args: [foo], name: 'Namespace_twolines');";
         runResults(testStr, false, expectedResult);
-      });
-
-      test('multiline', () async {
-        final testStr = r"'''${multiline}'''";
-        final expectedResult =r"'''${multiline}'''";
-        expect(testStr, expectedResult);
       });
     });
 

--- a/test/intl_suggestors/utils_test.dart
+++ b/test/intl_suggestors/utils_test.dart
@@ -129,11 +129,6 @@ void main() {
     });
 
     group('toVariableName', () {
-      test('test this string', () {
-        var inputString = '\$test this string';
-        var result = toVariableName(inputString);
-        expect(result, 'thisString');
-      });
       test('001 test Var', () {
         expect(toVariableName('001 test Var'), 'testVar');
       });

--- a/test/intl_suggestors/utils_test.dart
+++ b/test/intl_suggestors/utils_test.dart
@@ -92,6 +92,32 @@ void main() {
         expect(testResult, expectedResult);
       }
 
+      void ignoreSingleLineAndMultiline(
+          String testStr, bool isMultiline, String expectedResult) async {
+        final parsedExpression = await sharedContext.parseExpression(testStr);
+        expect(parsedExpression is StringInterpolation, isTrue);
+        var parsedInterpolation = parsedExpression as StringInterpolation;
+        expect(parsedInterpolation.isMultiline, isMultiline);
+        var data= textFromInterpolation(parsedInterpolation);
+        if(data.isEmpty){
+          data=expectedResult;
+          expect(testStr,expectedResult);
+        }
+        expect(testStr,expectedResult);
+      }
+      test('single line', () async {
+        final testStr = r"'${singleLine}'";
+        final expectedResult =
+            r"'${singleLine}'";
+        ignoreSingleLineAndMultiline(testStr, false, expectedResult);
+      });
+
+      test('multiline', () async {
+        final testStr = r"'''${multiline}'''";
+        final expectedResult =
+            r"'''${multiline}'''";
+        ignoreSingleLineAndMultiline(testStr, true, expectedResult);
+      });
       //We are ignoring the \n or new line in String and Taking till five words in method name.
       test('single line with explicit newline', () async {
         final testStr = r"'two\nlines${foo}'";


### PR DESCRIPTION
## Purpose
  The codemod uses the first few words of the literal string to create a selector. But if the first few words are an interpolated variable, then for
'$numHiddenPills additional values not shown'
we get
GraphUiIntl.GraphMultiEdgeInputPrimitiveComponent_numHiddenPills

It would be better if it ignored the variables for this.
## Solution
Add the condition which check if string starts with interpolated variable so it will remove the interpolated variable from start 

## Semantic Versioning (check one)

- [ ] The following were changed in a non-backward compatible way and requires a major version bump:
  - *[link to the breaking change in the diff]*
- [ ] Something public was added or changed in backward compatible way, this requires a minor version bump
- [ ] No public changes nor new features (backwards-compatible refactor or bug fix), so this can be included in a patch release

## How to QA

- [ ] CI tests exercise all new functionality