### PR TITLE
Add a --migrate-components option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.12.0(https://github.com/Workiva/over_react_codemod/compare/2.10.1....2.10.0)
+
+- Add a --[no]-migrate-components option for intl\_message\_migration
+
 ## [2.10.1(https://github.com/Workiva/over_react_codemod/compare/2.10.1....2.10.0)
 
 - Switch the import in _intl.dart generated classes to be w\_intl/intl\_wrapper.dart

--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -39,6 +39,7 @@ const _yesToAllFlag = 'yes-to-all';
 const _failOnChangesFlag = 'fail-on-changes';
 const _stderrAssumeTtyFlag = 'stderr-assume-tty';
 const _migrateConstants = 'migrate-constants';
+const _migrateComponents = 'migrate-components';
 const _allCodemodFlags = {
   _verboseFlag,
   _yesToAllFlag,
@@ -85,10 +86,12 @@ final parser = ArgParser()
     help:
         'Should the codemod try to migrate constant Strings that look user-visible',
   )
-  ..addMultiOption(
-    'migrators',
-    defaultsTo: ['prop', 'child', 'displayName'],
-    allowed: ['prop', 'child', 'displayName'],
+  ..addFlag(
+    _migrateComponents,
+    negatable: true,
+    defaultsTo: true,
+    help:
+        'Should the codemod try to migrate properties and children of React components',
   );
 
 late ArgResults parsedArgs;
@@ -252,7 +255,7 @@ Future<void> migratePackage(
   exitCode = await runCodemodSequences(
       packageDartPaths,
       [
-        [intlPropMigrator],
+        if (parsedArgs[_migrateComponents]) [intlPropMigrator],
         if (parsedArgs[_migrateConstants]) [constantStringMigrator],
         [displayNameMigrator],
         [importMigrator],


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Sometimes we don't want to migrate props or children of components, maybe we just want to have the _intl.dart file rewritten with a different import, or have the file sorted. This lets us turn off the main migrator.


## Changes
  <!-- What this PR changes to fix the problem. -->

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
