### PR TITLE
INTL-231: Try checking for ignore lines within components

### DIFF
--- a/lib/src/intl_suggestors/intl_migrator.dart
+++ b/lib/src/intl_suggestors/intl_migrator.dart
@@ -93,7 +93,7 @@ class ConstantStringMigrator extends GeneralizingAstVisitor
   ConstantStringMigrator(this._className, this._messages);
 
   bool shouldMigrate(VariableDeclaration node) {
-    if (isLineIgnored(node)) return false;
+    if (isStatementIgnored(node)) return false;
     if (isFileIgnored(this.context.sourceText)) return false;
     return true;
   }
@@ -176,7 +176,7 @@ class IntlMigrator extends ComponentUsageMigrator {
   @override
   bool shouldMigrateUsage(FluentComponentUsage usage) {
     // TODO: Handle adjacent strings with an interpolation.
-    if (isLineIgnored(usage.node)) return false;
+    if (isStatementIgnored(usage.node)) return false;
     if (isFileIgnored(this.context.sourceText)) return false;
 
     return usage.cascadedProps.any((prop) =>

--- a/lib/src/intl_suggestors/message_parser.dart
+++ b/lib/src/intl_suggestors/message_parser.dart
@@ -52,11 +52,11 @@ class MessageParser {
     var allDeclarations = intlClass.members.toList();
     for (var decl in allDeclarations) {
       if (decl is! MethodDeclaration) {
-        throw FormatException('Invalid member, not a method declaration: "$decl"');
+        throw FormatException(
+            'Invalid member, not a method declaration: "$decl"');
       }
     }
-    var methodDeclarations =
-        allDeclarations.cast<MethodDeclaration>();
+    var methodDeclarations = allDeclarations.cast<MethodDeclaration>();
     methods = [
       for (var declaration in methodDeclarations)
         Method(declaration.name.name, messageText(declaration),
@@ -127,8 +127,16 @@ class MessageParser {
   /// The invocation of the internal Intl method. That is, the part after the
   /// '=>'.  We know there's only ever one. Used for determining what sort of
   /// method this is message/plural/select/formattedMessage.
-  MethodInvocation intlMethodInvocation(MethodDeclaration method) =>
-      method.body.childEntities.toList()[1] as MethodInvocation;
+  MethodInvocation intlMethodInvocation(MethodDeclaration method) {
+    var invocation = method.body.childEntities.toList()[1];
+    if (invocation is MethodInvocation) {
+      return invocation;
+    } else {
+      print('ERROR: Invalid Intl method: $method');
+      // We expect this to throw
+      return invocation as MethodInvocation;
+    }
+  }
 
   /// The message text for an Intl method, that is to say the first argument
   /// of the method. We expect [method] to be a declaration of the form

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -93,6 +93,7 @@ bool isValidStringLiteralProp(PropAssignment prop) {
   if (excludeKnownBadCases(prop, prop.name.name)) return false;
   if (excludeUnlikelyExpressions(prop, prop.name.name)) return false;
   if (!isValidStringLiteralNode(prop.rightHandSide)) return false;
+  if (isLineIgnored(prop.node)) return false;
   return true;
 }
 // -- End Node Validation --

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -85,6 +85,7 @@ bool isValidStringInterpolationProp(PropAssignment prop) {
   if (excludeKnownBadCases(prop, prop.name.name)) return false;
   if (excludeUnlikelyExpressions(prop, prop.name.name)) return false;
   if (!isValidStringInterpolationNode(prop.rightHandSide)) return false;
+  if (isLineIgnored(prop.node)) return false;
   return true;
 }
 
@@ -331,7 +332,16 @@ bool isIgnoreCommentBeforePreviousTerminator(Token token, {int limit = 128}) {
 // TODO: Could we do a better job of this by finding all the ignore comments in the file and then
 // figuring out what they apply to? See e.g. https://github.com/dart-lang/sdk/blob/cc18b250ae886f556fe1d5a7962894c86f5b7be1/pkg/analyzer/lib/src/ignore_comments/ignore_info.dart#L138
 // and its uses.
-bool isLineIgnored(AstNode node) =>
+bool isStatementIgnored(AstNode node) =>
     isIgnoreCommentBeforePreviousTerminator(node.beginToken);
+
+/// Attempt to determine if this single line is being ignored within a
+/// statement, which is probably a component invocation or other complex
+/// construct.
+///
+/// We assume that the comment is immediately before in terms of tokens, which
+/// is a little fragile, but better than nothing.
+bool isLineIgnored(AstNode node) =>
+    isIgnoreCommentBeforePreviousTerminator(node.beginToken, limit: 1);
 
 bool isFileIgnored(String fileContents) => fileContents.contains(ignoreFile);

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -1420,6 +1420,51 @@ void main() {
         );
       });
 
+      test('Ignore line within a component', () async {
+        final source = '''
+import 'package:over_react/over_react.dart';
+            
+mixin FooProps on UiProps {}
+          
+  UiFactory<FooProps> Bar = uiFunction(
+    (props) {
+      return (Dom.div()
+        ..value='foo'
+        //ignore_statement: intl_message_migration
+        ..value='bar'
+        ..title='qux')(
+         'testString1',
+        );
+    },
+    _\$FooConfig, //ignore: undefined_identifier
+  );
+''';
+
+        final output = '''
+import 'package:over_react/over_react.dart';
+            
+mixin FooProps on UiProps {}
+          
+  UiFactory<FooProps> Bar = uiFunction(
+    (props) {
+      return (Dom.div()
+        ..value=TestClassIntl.foo
+        //ignore_statement: intl_message_migration
+        ..value='bar'
+        ..title=TestClassIntl.qux)(
+         TestClassIntl.testString1,
+        );
+    },
+    _\$FooConfig, //ignore: undefined_identifier
+  );
+''';
+
+        await testSuggestor(
+          input: source,
+          expectedOutput: output,
+        );
+      });
+
       test('Ignore statement with ignore comment with leading spaces',
           () async {
         final source = 'import \'package:over_react/over_react.dart\';\n'


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Ignore comments of the form 
```
(mui.MenuItem()
                ..component = Dom.div.elementType
                // ignore_statement: intl_message_migration
               ..value = 'audit-info'
```
don't work because we start looking for the ignore comment ahead of the full expression. Try looking for them ahead of the line as well. We don't want it to trigger on other lines in the sequence of calls, e.g.

```
(mui.MenuItem()
                ..component = Dom.div.elementType
                // ignore_statement: intl_message_migration
               ..value = 'audit-info'
               ..title = 'some translateable string'
```
so only look a depth of one token back. That probably won't catch every condition, but it's better than nothing and shouldn't have too many bad cases if it only looks back one.

## Changes
  <!-- What this PR changes to fix the problem. -->

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
