### PR TITLE
Add a --[no]-prune-unused flag to remove unused methods from the _intl.dart file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## [2.12.0(https://github.com/Workiva/over_react_codemod/compare/2.10.1....2.10.0)
+## [2.13.0(https://github.com/Workiva/over_react_codemod/compare/2.13.0....2.12.0)
+
+- Add a --[no]-prune-unused flag to remove methods that appear to be ununused
+  from the _intl.dart file.
+
+## [2.12.0(https://github.com/Workiva/over_react_codemod/compare/2.12.0....2.10.1)
 
 - Add a --[no]-migrate-components option for intl\_message\_migration
 

--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -40,6 +40,7 @@ const _failOnChangesFlag = 'fail-on-changes';
 const _stderrAssumeTtyFlag = 'stderr-assume-tty';
 const _migrateConstants = 'migrate-constants';
 const _migrateComponents = 'migrate-components';
+const _pruneUnused = 'prune-unused';
 const _allCodemodFlags = {
   _verboseFlag,
   _yesToAllFlag,
@@ -78,6 +79,13 @@ final parser = ArgParser()
     _stderrAssumeTtyFlag,
     negatable: false,
     help: 'Forces ansi color highlighting of stderr. Useful for debugging.',
+  )
+  ..addFlag(
+    _pruneUnused,
+    negatable: true,
+    defaultsTo: false,
+    help:
+        "Try to remove any messages in the generated _intl.dart file that aren't called.",
   )
   ..addFlag(
     _migrateConstants,
@@ -251,6 +259,7 @@ Future<void> migratePackage(
   final displayNameMigrator = ConfigsMigrator(messages.className, messages);
   final importMigrator = (FileContext context) =>
       intlImporter(context, packageName, messages.className);
+  final usedMethodsChecker = UsedMethodsChecker(messages.className, messages);
 
   exitCode = await runCodemodSequences(
       packageDartPaths,
@@ -259,6 +268,7 @@ Future<void> migratePackage(
         if (parsedArgs[_migrateConstants]) [constantStringMigrator],
         [displayNameMigrator],
         [importMigrator],
+        if (parsedArgs[_pruneUnused]) [usedMethodsChecker],
       ],
       codemodArgs);
 

--- a/lib/src/intl_suggestors/intl_messages.dart
+++ b/lib/src/intl_suggestors/intl_messages.dart
@@ -26,6 +26,10 @@ class IntlMessages {
   /// Flag to check if we've actually added anything, and need to rewrite the file.
   bool addedNewMethods = false;
 
+  /// We assume that we're pruning if we've made entries in [methodsUsed] and otherwise
+  /// we aren't.
+  bool get pruning => methodsUsed.isNotEmpty;
+
   // TODO: I think packagePath only applies if there's a sub-package.
   IntlMessages(this.packageName,
       {Directory? directory, String packagePath = '', File? output})
@@ -119,8 +123,9 @@ Attempting to add a different message with the same name:
   /// Remove any methods that we haven't seen a usage for.
   void prune() {
     // Don't prune if we don't seem to have looked for usages.
-    if (methodsUsed.isEmpty) return;
-    methods.removeWhere((name, method) => !methodsUsed.contains(name));
+    if (pruning) {
+      methods.removeWhere((name, method) => !methodsUsed.contains(name));
+    }
   }
 
   /// Write the messages to a file. If the file exists and there are no changes, it will just
@@ -134,9 +139,7 @@ Attempting to add a different message with the same name:
     if (force || !exists || fileContents.isEmpty) {
       outputFile.createSync(recursive: true);
       outputFile.writeAsStringSync(contents);
-    } else if (addedNewMethods ||
-        !hasTheSamePrologue ||
-        prunedMethods.isNotEmpty) {
+    } else if (addedNewMethods || !hasTheSamePrologue || pruning) {
       outputFile.writeAsStringSync(contents);
     }
   }

--- a/lib/src/intl_suggestors/intl_messages.dart
+++ b/lib/src/intl_suggestors/intl_messages.dart
@@ -15,16 +15,10 @@ class IntlMessages {
   File outputFile;
 
   /// The methods for this class, indexed by method name.
-  Map<String, Method> methods = {};
-
-  /// The methods after removing any that appear to be unused.
-  ///
-  /// If this is empty, it probably means we haven't used the prune option.
-  Map<String, Method> prunedMethods = {};
+  final Map<String, Method> methods = {};
 
   /// If we are pruning, the list of methods that we found used. If empty, we were
   /// likely not pruning.
-  // TODO: Clean up this, prunedMethods, and how we check if we were pruning or not.
   Set<String> methodsUsed = {};
 
   late MessageSyntax syntax;
@@ -117,9 +111,8 @@ Attempting to add a different message with the same name:
   // Just the messages, without the prologue or closing brace.
   String get _messageContents {
     var buffer = StringBuffer();
-    var methodsToWrite = prunedMethods.isEmpty ? methods : prunedMethods;
-    (methodsToWrite.keys.toList()..sort())
-        .forEach((name) => buffer.write('\n${methodsToWrite[name]?.source}'));
+    (methods.keys.toList()..sort())
+        .forEach((name) => buffer.write('\n${methods[name]?.source}'));
     return '$buffer';
   }
 
@@ -127,11 +120,7 @@ Attempting to add a different message with the same name:
   void prune() {
     // Don't prune if we don't seem to have looked for usages.
     if (methodsUsed.isEmpty) return;
-
-    prunedMethods = {
-      for (var name in methods.keys)
-        if (methodsUsed.contains(name)) name: methods[name]!
-    };
+    methods.removeWhere((name, method) => !methodsUsed.contains(name));
   }
 
   /// Write the messages to a file. If the file exists and there are no changes, it will just

--- a/lib/src/intl_suggestors/intl_migrator.dart
+++ b/lib/src/intl_suggestors/intl_migrator.dart
@@ -6,6 +6,31 @@ import 'package:over_react_codemod/src/intl_suggestors/utils.dart';
 import 'package:over_react_codemod/src/util/component_usage.dart';
 import 'package:over_react_codemod/src/util/component_usage_migrator.dart';
 
+class UsedMethodsChecker extends GeneralizingAstVisitor
+    with AstVisitingSuggestor {
+  final IntlMessages _messages;
+  final String _className;
+
+  UsedMethodsChecker(this._className, this._messages);
+
+  @override
+  visitPrefixedIdentifier(PrefixedIdentifier node) {
+    if ('${node.prefix}' == _className) {
+      _messages.noteUsage('${node.identifier}');
+    }
+    // TODO: implement visitPrefixedIdentifier
+    return super.visitPrefixedIdentifier(node);
+  }
+
+  @override
+  visitMethodInvocation(MethodInvocation node) {
+    if ('${node.target}' == _className) {
+      _messages.noteUsage('${node.methodName}');
+    }
+    return super.visitMethodInvocation(node);
+  }
+}
+
 /// Mark const string variables whose first character is uppercase for internationalization. e.g.
 ///
 ///   const String cancel = 'Cancel';

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -96,6 +96,7 @@ void main() {
             messages: [
               ...defaultMessages,
               ...annotatedMessages,
+              ...longMessages,
             ]..sort()),
         args: ['--yes-to-all']);
 

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -96,6 +96,36 @@ void main() {
             messages: [
               ...defaultMessages,
               ...annotatedMessages,
+            ]..sort()),
+        args: ['--yes-to-all']);
+
+    // We've removed the file for some that were already in the _intl.dart file,
+    // and we expect them to be removed.
+    testCodemod('Unused messages are removed',
+        script: script,
+        input: expectedOutputFiles(additionalFilesInLib: [], messages: [
+          ...defaultMessages,
+          ...annotatedMessages,
+        ]),
+        expectedOutput: expectedOutputFiles(
+            additionalFilesInLib: [], messages: [...defaultMessages]..sort()),
+        args: ['--yes-to-all', '--prune-unused']);
+
+    // Don't prune, but remove the input file. Also add some extra messages to force
+    // the file to be rewritten, and ensure the unused messages are still there.
+    testCodemod("Unused messages are not removed if we don't pass the flag",
+        script: script,
+        input: expectedOutputFiles(additionalFilesInLib: [
+          extraInput()
+        ], messages: [
+          ...defaultMessages,
+          ...annotatedMessages,
+        ]),
+        expectedOutput: expectedOutputFiles(
+            additionalFilesInLib: [],
+            messages: [
+              ...defaultMessages,
+              ...annotatedMessages,
               ...longMessages
             ]..sort()),
         args: ['--yes-to-all']);


### PR DESCRIPTION
We can accumulate methods in the _intl.dart file that we're no longer using. This attempts to prune them out.

## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

## Changes
  <!-- What this PR changes to fix the problem. -->

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
