### PR TITLE
INTL-967 - fix ignore comment

### DIFF
--- a/lib/src/intl_suggestors/intl_migrator.dart
+++ b/lib/src/intl_suggestors/intl_migrator.dart
@@ -241,37 +241,8 @@ class IntlMigrator extends ComponentUsageMigrator {
     // }
   }
 
-  // recursive function to if previous node is ignore comment until we come to the previous ";"
-  // limit
-  bool isIgnoreCommentBeforePreviousTerminator(node, limit) {
-    // Make *absolutely sure* we can't just recurse forever.
-    if (limit == null) {
-      limit = 128;
-    }
-
-    if (limit == 0) {
-      return false;
-    }
-
-    if (node.toString() == ';') {
-      return false;
-    }
-
-    if (node.precedingComments != null &&
-        node.precedingComments.value().contains(ignoreStatement)) {
-      return true;
-    } else {
-      return isIgnoreCommentBeforePreviousTerminator(node.previous, limit - 1);
-    }
-  }
-
   bool isLineIgnored(node) {
     //var prev = node.previous.length ? node.previous : null;
-
-    if (isIgnoreCommentBeforePreviousTerminator(
-        node.beginToken.previous, 128)) {
-      return true;
-    }
 
     return false;
   }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -126,6 +126,9 @@ String buildIgnoreComment({
   if (undefinedIdentifier) {
     ignores.add('undefined_identifier');
   }
+  if (undefinedIdentifier) {
+    ignores.add('intl_message_migration');
+  }
   if (uriHasNotBeenGenerated) {
     ignores.add('uri_has_not_been_generated');
   }
@@ -262,12 +265,8 @@ String? parseAndRemoveCommentPrefixArg(List<String> args) {
         commentPrefixArgs.add(args[i]);
         args.removeAt(i);
       } else if (i + 1 < args.length) {
-        commentPrefixArgs
-          ..add(args[i])
-          ..add(args[i + 1]);
-        args
-          ..removeAt(i)
-          ..removeAt(i + 1);
+        commentPrefixArgs..add(args[i])..add(args[i + 1]);
+        args..removeAt(i)..removeAt(i + 1);
       }
       break;
     }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -106,13 +106,13 @@ Iterable<Token> allCommentsForNode(AstNode node) sync* {
 ///     // '// ignore: mixin_of_non_class'
 ///     buildIgnoreComment(mixinOfNonClass: true, undefinedClass: true);
 ///     // '// ignore: mixin_of_non_class, undefined_class'
-String buildIgnoreComment({
-  bool constInitializedWithNonConstantValue = false,
-  bool mixinOfNonClass = false,
-  bool undefinedClass = false,
-  bool undefinedIdentifier = false,
-  bool uriHasNotBeenGenerated = false,
-}) {
+String buildIgnoreComment(
+    {bool constInitializedWithNonConstantValue = false,
+    bool mixinOfNonClass = false,
+    bool undefinedClass = false,
+    bool undefinedIdentifier = false,
+    bool uriHasNotBeenGenerated = false,
+    bool intlMessageMigration = false}) {
   final ignores = [];
   if (constInitializedWithNonConstantValue) {
     ignores.add('const_initialized_with_non_constant_value');
@@ -126,7 +126,7 @@ String buildIgnoreComment({
   if (undefinedIdentifier) {
     ignores.add('undefined_identifier');
   }
-  if (undefinedIdentifier) {
+  if (intlMessageMigration) {
     ignores.add('intl_message_migration');
   }
   if (uriHasNotBeenGenerated) {

--- a/test/dart2_9_suggestors/dart2_9_utilities_test.dart
+++ b/test/dart2_9_suggestors/dart2_9_utilities_test.dart
@@ -346,28 +346,6 @@ void main() {
             expectedName: '_\$Foo',
           );
         });
-
-        test(
-            'for `when the intl_message_migration ignore comment is on the line after the variable`',
-            () {
-          _expectGeneratedFactoryName(
-            input: '''
-              UiFactory<FooProps> Foo = composeHocs([
-                connect<RandomColorStore, FooProps>(
-                  context: randomColorStoreContext,
-                  mapStateToProps: (_) => {},
-                  pure: false,
-                ),
-                connect<LowLevelStore, FooProps>(
-                  context: lowLevelStoreContext,
-                  mapStateToProps: (_) => {},
-                  pure: false,
-                ),
-              ])(_\$Foo); // ignore: intl_message_migration
-            ''',
-            expectedName: '_\$Foo',
-          );
-        });
       });
     });
 

--- a/test/dart2_9_suggestors/dart2_9_utilities_test.dart
+++ b/test/dart2_9_suggestors/dart2_9_utilities_test.dart
@@ -268,17 +268,6 @@ void main() {
           );
         });
 
-        test('when the ignore comment is for intl_message_migration', () {
-          _expectGeneratedFactoryName(
-            input: '''
-            UiFactory<FooProps> Foo = 
-              // ignore: intl_message_migration
-              _\$Foo;
-          ''',
-            expectedName: '_\$Foo',
-          );
-        });
-
         test('with type casting function', () {
           _expectGeneratedFactoryName(
             input: '''
@@ -340,6 +329,41 @@ void main() {
                   pure: false,
                 ),
               ])(_\$Foo); // ignore: undefined_identifier
+            ''',
+            expectedName: '_\$Foo',
+          );
+        });
+
+        test(
+            'when the intl_mmessage_migration ignore comment is before initializer',
+            () {
+          _expectGeneratedFactoryName(
+            input: '''
+            UiFactory<FooProps> Foo = 
+              // ignore: intl_message_migration
+              _\$Foo;
+          ''',
+            expectedName: '_\$Foo',
+          );
+        });
+
+        test(
+            'for `when the intl_message_migration ignore comment is on the line after the variable`',
+            () {
+          _expectGeneratedFactoryName(
+            input: '''
+              UiFactory<FooProps> Foo = composeHocs([
+                connect<RandomColorStore, FooProps>(
+                  context: randomColorStoreContext,
+                  mapStateToProps: (_) => {},
+                  pure: false,
+                ),
+                connect<LowLevelStore, FooProps>(
+                  context: lowLevelStoreContext,
+                  mapStateToProps: (_) => {},
+                  pure: false,
+                ),
+              ])(_\$Foo); // ignore: intl_message_migration
             ''',
             expectedName: '_\$Foo',
           );

--- a/test/dart2_9_suggestors/dart2_9_utilities_test.dart
+++ b/test/dart2_9_suggestors/dart2_9_utilities_test.dart
@@ -268,6 +268,17 @@ void main() {
           );
         });
 
+        test('when the ignore comment is for intl_message_migration', () {
+          _expectGeneratedFactoryName(
+            input: '''
+            UiFactory<FooProps> Foo = 
+              // ignore: intl_message_migration
+              _\$Foo;
+          ''',
+            expectedName: '_\$Foo',
+          );
+        });
+
         test('with type casting function', () {
           _expectGeneratedFactoryName(
             input: '''

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -1362,64 +1362,6 @@ void main() {
     });
 
     group('Ignore', () {
-      test('Ignore statement with ignore comment', () async {
-        final source = 'import \'package:over_react/over_react.dart\';\n'
-            '\n'
-            'mixin FooProps on UiProps {}\n'
-            '\n'
-            'UiFactory<FooProps> Foo = uiFunction(\n'
-            '  (props) {\n'
-            '    return (Dom.div())(\n'
-            '      \'testString1\',\n'
-            '      \'testString2\',\n'
-            '    );\n'
-            '  },\n'
-            '  _\$FooConfig, //ignore: undefined_identifier\n'
-            ');\n'
-            '\n'
-            'UiFactory<FooProps> Bar = uiFunction(\n'
-            '  (props) {\n'
-            '    //ignore_statement: intl_message_migration\n'
-            '    return (Dom.div())(\n'
-            '      \'testString1\',\n'
-            '      \'testString2\',\n'
-            '    );\n'
-            '  },\n'
-            '  _\$FooConfig, //ignore: undefined_identifier\n'
-            ');\n'
-            '';
-        final output = 'import \'package:over_react/over_react.dart\';\n'
-            '\n'
-            'mixin FooProps on UiProps {}\n'
-            '\n'
-            'UiFactory<FooProps> Foo = uiFunction(\n'
-            '  (props) {\n'
-            '    return (Dom.div())(\n'
-            '      TestClassIntl.testString1,\n'
-            '      TestClassIntl.testString2,\n'
-            '    );\n'
-            '  },\n'
-            '  _\$FooConfig, //ignore: undefined_identifier\n'
-            ');\n'
-            '\n'
-            'UiFactory<FooProps> Bar = uiFunction(\n'
-            '  (props) {\n'
-            '    //ignore_statement: intl_message_migration\n'
-            '    return (Dom.div())(\n'
-            '      \'testString1\',\n'
-            '      \'testString2\',\n'
-            '    );\n'
-            '  },\n'
-            '  _\$FooConfig, //ignore: undefined_identifier\n'
-            ');\n'
-            '';
-
-        await testSuggestor(
-          input: source,
-          expectedOutput: output,
-        );
-      });
-
       test('Ignore file with ignore comment', () async {
         final source = '''
             //ignore_file: intl_message_migration

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -14,18 +14,16 @@
 
 @TestOn('vm')
 import 'package:analyzer/dart/analysis/utilities.dart';
-import 'package:analyzer/dart/ast/token.dart';
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:over_react_codemod/src/constants.dart';
 import 'package:over_react_codemod/src/executables/dependency_validator_ignore.dart';
-
+import 'package:over_react_codemod/src/react16_suggestors/react16_utilities.dart';
+import 'package:over_react_codemod/src/util.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:source_span/source_span.dart';
 import 'package:test/test.dart';
-
-import 'package:over_react_codemod/src/constants.dart';
-import 'package:over_react_codemod/src/react16_suggestors/react16_utilities.dart';
-import 'package:over_react_codemod/src/util.dart';
 
 void main() {
   group('Utils', () {
@@ -48,6 +46,11 @@ void main() {
       test('undefinedIdentifier', () {
         expect(buildIgnoreComment(undefinedIdentifier: true),
             '// ignore: undefined_identifier');
+      });
+
+      test('intlMessageMigration', () {
+        expect(buildIgnoreComment(intlMessageMigration: true),
+            '// ignore: intl_message_migration');
       });
 
       test('uriHasNotBeenGenerated', () {


### PR DESCRIPTION
## Motivation
  Need the ability to ignore lines in for intl migration

## Changes
  Resolves issue with this functionality where it was inconsistent.

#### Release Notes
Fixes issue where intl_message_migration ignore comments weren't being ignored

### QA Checklist
- [X] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct