### PR TITLE
FED-1237: add shouldAddDependencies

### DIFF
--- a/lib/src/executables/rmui_bundle_update.dart
+++ b/lib/src/executables/rmui_bundle_update.dart
@@ -38,7 +38,8 @@ void main(List<String> args) async {
     pubspecYamlPaths(),
     aggregate([
       PubspecUpgrader('react_material_ui', parseVersionRange('^1.89.1'),
-          hostedUrl: 'https://pub.workiva.org'),
+          hostedUrl: 'https://pub.workiva.org',
+          shouldAddDependencies: false),
     ].map((s) => ignoreable(s))),
     defaultYes: true,
     args: parsedArgs.rest,


### PR DESCRIPTION
# [FED-1237](https://jira.atl.workiva.net/browse/FED-1237)
![Issue Status](https://h.inf-dev.workiva.org/s/wk-backend/jira/status/FED-1237)

## Motivation
When creating the codemod change to update consumers to new RMUI ESM bundle we neglected to include the case in which would add a dependency where there previously wasn't. To remedy this we need to add the `shouldAddDependencies` flag.

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
