### PR TITLE
Avoid meta 1.10.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   collection: ^1.15.0
   glob: ^2.0.1
   logging: ^1.0.1
-  meta: '>=1.7.0 <1.10.0'
+  meta: '>=1.7.0  <1.10.0'
   path: ^1.8.0
   pub_semver: ^2.0.0
   source_span: ^1.8.1
@@ -47,4 +47,5 @@ executables:
   intl_message_migration:
 dependency_validator:
   ignore:
+    - meta
     - mockito


### PR DESCRIPTION
Summary
---
This is a batch change to apply a dependency range pin to the meta package
in order to avoid a "bad release". That version causes nearly all of our builds to
fail (anything on analyzer < 5).
So restricting the version range to <1.10.0 works around the issue until we
can upgrade to analyzer 5.

For more info, visit `#lang-dart` in Slack.

[_Created by Sourcegraph batch change `Workiva/avoid_meta_1_10_0`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/avoid_meta_1_10_0)