### PR TITLE
Fix the ignore for static-only classes to be for the file

### DIFF
--- a/lib/src/intl_suggestors/intl_messages.dart
+++ b/lib/src/intl_suggestors/intl_messages.dart
@@ -108,9 +108,11 @@ Attempting to add a different message with the same name:
   void delete() => outputFile.deleteSync();
 
   /// The contents of the generated file.
-  String get contents =>
-      (StringBuffer()..write(prologue)..write(_messageContents)..write('\n}'))
-          .toString();
+  String get contents => (StringBuffer()
+        ..write(prologue)
+        ..write(_messageContents)
+        ..write('\n}'))
+      .toString();
 
   // Just the messages, without the prologue or closing brace.
   String get _messageContents {
@@ -152,9 +154,8 @@ Attempting to add a different message with the same name:
   static String prologueFor(String className) =>
       '''import 'package:${w_intl}/intl_wrapper.dart';
 
-//ignore: avoid_classes_with_only_static_members
+//ignore_for_file: avoid_classes_with_only_static_members
 //ignore_for_file: unnecessary_brace_in_string_interps
-
 class $className {''';
 
   /// The beginning of our Intl class.


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
The ignore comment for avoid_classes_with_only_static_members in the _intl.dart file isn't being respected, and it highlights the ENTIRE file, which is very distracting. I think it has to be the comment immediately before the class. Changed it to be ignore_for_file, since that's the only thing in this file anyway.

## Changes
  <!-- What this PR changes to fix the problem. -->
As above.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
