### PR TITLE
The glob for pubspecs would pick up things like empty_pubspec.yaml

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -17,6 +17,7 @@
 library over_react_codemod.src.util;
 
 import 'dart:collection';
+import 'dart:io';
 
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
@@ -261,8 +262,12 @@ String? parseAndRemoveCommentPrefixArg(List<String> args) {
         commentPrefixArgs.add(args[i]);
         args.removeAt(i);
       } else if (i + 1 < args.length) {
-        commentPrefixArgs..add(args[i])..add(args[i + 1]);
-        args..removeAt(i)..removeAt(i + 1);
+        commentPrefixArgs
+          ..add(args[i])
+          ..add(args[i + 1]);
+        args
+          ..removeAt(i)
+          ..removeAt(i + 1);
       }
       break;
     }
@@ -392,8 +397,11 @@ String stripPrivateGeneratedPrefix(String value) {
       : value;
 }
 
-Iterable<String> pubspecYamlPaths() =>
-    filePathsFromGlob(Glob('**pubspec.yaml', recursive: true));
+Iterable<String> pubspecYamlPaths() => Directory.current
+    .listSync(recursive: true, followLinks: false)
+    .whereType<File>()
+    .map((f) => f.path)
+    .where((f) => p.basename(f) == 'pubspec.yaml');
 
 Iterable<String> allHtmlPaths() =>
     filePathsFromGlob(Glob('**.html', recursive: true));


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

The glob for pubspecs was "**pubspec.yaml", which would pick up e.g. empty_pubspec.yaml, but other methods would expect (correctly) that pubspecs are only ever named exactly pubspec.yaml. This led to creating a spurious migration file for the 'empty' project. Change the glob to use a directory traversal instead.

## Changes
  <!-- What this PR changes to fix the problem. -->
Change the glob to use a directory traversal instead.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
