### PR TITLE
INTL-1250: Fix for creating two copies of identical messages when they used double quotes

### DIFF
--- a/lib/src/intl_suggestors/intl_message_syntax.dart
+++ b/lib/src/intl_suggestors/intl_message_syntax.dart
@@ -125,9 +125,7 @@ class MessageSyntax {
 
   String nameForNode(StringLiteral body,
       {String? initialName, bool startAtZero = false}) {
-    var messageText = body is StringInterpolation
-        ? textFromInterpolation(body)
-        : body.toSource();
+    var messageText = literalText(body);
     // The case where there is no text after this should be checked in
     // isValidStringInterpolationNode and so it should never happen here.
     return owner.nameForString(

--- a/lib/src/intl_suggestors/message_parser.dart
+++ b/lib/src/intl_suggestors/message_parser.dart
@@ -2,6 +2,7 @@ import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:collection/collection.dart';
+import 'package:over_react_codemod/src/intl_suggestors/utils.dart';
 
 /// Holds the important parts of a method that we've parsed.
 class Method {
@@ -139,7 +140,7 @@ class MessageParser {
       // This isn't an Intl.message call, we don't know what to do, bail.
       return '';
     }
-    var text = invocation.argumentList.arguments.first.toSource();
-    return text;
+
+    return literalText(invocation.argumentList.arguments.first);
   }
 }

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -12,6 +12,14 @@ import 'constants.dart';
 // Checks the text under [node] has any alphabetic value, ignore if it's not.
 RegExp alphabetMatcher = RegExp('[a-zA-Z]');
 
+/// The text from a string literal, without quotes.
+String literalText(Expression literal) {
+  if (literal is! StringLiteral) return '';
+  return literal is StringInterpolation
+      ? textFromInterpolation(literal)
+      : literal.stringValue!;
+}
+
 /// For a string interpolation, get all the non-interpolated parts in a string,
 /// separated by spaces.
 String textFromInterpolation(StringInterpolation body) => body.elements

--- a/test/intl_suggestors/constant_migrator_test.dart
+++ b/test/intl_suggestors/constant_migrator_test.dart
@@ -188,6 +188,40 @@ void main() {
             expectedFileContent.trim()); // Avoid the leading return.
       });
 
+      test('duplicate static names with duplicated text, with double quotes',
+          () async {
+        await testSuggestor(
+          input: '''
+          class Bar {
+            static const foo = "I am a user-visible constant";
+          }
+          class Qux {
+            static const foo = "Another static";
+          }
+          const foo = "Another static";
+            ''',
+          expectedOutput: '''
+          class Bar { 
+            static final String foo = TestClassIntl.foo;
+          }
+          class Qux {
+            static final String foo = TestClassIntl.anotherStatic;
+          }
+
+          final String foo = TestClassIntl.anotherStatic;
+          
+            ''',
+        );
+        final expectedFileContent = '''
+  static String get anotherStatic => Intl.message(\'Another static\', name: \'TestClassIntl_anotherStatic\');
+
+  static String get foo => Intl.message(\'I am a user-visible constant\', name: \'TestClassIntl_foo\');
+
+''';
+        expect(messages.messageContents().trim(),
+            expectedFileContent.trim()); // Avoid the leading return.
+      });
+
       test('duplicate getter names increment', () async {
         await testSuggestor(
           input: '''

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -863,7 +863,7 @@ void main() {
                     ),
                     (Dom.p()..addTestId('bar'))(
                       (Dom.p())(
-                        TestClassIntl.createOneFromAnyBy1(props.displayName),
+                        TestClassIntl.createOneFromAnyBy(props.displayName),
                       ),
                     ),
                   );
@@ -875,10 +875,7 @@ void main() {
 
         String expectedFileContent1 =
             "\n  static String createOneFromAnyBy(String displayName) => Intl.message('Create one from any \${displayName} by selecting Save As Template', args: [displayName], name: 'TestClassIntl_createOneFromAnyBy');\n";
-        String expectedFileContent2 =
-            "\n  static String createOneFromAnyBy1(String displayName) => Intl.message('Create one from any \${displayName} by selecting Save As Template', args: [displayName], name: 'TestClassIntl_createOneFromAnyBy1');\n";
-        expect(messages.messageContents(),
-            [expectedFileContent1, expectedFileContent2].join(''));
+        expect(messages.messageContents(), expectedFileContent1);
       });
 
       test('Home Example', () async {


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
The codemod could create duplicate messages for the same string if the original source code used double quotes. This is because the toSource() method in the analyzer included the quotes for a string literal. We would end up comparing "Search" to 'Search', and failing because the quotes aren't the same. We should consistently handle the strings with quotes removed.

## Changes
  <!-- What this PR changes to fix the problem. -->
Add a utility method that gets the string without quotes in a consistent way, and call it. Add tests, and fix one test that seemed to be expecting the incorrect result.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
