### PR TITLE
INTL-1294: Implement ignore comments for const strings

### DIFF
--- a/lib/src/intl_suggestors/constants.dart
+++ b/lib/src/intl_suggestors/constants.dart
@@ -15,3 +15,6 @@ const propsToCheck = [
   'tooltipContent',
   'value',
 ];
+
+const ignoreStatement = 'ignore_statement: intl_message_migration';
+const ignoreFile = 'ignore_file: intl_message_migration';

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -305,3 +305,32 @@ enum PackageType {
   dartCore,
   package,
 }
+
+// recursive function to if previous node is ignore comment until we come to the previous ";"
+// limit
+bool isIgnoreCommentBeforePreviousTerminator(Token token, {int limit = 128}) {
+  if (limit == 0) {
+    return false;
+  }
+
+  if ('$token' == ';') {
+    return false;
+  }
+
+  if (token.precedingComments != null &&
+      (token.precedingComments?.value().contains(ignoreStatement) ?? false)) {
+    return true;
+  } else {
+    return token.previous != null &&
+        isIgnoreCommentBeforePreviousTerminator(token.previous!,
+            limit: limit - 1);
+  }
+}
+
+// TODO: Could we do a better job of this by finding all the ignore comments in the file and then
+// figuring out what they apply to? See e.g. https://github.com/dart-lang/sdk/blob/cc18b250ae886f556fe1d5a7962894c86f5b7be1/pkg/analyzer/lib/src/ignore_comments/ignore_info.dart#L138
+// and its uses.
+bool isLineIgnored(AstNode node) =>
+    isIgnoreCommentBeforePreviousTerminator(node.beginToken);
+
+bool isFileIgnored(String fileContents) => fileContents.contains(ignoreFile);

--- a/test/intl_suggestors/constant_migrator_test.dart
+++ b/test/intl_suggestors/constant_migrator_test.dart
@@ -71,6 +71,53 @@ void main() {
         expect(messages.messageContents(), expectedFileContent);
       });
 
+      test('ignored standalone constant', () async {
+        var input = '''
+            // ignore_statement: intl_message_migration
+            const foo = 'I am a user-visible constant';
+            ''';
+        await testSuggestor(
+          input: input,
+          expectedOutput: input,
+        );
+        final expectedFileContent = '';
+        expect(messages.messageContents(), expectedFileContent);
+      });
+
+      test('ignore one but not the second', () async {
+        var input = '''
+            // ignore_statement: intl_message_migration
+            const foo = 'I am a user-visible constant';
+            const bar = 'Me too!';
+            ''';
+        await testSuggestor(
+          input: input,
+          expectedOutput: '''
+            // ignore_statement: intl_message_migration
+            const foo = 'I am a user-visible constant';
+            final String bar = TestClassIntl.bar;
+            ''',
+        );
+        final expectedFileContent =
+            '\n  static String get bar => Intl.message(\'Me too!\', name: \'TestClassIntl_bar\');\n';
+        expect(messages.messageContents(), expectedFileContent);
+      });
+
+      test('ignored standalone constant in file', () async {
+        var input = '''
+            // ignore_file: intl_message_migration
+            var x = 4;
+            var y = x == 5 ? x : 42;
+            const foo = 'I am a user-visible constant';
+            ''';
+        await testSuggestor(
+          input: input,
+          expectedOutput: input,
+        );
+        final expectedFileContent = '';
+        expect(messages.messageContents(), expectedFileContent);
+      });
+
       test('SCREAMING_CAPS_ARE_IGNORED', () async {
         await testSuggestor(
           input: '''

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -1420,6 +1420,69 @@ void main() {
         );
       });
 
+      test('Ignore statement with ignore comment with leading spaces',
+          () async {
+        final source = 'import \'package:over_react/over_react.dart\';\n'
+            '\n'
+            'mixin FooProps on UiProps {}\n'
+            '\n'
+            'UiFactory<FooProps> Foo = uiFunction(\n'
+            '  (props) {\n'
+            '    // ignore_statement: intl_message_migration \n'
+            '    const String uploaderAutomationId = \'Shell.Rich.Body.Uploader\';'
+            '    // ignore_statement: intl_message_migration \n'
+            '    return (Dom.div())(\n'
+            '      \'testString1\',\n'
+            '      uploaderAutomationId,\n'
+            '    );\n'
+            '  },\n'
+            '  _\$FooConfig, //ignore: undefined_identifier\n'
+            ');\n'
+            '\n'
+            'UiFactory<FooProps> Bar = uiFunction(\n'
+            '  (props) {\n'
+            '    return (Dom.div())(\n'
+            '      \'testString1\',\n'
+            '      \'testString2\',\n'
+            '    );\n'
+            '  },\n'
+            '  _\$FooConfig, //ignore: undefined_identifier\n'
+            ');\n'
+            '';
+        final output = 'import \'package:over_react/over_react.dart\';\n'
+            '\n'
+            'mixin FooProps on UiProps {}\n'
+            '\n'
+            'UiFactory<FooProps> Foo = uiFunction(\n'
+            '  (props) {\n'
+            '    // ignore_statement: intl_message_migration \n'
+            '    const String uploaderAutomationId = \'Shell.Rich.Body.Uploader\';'
+            '    // ignore_statement: intl_message_migration \n'
+            '    return (Dom.div())(\n'
+            '      \'testString1\',\n'
+            '      uploaderAutomationId,\n'
+            '    );\n'
+            '  },\n'
+            '  _\$FooConfig, //ignore: undefined_identifier\n'
+            ');\n'
+            '\n'
+            'UiFactory<FooProps> Bar = uiFunction(\n'
+            '  (props) {\n'
+            '    return (Dom.div())(\n'
+            '      TestClassIntl.testString1,\n'
+            '      TestClassIntl.testString2,\n'
+            '    );\n'
+            '  },\n'
+            '  _\$FooConfig, //ignore: undefined_identifier\n'
+            ');\n'
+            '';
+
+        await testSuggestor(
+          input: source,
+          expectedOutput: output,
+        );
+      });
+
       test('Ignore file with ignore comment', () async {
         final source = '''
             //ignore_file: intl_message_migration


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Ignore comments did not work at all for const strings, because those are done by a separate migrator.

## Changes
  <!-- What this PR changes to fix the problem. -->
Extract the code for ignore comments, tidy up very slightly, and implement for ConstantStringMigrator. Add tests.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
