### PR TITLE
INTL-174 : Add nicer logging to codemod dryrun check

### DIFF
--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -23,11 +23,14 @@ import 'package:file/local.dart';
 import 'package:glob/glob.dart';
 import 'package:glob/list_local_fs.dart';
 import 'package:logging/logging.dart';
+
 import 'package:over_react_codemod/src/intl_suggestors/intl_configs_migrator.dart';
 import 'package:over_react_codemod/src/intl_suggestors/intl_importer.dart';
 import 'package:over_react_codemod/src/intl_suggestors/intl_messages.dart';
 import 'package:over_react_codemod/src/intl_suggestors/intl_migrator.dart';
 import 'package:over_react_codemod/src/util/package_util.dart';
+import 'package:over_react_codemod/src/util/logging.dart';
+
 import 'package:path/path.dart' as p;
 
 import '../util.dart';
@@ -129,7 +132,7 @@ void main(List<String> args) async {
     additionalHelpOutput: parser.usage,
   );
   if (exitCode != 0) return;
-  print('^ Ignore the "codemod found no files" warning above for now.');
+  logWarning('^ Ignore the "codemod found no files" warning above for now.');
 
   // If we have specified paths on the command line, limit our processing to
   // those, and make sure they're absolute.
@@ -168,7 +171,7 @@ void main(List<String> args) async {
     additionalHelpOutput: parser.usage,
   );
   if (exitCode != 0) return;
-  print('^ Ignore the "codemod found no files" warning above for now.');
+  logWarning('^ Ignore the "codemod found no files" warning above for now.');
 
   for (String package in packageRoots) {
     await migratePackage(
@@ -281,7 +284,7 @@ void sortPartsLast(List<String> dartPaths) {
       });
 
   if (dartPaths.isNotEmpty && dartPaths.every(isPart)) {
-    _log.severe(
+    logShout(
         'Only part files were specified. The containing library must be included for any part file, as it is needed for analysis context');
     exit(1);
   }
@@ -292,7 +295,7 @@ void sortPartsLast(List<String> dartPaths) {
     if (isAPart == isBPart) return 0;
     return isAPart ? 1 : -1;
   });
-  _log.info('Done.');
+  logShout('Done.');
 }
 
 void sortDeepestFirst(Set<String> packageRoots) {

--- a/lib/src/executables/mui_migration.dart
+++ b/lib/src/executables/mui_migration.dart
@@ -28,7 +28,7 @@ import 'package:over_react_codemod/src/mui_suggestors/mui_importer.dart';
 import 'package:over_react_codemod/src/mui_suggestors/unused_wsd_import_remover.dart';
 import 'package:over_react_codemod/src/util/package_util.dart';
 import 'package:over_react_codemod/src/util/pubspec_upgrader.dart';
-
+import 'package:over_react_codemod/src/util/logging.dart';
 final _log = Logger('orcm.mui_migration');
 
 const _componentOption = 'component';
@@ -130,7 +130,7 @@ void main(List<String> args) async {
     additionalHelpOutput: parser.usage,
   );
   if (exitCode != 0) return;
-  print('^ Ignore the "codemod found no files" warning above for now.');
+  logWarning('^ Ignore the "codemod found no files" warning above for now.');
 
   /// Runs a set of codemod sequences separately to work around an issue where
   /// updates from an earlier suggestor aren't reflected in the resolved AST

--- a/lib/src/util/logging.dart
+++ b/lib/src/util/logging.dart
@@ -1,0 +1,50 @@
+import 'dart:io';
+import 'package:logging/logging.dart';
+
+import 'package:io/ansi.dart' as ansi;
+
+Logger logger = Logger('orcm.logging');
+bool verbose = true;
+void initLogging(verbose, String message) {
+
+  Logger.root.level = Level.INFO;
+  Logger.root.onRecord.listen((rec) {
+    var colorizer;
+    IOSink output;
+
+    if (rec.level >= Level.SEVERE) {
+      colorizer = ansi.backgroundRed.wrap;
+      output = stderr;
+    } else if (rec.level >= Level.WARNING) {
+      colorizer = ansi.backgroundLightYellow.wrap;
+      output = stderr;
+    } else{
+      colorizer = _noopColorizer;
+      output = stdout;
+    }
+
+    if (rec.message != '') {
+      output.writeln(colorizer(rec.message));
+    }
+    if (rec.error != null) {
+      output.writeln(colorizer(rec.error.toString()));
+    }
+    if (verbose && rec.stackTrace != null) {
+      output.writeln(colorizer(rec.stackTrace.toString()));
+    }
+
+  });
+
+}
+String _noopColorizer(String string) => string;
+
+void logWarning(String message){
+  initLogging(verbose,message);
+  logger.warning(message);
+}
+void logShout(String message){
+  initLogging(verbose,message);
+  logger.shout(message);
+}
+
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   yaml: ^3.1.0
   yaml_edit: ^2.0.0
   file: ^6.1.2
+  io: ^1.0.0
 
 dev_dependencies:
   async: ^2.0.0


### PR DESCRIPTION
## Purpose

When repos start adding the codemod dryrun check to their CI, we want them to be able to easily see failures and be able to debug issues. So, let's add some better logging with colors.
## Solution
Create `logging.dart` file in `utill` directory where mention all colors as per `rec.level` 
