### PR TITLE
INTL-1237: Fix names when writing the _intl.dart file

### DIFF
--- a/lib/src/intl_suggestors/intl_messages.dart
+++ b/lib/src/intl_suggestors/intl_messages.dart
@@ -70,7 +70,8 @@ class IntlMessages {
     // If we call this rather than addMethodNamed, then we're adding a new
     // method, record that.
     addedNewMethods |= true;
-    var parsed = MessageParser.forMethod(source).methods.first;
+    var parsed =
+        MessageParser.forMethod(source, className: className).methods.first;
     var expectedName = nameForString(parsed.name, parsed.messageText);
     if (expectedName != parsed.name) {
       throw AssertionError('''

--- a/lib/src/intl_suggestors/message_parser.dart
+++ b/lib/src/intl_suggestors/message_parser.dart
@@ -1,6 +1,7 @@
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:collection/collection.dart';
 
 /// Holds the important parts of a method that we've parsed.
 class Method {
@@ -94,18 +95,10 @@ class MessageParser {
 
   /// Find the parameter `name:` from the invocation, or return null if there
   /// isn't one.
-  NamedExpression? nameParameterFrom(MethodInvocation invocation) {
-    // firstWhere doesn't like an orElse that can return null if the original collection couldn't return nulls,
-    // so hackily force the collection to be nullable without requiring us to figure out where/if SyntacticEntity
-    // needs to be imported from.
-    var children = [...invocation.argumentList.childEntities, null];
-    // But now we don't need a null check, because is NamedExpression excludes
-    // 'null' with null-safety.
-    return children.firstWhere(
-        (element) =>
-            element is NamedExpression && element.name.label.name == 'name',
-        orElse: () => null) as NamedExpression?;
-  }
+  NamedExpression? nameParameterFrom(MethodInvocation invocation) =>
+      invocation.argumentList.childEntities.firstWhereOrNull((element) =>
+              element is NamedExpression && element.name.label.name == 'name')
+          as NamedExpression?;
 
   /// Return the method body with the correct name.
   String withCorrectedNameParameter(MethodDeclaration declaration) {

--- a/test/intl_suggestors/intl_messages_test.dart
+++ b/test/intl_suggestors/intl_messages_test.dart
@@ -151,11 +151,11 @@ void main() {
       /// find it. So we're really exercising the nameForString more than the addMethod.
       var tweaked = sampleMethods[3].replaceFirst('def', 'zzzz');
       var name = messages.nameForString('function', r'abc${x}zzzz');
-      tweaked = tweaked.replaceFirst('function', name);
+      tweaked = tweaked.replaceAll('function', name);
       messages.addMethod(tweaked);
       var tweakedMore = sampleMethods[3].replaceFirst('abc', 'www');
       var otherName = messages.nameForString('function', r'www${x}def');
-      tweakedMore = tweakedMore.replaceFirst('function', otherName);
+      tweakedMore = tweakedMore.replaceAll('function', otherName);
       messages.addMethod(tweakedMore);
       expect(messages.methods.length, 9);
       expect(messages.methods['function']?.source, sampleMethods[3]);
@@ -181,9 +181,9 @@ List<String> sampleMethods = [
 line 
 string''', name: 'TestProjectIntl_long');""",
   """  static String function(String x) => Intl.message('abc\${x}def', name: 'TestProjectIntl_function');""",
-  """  static String aPlural(int n) => Intl.plural(n, zero: 'zero', other: 'other', name: 'aPlural', args: [n]);""",
-  """  static List<Object> formatted(Object f) => Intl.formattedMessage([f, 'foo'], name: 'formatted', args: [f]);""",
-  """  static String someSelect(Object choice) => Intl.select(choice, {'a' : 'b'}, name: 'someSelect', args: [choice]);"""
+  """  static String aPlural(int n) => Intl.plural(n, zero: 'zero', other: 'other', name: 'TestProjectIntl_aPlural', args: [n]);""",
+  """  static List<Object> formatted(Object f) => Intl.formattedMessage([f, 'foo'], name: 'TestProjectIntl_formatted', args: [f]);""",
+  """  static String someSelect(Object choice) => Intl.select(choice, {'a' : 'b'}, name: 'TestProjectIntl_someSelect', args: [choice]);"""
 ];
 
 // The sample methods in a hard-coded sorted order.


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
It's easy to get the name: parameter value wrong when editing an _intl.dart file. 

## Changes
  <!-- What this PR changes to fix the problem. -->
Rewrite any missing or incorrect name parameters when writing the file to use the format we're using 'PackageNameIntl_methodName'

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
