### PR TITLE
INTL-1071 Add a --no-migrate option that just sorts and possibly prunes

### DIFF
--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -69,6 +69,14 @@ void main() {
       expect(err, contains(' change(s) needed.'));
     });
 
+    // It would be nice to verify that the file modification date is newer, but
+    // the codemod test framework doesn't really support that.
+    testCodemod('--no-migrate exits with zero, does not does not update files',
+        script: script,
+        input: inputFiles(),
+        expectedOutput: inputFiles(),
+        args: ['--no-migrate']);
+
     testCodemod('Output is sorted',
         script: script,
         input: inputFiles(additionalFilesInLib: [extraInput()]),
@@ -161,8 +169,8 @@ void main() {
     testCodemod('Specifying only part files is an error',
         script: script,
         input: inputFiles(additionalFilesInLib: [
-          d.file('a_part_file.dart',
-              /*language=dart*/ '''part of something.bigger;
+          d.file(
+              'a_part_file.dart', /*language=dart*/ '''part of something.bigger;
 
 someMoreStrings() => (mui.Button()..aria.label='orange')('aquamarine');''')
         ]),


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Add a --no-migrate option that just sorts and possibly prunes

## Changes
  <!-- What this PR changes to fix the problem. -->
It's nice to just sort the _intl.dart file occasionally to reduce merge conflicts/size of diffs. It's an annoying amount of command line options right now to turn off all the migrators, and some of them you can't. So add a general option for that.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
