### PR TITLE
INTL-1363 : Give a better error message when something in the intl file is not a method

### DIFF
--- a/lib/src/intl_suggestors/message_parser.dart
+++ b/lib/src/intl_suggestors/message_parser.dart
@@ -49,8 +49,14 @@ class MessageParser {
       rethrow;
     }
     var intlClass = parsed.unit.declarations.first as ClassDeclaration;
+    var allDeclarations = intlClass.members.toList();
+    for (var decl in allDeclarations) {
+      if (decl is! MethodDeclaration) {
+        throw FormatException('Invalid member, not a method declaration: "$decl"');
+      }
+    }
     var methodDeclarations =
-        intlClass.members.toList().cast<MethodDeclaration>();
+        allDeclarations.cast<MethodDeclaration>();
     methods = [
       for (var declaration in methodDeclarations)
         Method(declaration.name.name, messageText(declaration),


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
If you declare something as a field, which people do, then the codemod crashes trying to parse it.
You're not allowed to put fields in there. Or at least we don't want to allow it. But at least make it tell you which declaration was the problem.

## Changes
  <!-- What this PR changes to fix the problem. -->
Add a print statement and an explicit throw rather than crashing on a cast error without telling you the problem declaration.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
