### PR TITLE
Limit meta to avoid 1.10.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   collection: ^1.15.0
   glob: ^2.0.1
   logging: ^1.0.1
-  meta: ^1.7.0
+  meta: '>=1.7.0 <1.10.0'
   path: ^1.8.0
   pub_semver: ^2.0.0
   source_span: ^1.8.1


### PR DESCRIPTION
## Motivation

meta 1.10.0 was just released and breaks things

## Changes

Change the max allowed version to avoid the problem version.
