### PR TITLE
INTL-346: Use the W_intl wrapper class in the codemod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.10.1(https://github.com/Workiva/over_react_codemod/compare/2.10.1....2.10.0)
+
+- Switch the import in _intl.dart generated classes to be w\_intl/intl\_wrapper.dart
+
 ## [2.10.0](https://github.com/Workiva/over_react_codemod/compare/2.10.0....2.9.0)
 
 - Upgrade to analyzer 2.0

--- a/lib/src/intl_suggestors/intl_messages.dart
+++ b/lib/src/intl_suggestors/intl_messages.dart
@@ -121,9 +121,13 @@ Attempting to add a different message with the same name:
     }
   }
 
+  /// The dependency analyzer thinks we depend on this if we have the literal string, so
+  /// use it in an interpolation to placate it.
+  static const w_intl = 'w_intl';
+
   /// The beginning of any Intl class.
   static String prologueFor(String className) =>
-      '''import 'package:w_intl/intl_wrapper.dart';
+      '''import 'package:${w_intl}/intl_wrapper.dart';
 
 //ignore: avoid_classes_with_only_static_members
 //ignore_for_file: unnecessary_brace_in_string_interps

--- a/lib/src/intl_suggestors/intl_messages.dart
+++ b/lib/src/intl_suggestors/intl_messages.dart
@@ -123,7 +123,7 @@ Attempting to add a different message with the same name:
 
   /// The beginning of any Intl class.
   static String prologueFor(String className) =>
-      '''import 'package:intl/intl.dart';
+      '''import 'package:w_intl/intl_wrapper.dart';
 
 //ignore: avoid_classes_with_only_static_members
 //ignore_for_file: unnecessary_brace_in_string_interps

--- a/lib/src/intl_suggestors/intl_messages.dart
+++ b/lib/src/intl_suggestors/intl_messages.dart
@@ -113,10 +113,12 @@ Attempting to add a different message with the same name:
   void write({bool force = false}) {
     // Create the file if it didn't exist, but if there are no changes, don't rewrite the existing.
     var exists = outputFile.existsSync();
-    if (force || !exists || outputFile.readAsStringSync().isEmpty) {
+    var fileContents = exists ? outputFile.readAsStringSync() : '';
+    var hasTheSamePrologue = fileContents.startsWith(prologue);
+    if (force || !exists || fileContents.isEmpty) {
       outputFile.createSync(recursive: true);
       outputFile.writeAsStringSync(contents);
-    } else if (addedNewMethods) {
+    } else if (addedNewMethods || !hasTheSamePrologue) {
       outputFile.writeAsStringSync(contents);
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   source_span: ^1.8.1
   yaml: ^3.1.0
   yaml_edit: ^2.0.0
-  intl: ^0.17.0
   file: ^6.1.2
 
 dev_dependencies:
@@ -32,6 +31,7 @@ dev_dependencies:
   build_test: ^2.1.3
   dart_style: ^2.0.3
   dependency_validator: ^3.1.2
+  intl: ^0.17.0
   mockito: ^5.0.14
   test: ^1.17.10
   test_descriptor: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,6 @@ dev_dependencies:
   build_test: ^2.1.3
   dart_style: ^2.0.3
   dependency_validator: ^3.1.2
-  intl: ^0.17.0
   mockito: ^5.0.14
   test: ^1.17.10
   test_descriptor: ^2.0.0

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -264,7 +264,7 @@ usage() => (mui.Button()..aria.label=TestProjectIntl.sortsLater)(TestProjectIntl
       d.dir('src', [
         d.dir('intl', [
           d.file('test_project_intl.dart', /*language=dart*/ '''
-import 'package:intl/intl.dart';
+import 'package:w_intl/intl_wrapper.dart';
 
 //ignore: avoid_classes_with_only_static_members
 //ignore_for_file: unnecessary_brace_in_string_interps

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -100,6 +100,30 @@ void main() {
             ]..sort()),
         args: ['--yes-to-all']);
 
+    // Test that we update the file to use the w_intl import, even if there are no other changes.
+    testCodemod('Import is updated',
+        script: script,
+        input: expectedOutputFiles(additionalFilesInLib: [
+          extraInput()
+        ], messages: [
+          ...defaultMessages,
+          ...annotatedMessages,
+        ], intlImport: 'intl/intl.dart'),
+        expectedOutput: expectedOutputFiles(
+            additionalFilesInLib: [extraOutput()],
+            messages: [
+              ...defaultMessages,
+              ...annotatedMessages,
+              ...longMessages
+            ]..sort()),
+        args: ['--yes-to-all']);
+
+    testCodemod('Import is updated without other modifications',
+        script: script,
+        input: expectedOutputFiles(intlImport: 'intl/intl.dart'),
+        expectedOutput: expectedOutputFiles(),
+        args: ['--yes-to-all']);
+
     testCodemod('Specify a single file',
         // We add some extra files, but we specify just the original, so they shouldn't be included.
         script: script,
@@ -237,11 +261,11 @@ const List<String> defaultMessages = [
   "  static String get sortsLater => Intl.message('Sorts later', name: 'TestProjectIntl_sortsLater');",
 ];
 
-d.DirectoryDescriptor expectedOutputFiles({
-  Iterable<d.Descriptor> additionalFilesInLib = const [],
-  List<String> messages = defaultMessages,
-  String rmuiVersionConstraint = '^1.1.1',
-}) {
+d.DirectoryDescriptor expectedOutputFiles(
+    {Iterable<d.Descriptor> additionalFilesInLib = const [],
+    List<String> messages = defaultMessages,
+    String rmuiVersionConstraint = '^1.1.1',
+    String intlImport = '${wIntl}/intl_wrapper.dart'}) {
   return d.dir('project', [
     // Note that the codemod doesn't currently add the intl dependency to the pubspec.
     d.file('pubspec.yaml', /*language=yaml*/ '''
@@ -264,7 +288,7 @@ usage() => (mui.Button()..aria.label=TestProjectIntl.sortsLater)(TestProjectIntl
       d.dir('src', [
         d.dir('intl', [
           d.file('test_project_intl.dart', /*language=dart*/ '''
-import 'package:${wIntl}/intl_wrapper.dart';
+import 'package:${intlImport}';
 
 //ignore: avoid_classes_with_only_static_members
 //ignore_for_file: unnecessary_brace_in_string_interps

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -264,7 +264,7 @@ usage() => (mui.Button()..aria.label=TestProjectIntl.sortsLater)(TestProjectIntl
       d.dir('src', [
         d.dir('intl', [
           d.file('test_project_intl.dart', /*language=dart*/ '''
-import 'package:w_intl/intl_wrapper.dart';
+import 'package:${wIntl}/intl_wrapper.dart';
 
 //ignore: avoid_classes_with_only_static_members
 //ignore_for_file: unnecessary_brace_in_string_interps
@@ -277,3 +277,5 @@ ${messages.join('\n')}
     ]),
   ]);
 }
+
+const wIntl = 'w_intl';

--- a/test/intl_suggestors/intl_messages_test.dart
+++ b/test/intl_suggestors/intl_messages_test.dart
@@ -84,9 +84,16 @@ void main() {
     });
 
     test('messages found', () {
-      expect(messages.methods.length, 4);
-      expect(
-          messages.methods.keys, ['orange', 'aquamarine', 'long', 'function']);
+      expect(messages.methods.length, 7);
+      expect(messages.methods.keys, [
+        'orange',
+        'aquamarine',
+        'long',
+        'function',
+        'aPlural',
+        'formatted',
+        'someSelect'
+      ]);
       expect(messages.methods.values.map((each) => each.source).toList(),
           sampleMethods);
     });
@@ -109,7 +116,7 @@ void main() {
     });
 
     test('duplicate names with different content throw in addMethod', () {
-      var tweaked = sampleMethods.last.replaceFirst('def', 'zzzz');
+      var tweaked = sampleMethods[3].replaceFirst('def', 'zzzz');
       expect(() => messages.addMethod(tweaked), throwsA(isA<AssertionError>()));
     });
 
@@ -117,16 +124,16 @@ void main() {
         () {
       /// Modify the message text, but also change the name so that when it parses the function it will
       /// find it. So we're really exercising the nameForString more than the addMethod.
-      var tweaked = sampleMethods.last.replaceFirst('def', 'zzzz');
+      var tweaked = sampleMethods[3].replaceFirst('def', 'zzzz');
       var name = messages.nameForString('function', r'abc${x}zzzz');
       tweaked = tweaked.replaceFirst('function', name);
       messages.addMethod(tweaked);
-      var tweakedMore = sampleMethods.last.replaceFirst('abc', 'www');
+      var tweakedMore = sampleMethods[3].replaceFirst('abc', 'www');
       var otherName = messages.nameForString('function', r'www${x}def');
       tweakedMore = tweakedMore.replaceFirst('function', otherName);
       messages.addMethod(tweakedMore);
-      expect(messages.methods.length, 6);
-      expect(messages.methods['function']?.source, sampleMethods.last);
+      expect(messages.methods.length, 9);
+      expect(messages.methods['function']?.source, sampleMethods[3]);
       expect(messages.methods['function1']?.source, tweaked);
       expect(messages.methods['function2']?.source, contains(r'www${x}def'));
     });
@@ -134,7 +141,7 @@ void main() {
 }
 
 String expectedFile(String methods) => '''
-import 'package:intl/intl.dart';
+import 'package:w_intl/intl_wrapper.dart';
 
 //ignore: avoid_classes_with_only_static_members
 //ignore_for_file: unnecessary_brace_in_string_interps
@@ -149,15 +156,14 @@ List<String> sampleMethods = [
 line 
 string''', name: 'TestProjectIntl_long');""",
   """  static String function(String x) => Intl.message('abc\${x}def', name: 'TestProjectIntl_function');""",
+  """  static String aPlural(int n) => Intl.plural(n, zero: 'zero', other: 'other', name: 'aPlural', args: [n]);""",
+  """  static List<Object> formatted(Object f) => Intl.formattedMessage([f, 'foo'], name: 'formatted', args: [f]);""",
+  """  static String someSelect(Object choice) => Intl.select(choice, {'a' : 'b'}, name: 'someSelect', args: [choice]);"""
 ];
 
 // The sample methods in a hard-coded sorted order.
-List<String> get sortedSampleMethods => [
-      sampleMethods[1],
-      sampleMethods[3],
-      sampleMethods[2],
-      sampleMethods[0],
-    ];
+List<String> get sortedSampleMethods =>
+    [4, 1, 5, 3, 2, 0, 6].map((i) => sampleMethods[i]).toList();
 
 // A test utility to be invoked from the debug console to see where subtly-different long strings differ.
 void firstDifference(String a, String b) {

--- a/test/intl_suggestors/intl_messages_test.dart
+++ b/test/intl_suggestors/intl_messages_test.dart
@@ -17,7 +17,15 @@ void main() {
         for (var method in sampleMethods)
           MessageParser.forMethod(method).methods.first.name
       ];
-      expect(names, ['orange', 'aquamarine', 'long', 'function']);
+      expect(names, [
+        'orange',
+        'aquamarine',
+        'long',
+        'function',
+        'aPlural',
+        'formatted',
+        'someSelect'
+      ]);
     });
     test('Tabs instead of spaces', () {
       var tabbed =
@@ -140,8 +148,9 @@ void main() {
   });
 }
 
+String wIntl = 'w_intl';
 String expectedFile(String methods) => '''
-import 'package:w_intl/intl_wrapper.dart';
+import 'package:${wIntl}/intl_wrapper.dart';
 
 //ignore: avoid_classes_with_only_static_members
 //ignore_for_file: unnecessary_brace_in_string_interps


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
We're adding an Intl wrapper in w_intl. The codemod should generate code that calls that, rather than basic intl.

## Changes
  <!-- What this PR changes to fix the problem. -->
Changes the import.
Also adds tests that exercise plurals, etc., rather than just messages.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
