### PR TITLE
INTL-1332: Add import smarts to codemod

### DIFF
--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -48,8 +48,8 @@ Stream<Patch> intlImporter(
 
   final importFormat = decideImportFormat(hasPackageImport, hasRelativeImports);
 
-  final importStatement = importFormat == 'package' ? "import '$intlUri'; "
-                                                    : "import './intl/${projectName}_intl.dart'; ";
+  final importStatement = importFormat == 'package' ? insertInfo.leadingNewlines + "import '$intlUri'; " + insertInfo.trailingNewlines
+                                                    : insertInfo.leadingNewlines + "import './intl/${projectName}_intl.dart'; " + insertInfo.trailingNewlines;
   yield Patch(
       importStatement,
       insertInfo.offset,

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -31,7 +31,7 @@ Stream<Patch> intlImporter(
   // Parts that have not been generated can show up as `exists = false` but also `isPart = false`,
   // so using the unitResults is a little trickier than using the libraryElement to get it.
   final mainLibraryUnitResult = libraryResult.units.singleWhere((unitResult) =>
-  unitResult.unit.declaredElement ==
+      unitResult.unit.declaredElement ==
       libraryResult.element.definingCompilationUnit);
 
   final needsIntlImport = libraryResult.units
@@ -41,23 +41,30 @@ Stream<Patch> intlImporter(
 
   if (!needsIntlImport) return;
 
-  final intlUri = 'package:${projectName}/src/intl/${projectName}_intl.dart';
-  final currentDirectory = Directory.current;
-  final intlDirectory = path.join(currentDirectory.path, 'lib/src/intl/${projectName}_intl.dart');
-  final relativePathToIntlDir = path.relative(intlDirectory, from: path.current);
-  final levelsUp = List<String>.generate(relativePathToIntlDir.split(path.separator).length, (_) => '..').join('/');
-  final relativeImportPath = '${levelsUp}/src/intl/${projectName}_intl.dart';
+  final intlFilePath = '/src/intl/${projectName}_intl.dart';
+  final intlUri = 'package:${projectName}' + intlFilePath;
+  final intlDirectory = path.join(Directory.current.path, intlFilePath);
+  final relativePathToIntlDir =
+      path.relative(intlDirectory, from: Directory.current.path);
   final insertInfo = _insertionLocationForPackageImport(
       intlUri, mainLibraryUnitResult.unit, mainLibraryUnitResult.lineInfo);
-  final importStatement = insertInfo.usePackageImports  ? packageImport(intlUri, insertInfo) : relativeImport(relativeImportPath, insertInfo);
-  yield Patch(
-      importStatement,
-      insertInfo.offset,
-      insertInfo.offset);
+
+  final importStatement = insertInfo.usePackageImports
+      ? packageImport(intlUri, insertInfo)
+      : relativeImport(relativePathToIntlDir, insertInfo);
+
+  yield Patch(importStatement, insertInfo.offset, insertInfo.offset);
 }
 
-String packageImport(String intlUri, _InsertionLocation insertInfo) => insertInfo.leadingNewlines + "import '$intlUri';" + insertInfo.trailingNewlines;
-String relativeImport(String relativeImportPath, _InsertionLocation insertInfo) =>  insertInfo.leadingNewlines + "import '$relativeImportPath';" + insertInfo.trailingNewlines;
+String packageImport(String intlUri, _InsertionLocation insertInfo) =>
+    insertInfo.leadingNewlines +
+    "import '$intlUri';" +
+    insertInfo.trailingNewlines;
+String relativeImport(
+        String relativeImportPath, _InsertionLocation insertInfo) =>
+    insertInfo.leadingNewlines +
+    "import '$relativeImportPath';" +
+    insertInfo.trailingNewlines;
 
 class _InsertionLocation {
   final int offset;
@@ -66,11 +73,11 @@ class _InsertionLocation {
   final bool usePackageImports;
 
   _InsertionLocation(
-      this.offset, {
-        this.leadingNewlineCount = 0,
-        this.trailingNewlineCount = 0,
-        this.usePackageImports = false,
-      });
+    this.offset, {
+    this.leadingNewlineCount = 0,
+    this.trailingNewlineCount = 0,
+    this.usePackageImports = false,
+  });
 
   String get leadingNewlines => '\n' * leadingNewlineCount;
 
@@ -87,11 +94,11 @@ _InsertionLocation _insertionLocationForPackageImport(
   final firstImport = imports.firstOrNull;
 
   final dartImports =
-  imports.where((i) => i.uriContent?.startsWith('dart:') ?? false);
+      imports.where((i) => i.uriContent?.startsWith('dart:') ?? false);
   final lastDartImport = dartImports.lastOrNull;
 
   final packageImports =
-  imports.where((i) => i.uriContent?.startsWith('package:') ?? false);
+      imports.where((i) => i.uriContent?.startsWith('package:') ?? false);
   final firstPackageImportSortedAfterNewImport = packageImports
       .where((i) => i.uriContent!.compareTo(importUri) > 0)
       .firstOrNull;
@@ -151,6 +158,5 @@ _InsertionLocation _insertionLocationForPackageImport(
       insertAfter ? relativeNode.end : relativeNode.offset,
       leadingNewlineCount: insertAfter ? (inOwnSection ? 2 : 1) : 0,
       trailingNewlineCount: !insertAfter ? (inOwnSection ? 2 : 1) : 0,
-      usePackageImports: hasPackageImports
-  );
+      usePackageImports: hasPackageImports);
 }

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -153,7 +153,6 @@ _InsertionLocation _insertionLocationForPackageImport(
     return true;
   });
 
-
   return _InsertionLocation(
       insertAfter ? relativeNode.end : relativeNode.offset,
       leadingNewlineCount: insertAfter ? (inOwnSection ? 2 : 1) : 0,

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -49,7 +49,7 @@ Stream<Patch> intlImporter(
   final importFormat = decideImportFormat(hasPackageImport, hasRelativeImports);
 
   final importStatement = importFormat == 'package' ? insertInfo.leadingNewlines + "import '$intlUri'; " + insertInfo.trailingNewlines
-                                                    : insertInfo.leadingNewlines + "import '../intl/${projectName}_intl.dart'; " + insertInfo.trailingNewlines;
+                                                    : insertInfo.leadingNewlines + "import '../../intl/${projectName}_intl.dart'; " + insertInfo.trailingNewlines;
   yield Patch(
       importStatement,
       insertInfo.offset,

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -113,7 +113,7 @@ _InsertionLocation _insertionLocationForPackageImport(
   final AstNode relativeNode;
   final bool insertAfter;
   final bool inOwnSection;
-  bool hasPackageImports = true;
+  bool hasOnlyPackageImports = true;
   if (firstPackageImportSortedAfterNewImport != null) {
     relativeNode = firstPackageImportSortedAfterNewImport;
     insertAfter = false;
@@ -141,20 +141,21 @@ _InsertionLocation _insertionLocationForPackageImport(
     // No directive to insert relative to; insert before the first member or
     // at the beginning of the file.
     return _InsertionLocation(unit.declarations.firstOrNull?.offset ?? 0,
-        trailingNewlineCount: 2, usePackageImports: hasPackageImports);
+        trailingNewlineCount: 2, usePackageImports: hasOnlyPackageImports);
   }
 
-  for (final importDirective in imports) {
+  hasOnlyPackageImports = !imports.any((importDirective) {
     final uriContent = importDirective.uri.stringValue;
     if (uriContent != null) {
       final uri = Uri.parse(uriContent);
-      hasPackageImports = !imports.any((importDirective) =>
-          uri != null && uri.scheme != 'package' && uri.scheme != 'dart:');
+      return uri != null && uri.scheme != 'package' && uri.scheme != 'dart:';
     }
-  }
+    return false;
+  });
+
   return _InsertionLocation(
       insertAfter ? relativeNode.end : relativeNode.offset,
       leadingNewlineCount: insertAfter ? (inOwnSection ? 2 : 1) : 0,
       trailingNewlineCount: !insertAfter ? (inOwnSection ? 2 : 1) : 0,
-      usePackageImports: hasPackageImports);
+      usePackageImports: hasOnlyPackageImports);
 }

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -60,6 +60,7 @@ String packageImport(String intlUri, _InsertionLocation insertInfo) =>
     insertInfo.leadingNewlines +
     "import '$intlUri';" +
     insertInfo.trailingNewlines;
+
 String relativeImport(
         String relativeImportPath, _InsertionLocation insertInfo) =>
     insertInfo.leadingNewlines +
@@ -136,10 +137,11 @@ _InsertionLocation _insertionLocationForPackageImport(
     insertAfter = firstNonImportDirective is LibraryDirective;
     inOwnSection = true;
   } else {
+    bool hasPackageImports = true;
     // No directive to insert relative to; insert before the first member or
     // at the beginning of the file.
     return _InsertionLocation(unit.declarations.firstOrNull?.offset ?? 0,
-        trailingNewlineCount: 2);
+        trailingNewlineCount: 2, usePackageImports: hasPackageImports);
   }
   bool hasPackageImports = true;
 

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -31,7 +31,7 @@ Stream<Patch> intlImporter(
   // Parts that have not been generated can show up as `exists = false` but also `isPart = false`,
   // so using the unitResults is a little trickier than using the libraryElement to get it.
   final mainLibraryUnitResult = libraryResult.units.singleWhere((unitResult) =>
-      unitResult.unit.declaredElement ==
+  unitResult.unit.declaredElement ==
       libraryResult.element.definingCompilationUnit);
 
   final needsIntlImport = libraryResult.units
@@ -42,10 +42,10 @@ Stream<Patch> intlImporter(
   if (!needsIntlImport) return;
 
   final intlFilePath = '/src/intl/${projectName}_intl.dart';
-  final intlUri = 'package:${projectName}$intlFilePath';
+  final intlUri = 'package:${projectName}' + intlFilePath;
   final intlDirectory = path.join(Directory.current.path, intlFilePath);
   final relativePathToIntlDir =
-      path.relative(intlDirectory, from: Directory.current.path);
+  path.relative(intlDirectory, from: Directory.current.path);
   final insertInfo = _insertionLocationForPackageImport(
       intlUri, mainLibraryUnitResult.unit, mainLibraryUnitResult.lineInfo);
 
@@ -58,14 +58,14 @@ Stream<Patch> intlImporter(
 
 String packageImport(String intlUri, _InsertionLocation insertInfo) =>
     insertInfo.leadingNewlines +
-    "import '$intlUri';" +
-    insertInfo.trailingNewlines;
+        "import '$intlUri';" +
+        insertInfo.trailingNewlines;
 
 String relativeImport(
-        String relativeImportPath, _InsertionLocation insertInfo) =>
+    String relativeImportPath, _InsertionLocation insertInfo) =>
     insertInfo.leadingNewlines +
-    "import '$relativeImportPath';" +
-    insertInfo.trailingNewlines;
+        "import '$relativeImportPath';" +
+        insertInfo.trailingNewlines;
 
 class _InsertionLocation {
   final int offset;
@@ -74,11 +74,11 @@ class _InsertionLocation {
   final bool usePackageImports;
 
   _InsertionLocation(
-    this.offset, {
-    this.leadingNewlineCount = 0,
-    this.trailingNewlineCount = 0,
-    this.usePackageImports = false,
-  });
+      this.offset, {
+        this.leadingNewlineCount = 0,
+        this.trailingNewlineCount = 0,
+        this.usePackageImports = false,
+      });
 
   String get leadingNewlines => '\n' * leadingNewlineCount;
 
@@ -95,11 +95,11 @@ _InsertionLocation _insertionLocationForPackageImport(
   final firstImport = imports.firstOrNull;
 
   final dartImports =
-      imports.where((i) => i.uriContent?.startsWith('dart:') ?? false);
+  imports.where((i) => i.uriContent?.startsWith('dart:') ?? false);
   final lastDartImport = dartImports.lastOrNull;
 
   final packageImports =
-      imports.where((i) => i.uriContent?.startsWith('package:') ?? false);
+  imports.where((i) => i.uriContent?.startsWith('package:') ?? false);
   final firstPackageImportSortedAfterNewImport = packageImports
       .where((i) => i.uriContent!.compareTo(importUri) > 0)
       .firstOrNull;

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -42,7 +42,7 @@ Stream<Patch> intlImporter(
   if (!needsIntlImport) return;
 
   final intlFilePath = '/src/intl/${projectName}_intl.dart';
-  final intlUri = 'package:${projectName}$intlFilePath';
+  final intlUri = 'package:${projectName}' + intlFilePath;
   final intlDirectory = path.join(Directory.current.path, intlFilePath);
   final relativePathToIntlDir =
       path.relative(intlDirectory, from: Directory.current.path);

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -148,7 +148,8 @@ _InsertionLocation _insertionLocationForPackageImport(
     final uriContent = importDirective.uri.stringValue;
     if (uriContent != null) {
       final uri = Uri.parse(uriContent);
-      hasPackageImports = !imports.any((importDirective) => uri!= null &&  uri.scheme != 'package'  && uri.scheme != 'dart:');
+      hasPackageImports = !imports.any((importDirective) =>
+          uri != null && uri.scheme != 'package' && uri.scheme != 'dart:');
     }
   }
   return _InsertionLocation(
@@ -157,4 +158,3 @@ _InsertionLocation _insertionLocationForPackageImport(
       trailingNewlineCount: !insertAfter ? (inOwnSection ? 2 : 1) : 0,
       usePackageImports: hasPackageImports);
 }
-

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -148,12 +148,11 @@ _InsertionLocation _insertionLocationForPackageImport(
     final uriContent = importDirective.uri.stringValue;
     if (uriContent != null) {
       final uri = Uri.parse(uriContent);
-      return uri != null && uri.scheme != 'package' && uri.scheme != 'dart:';
+      return uri != null && uri.scheme != 'package' && uri.scheme != 'dart';
     }
     return true;
   });
 
-  print(hasOnlyPackageImports);
 
   return _InsertionLocation(
       insertAfter ? relativeNode.end : relativeNode.offset,

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -148,13 +148,13 @@ _InsertionLocation _insertionLocationForPackageImport(
     final uriContent = importDirective.uri.stringValue;
     if (uriContent != null) {
       final uri = Uri.parse(uriContent);
-      if (uri.scheme != 'package') {
+
+      if (uri.scheme != 'package' && uri.scheme != 'dart:') {
         hasPackageImports = false;
         break;
       }
     }
   }
-
   return _InsertionLocation(
       insertAfter ? relativeNode.end : relativeNode.offset,
       leadingNewlineCount: insertAfter ? (inOwnSection ? 2 : 1) : 0,

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -43,7 +43,7 @@ Stream<Patch> intlImporter(
 
   final intlFilePath = '/src/intl/${projectName}_intl.dart';
   final intlUri = 'package:${projectName}' + intlFilePath;
-  final intlDirectory = path.join(Directory.current.path, intlFilePath);
+  final intlDirectory = path.join(context.root, intlFilePath);
   final relativePathToIntlDir =
       path.relative(intlDirectory, from: Directory.current.path);
   final insertInfo = _insertionLocationForPackageImport(

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -42,7 +42,7 @@ Stream<Patch> intlImporter(
   if (!needsIntlImport) return;
 
   final intlFilePath = '/src/intl/${projectName}_intl.dart';
-  final intlUri = 'package:${projectName}' + intlFilePath;
+  final intlUri = 'package:${projectName}$intlFilePath';
   final intlDirectory = path.join(Directory.current.path, intlFilePath);
   final relativePathToIntlDir =
       path.relative(intlDirectory, from: Directory.current.path);

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -31,7 +31,7 @@ Stream<Patch> intlImporter(
   // Parts that have not been generated can show up as `exists = false` but also `isPart = false`,
   // so using the unitResults is a little trickier than using the libraryElement to get it.
   final mainLibraryUnitResult = libraryResult.units.singleWhere((unitResult) =>
-      unitResult.unit.declaredElement ==
+  unitResult.unit.declaredElement ==
       libraryResult.element.definingCompilationUnit);
 
   final needsIntlImport = libraryResult.units
@@ -50,6 +50,8 @@ Stream<Patch> intlImporter(
   final insertInfo = _insertionLocationForPackageImport(
       intlUri, mainLibraryUnitResult.unit, mainLibraryUnitResult.lineInfo);
   final importStatement = insertInfo.usePackageImports  ? packageImport(intlUri, insertInfo) : relativeImport(relativeImportPath, insertInfo);
+  print("importStatement"+importStatement);
+  print(insertInfo.usePackageImports);
   yield Patch(
       importStatement,
       insertInfo.offset,
@@ -66,11 +68,11 @@ class _InsertionLocation {
   final bool usePackageImports;
 
   _InsertionLocation(
-    this.offset, {
-    this.leadingNewlineCount = 0,
-    this.trailingNewlineCount = 0,
-    this.usePackageImports = false,
-  });
+      this.offset, {
+        this.leadingNewlineCount = 0,
+        this.trailingNewlineCount = 0,
+        this.usePackageImports = false,
+      });
 
   String get leadingNewlines => '\n' * leadingNewlineCount;
 
@@ -87,11 +89,11 @@ _InsertionLocation _insertionLocationForPackageImport(
   final firstImport = imports.firstOrNull;
 
   final dartImports =
-      imports.where((i) => i.uriContent?.startsWith('dart:') ?? false);
+  imports.where((i) => i.uriContent?.startsWith('dart:') ?? false);
   final lastDartImport = dartImports.lastOrNull;
 
   final packageImports =
-      imports.where((i) => i.uriContent?.startsWith('package:') ?? false);
+  imports.where((i) => i.uriContent?.startsWith('package:') ?? false);
   final firstPackageImportSortedAfterNewImport = packageImports
       .where((i) => i.uriContent!.compareTo(importUri) > 0)
       .firstOrNull;
@@ -148,9 +150,9 @@ _InsertionLocation _insertionLocationForPackageImport(
   }
 
   return _InsertionLocation(
-    insertAfter ? relativeNode.end : relativeNode.offset,
-    leadingNewlineCount: insertAfter ? (inOwnSection ? 2 : 1) : 0,
-    trailingNewlineCount: !insertAfter ? (inOwnSection ? 2 : 1) : 0,
-    usePackageImports: hasPackageImports
+      insertAfter ? relativeNode.end : relativeNode.offset,
+      leadingNewlineCount: insertAfter ? (inOwnSection ? 2 : 1) : 0,
+      trailingNewlineCount: !insertAfter ? (inOwnSection ? 2 : 1) : 0,
+      usePackageImports: hasPackageImports
   );
 }

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -147,7 +147,7 @@ _InsertionLocation _insertionLocationForPackageImport(
 
 
   for (final importDirective in imports) {
-    final uriContent = importDirective.uriContent;
+    final uriContent = importDirective.uri.stringValue;
     if (uriContent != null) {
       final uri = Uri.parse(uriContent);
       if (uri.scheme != 'package') {

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -148,11 +148,7 @@ _InsertionLocation _insertionLocationForPackageImport(
     final uriContent = importDirective.uri.stringValue;
     if (uriContent != null) {
       final uri = Uri.parse(uriContent);
-
-      if (uri.scheme != 'package' && uri.scheme != 'dart:') {
-        hasPackageImports = false;
-        break;
-      }
+      hasPackageImports = !imports.any((importDirective) => uri!= null &&  uri.scheme != 'package'  && uri.scheme != 'dart:');
     }
   }
   return _InsertionLocation(
@@ -161,3 +157,4 @@ _InsertionLocation _insertionLocationForPackageImport(
       trailingNewlineCount: !insertAfter ? (inOwnSection ? 2 : 1) : 0,
       usePackageImports: hasPackageImports);
 }
+

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -31,7 +31,7 @@ Stream<Patch> intlImporter(
   // Parts that have not been generated can show up as `exists = false` but also `isPart = false`,
   // so using the unitResults is a little trickier than using the libraryElement to get it.
   final mainLibraryUnitResult = libraryResult.units.singleWhere((unitResult) =>
-  unitResult.unit.declaredElement ==
+      unitResult.unit.declaredElement ==
       libraryResult.element.definingCompilationUnit);
 
   final needsIntlImport = libraryResult.units
@@ -45,7 +45,7 @@ Stream<Patch> intlImporter(
   final intlUri = 'package:${projectName}' + intlFilePath;
   final intlDirectory = path.join(Directory.current.path, intlFilePath);
   final relativePathToIntlDir =
-  path.relative(intlDirectory, from: Directory.current.path);
+      path.relative(intlDirectory, from: Directory.current.path);
   final insertInfo = _insertionLocationForPackageImport(
       intlUri, mainLibraryUnitResult.unit, mainLibraryUnitResult.lineInfo);
 
@@ -58,14 +58,14 @@ Stream<Patch> intlImporter(
 
 String packageImport(String intlUri, _InsertionLocation insertInfo) =>
     insertInfo.leadingNewlines +
-        "import '$intlUri';" +
-        insertInfo.trailingNewlines;
+    "import '$intlUri';" +
+    insertInfo.trailingNewlines;
 
 String relativeImport(
-    String relativeImportPath, _InsertionLocation insertInfo) =>
+        String relativeImportPath, _InsertionLocation insertInfo) =>
     insertInfo.leadingNewlines +
-        "import '$relativeImportPath';" +
-        insertInfo.trailingNewlines;
+    "import '$relativeImportPath';" +
+    insertInfo.trailingNewlines;
 
 class _InsertionLocation {
   final int offset;
@@ -74,11 +74,11 @@ class _InsertionLocation {
   final bool usePackageImports;
 
   _InsertionLocation(
-      this.offset, {
-        this.leadingNewlineCount = 0,
-        this.trailingNewlineCount = 0,
-        this.usePackageImports = false,
-      });
+    this.offset, {
+    this.leadingNewlineCount = 0,
+    this.trailingNewlineCount = 0,
+    this.usePackageImports = false,
+  });
 
   String get leadingNewlines => '\n' * leadingNewlineCount;
 
@@ -138,13 +138,11 @@ _InsertionLocation _insertionLocationForPackageImport(
     insertAfter = firstNonImportDirective is LibraryDirective;
     inOwnSection = true;
   } else {
-
     // No directive to insert relative to; insert before the first member or
     // at the beginning of the file.
     return _InsertionLocation(unit.declarations.firstOrNull?.offset ?? 0,
         trailingNewlineCount: 2, usePackageImports: hasPackageImports);
   }
-
 
   for (final importDirective in imports) {
     final uriContent = importDirective.uri.stringValue;

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -50,8 +50,6 @@ Stream<Patch> intlImporter(
   final insertInfo = _insertionLocationForPackageImport(
       intlUri, mainLibraryUnitResult.unit, mainLibraryUnitResult.lineInfo);
   final importStatement = insertInfo.usePackageImports  ? packageImport(intlUri, insertInfo) : relativeImport(relativeImportPath, insertInfo);
-  print("importStatement"+importStatement);
-  print(insertInfo.usePackageImports);
   yield Patch(
       importStatement,
       insertInfo.offset,

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -113,7 +113,7 @@ _InsertionLocation _insertionLocationForPackageImport(
   final AstNode relativeNode;
   final bool insertAfter;
   final bool inOwnSection;
-  bool hasOnlyPackageImports = true;
+  bool hasOnlyPackageImports;
   if (firstPackageImportSortedAfterNewImport != null) {
     relativeNode = firstPackageImportSortedAfterNewImport;
     insertAfter = false;
@@ -141,7 +141,7 @@ _InsertionLocation _insertionLocationForPackageImport(
     // No directive to insert relative to; insert before the first member or
     // at the beginning of the file.
     return _InsertionLocation(unit.declarations.firstOrNull?.offset ?? 0,
-        trailingNewlineCount: 2, usePackageImports: hasOnlyPackageImports);
+        trailingNewlineCount: 2, usePackageImports: true);
   }
 
   hasOnlyPackageImports = !imports.any((importDirective) {
@@ -150,8 +150,10 @@ _InsertionLocation _insertionLocationForPackageImport(
       final uri = Uri.parse(uriContent);
       return uri != null && uri.scheme != 'package' && uri.scheme != 'dart:';
     }
-    return false;
+    return true;
   });
+
+  print(hasOnlyPackageImports);
 
   return _InsertionLocation(
       insertAfter ? relativeNode.end : relativeNode.offset,

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -113,6 +113,7 @@ _InsertionLocation _insertionLocationForPackageImport(
   final AstNode relativeNode;
   final bool insertAfter;
   final bool inOwnSection;
+  bool hasPackageImports = true;
   if (firstPackageImportSortedAfterNewImport != null) {
     relativeNode = firstPackageImportSortedAfterNewImport;
     insertAfter = false;
@@ -137,13 +138,13 @@ _InsertionLocation _insertionLocationForPackageImport(
     insertAfter = firstNonImportDirective is LibraryDirective;
     inOwnSection = true;
   } else {
-    bool hasPackageImports = true;
+
     // No directive to insert relative to; insert before the first member or
     // at the beginning of the file.
     return _InsertionLocation(unit.declarations.firstOrNull?.offset ?? 0,
         trailingNewlineCount: 2, usePackageImports: hasPackageImports);
   }
-  bool hasPackageImports = true;
+
 
   for (final importDirective in imports) {
     final uriContent = importDirective.uriContent;

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -49,7 +49,7 @@ Stream<Patch> intlImporter(
   final importFormat = decideImportFormat(hasPackageImport, hasRelativeImports);
 
   final importStatement = importFormat == 'package' ? insertInfo.leadingNewlines + "import '$intlUri'; " + insertInfo.trailingNewlines
-                                                    : insertInfo.leadingNewlines + "import './intl/${projectName}_intl.dart'; " + insertInfo.trailingNewlines;
+                                                    : insertInfo.leadingNewlines + "import '../intl/${projectName}_intl.dart'; " + insertInfo.trailingNewlines;
   yield Patch(
       importStatement,
       insertInfo.offset,
@@ -142,7 +142,7 @@ _InsertionLocation _insertionLocationForPackageImport(
     if(uriContent != null){
       if(uriContent.startsWith('package:')){
         hasPackageImports = true;
-      } else if(uriContent.startsWith('./intl/')){
+      } else if(uriContent.startsWith('../')){
         hasRelativeImports = true;
       }
     }

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -147,8 +147,8 @@ void main() {
         script: script,
         input: expectedOutputFiles(additionalFilesInLib: [
           d.file('more_stuff.dart', /*language=dart*/ '''
-import 'package:test_project/src/intl/test_project_intl.dart';
 import 'package:react_material_ui/react_material_ui.dart' as mui;
+import 'package:test_project/src/intl/test_project_intl.dart';
 
 someMoreStrings() => (mui.Button()
   ..aria.label=TestProjectIntl.orange

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -150,7 +150,7 @@ void main() {
         ], messages: [
           ...defaultMessages,
           ...annotatedMessages,
-        ], intlImport: '${wIntl}/intl_wrapper.dart'),
+        ], intlImport: 'intl/intl.dart'),
         expectedOutput: expectedSecondOutputFiles(
             additionalFilesInLib: [extraOutput()],
             messages: [

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -153,8 +153,8 @@ import 'package:test_project/src/intl/test_project_intl.dart';
 someMoreStrings() => (mui.Button()
   ..aria.label=TestProjectIntl.orange
   ..label=TestProjectIntl.aLongStringwithMultipleLines)
-    (TestProjectIntl.aquamarine,
-     TestProjectIntl.twoAdjacentStringsOnSeparate);
+  (TestProjectIntl.aquamarine,
+   TestProjectIntl.twoAdjacentStringsOnSeparate);
 ''')
         ], messages: [
           ...defaultMessages,

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -82,9 +82,9 @@ void main() {
         script: script,
         input: inputFiles(additionalFilesInLib: [extraInput()]),
         expectedOutput: expectedOutputFiles(
-            additionalFilesInLib: [extraOutput()],
-            messages: [...defaultMessages, ...extraMessages, ...longMessages]
-              ..sort(),
+          additionalFilesInLib: [extraOutput()],
+          messages: [...defaultMessages, ...extraMessages, ...longMessages]
+            ..sort(),
           rmuiVersionConstraint: '^1.1.1',
           intlImport: 'package:test_project/src/intl/test_project_intl.dart',
         ),
@@ -100,12 +100,12 @@ void main() {
           ...annotatedMessages,
         ]),
         expectedOutput: expectedOutputFiles(
-            additionalFilesInLib: [extraOutput()],
-            messages: [
-              ...defaultMessages,
-              ...annotatedMessages,
-              ...longMessages,
-            ]..sort(),
+          additionalFilesInLib: [extraOutput()],
+          messages: [
+            ...defaultMessages,
+            ...annotatedMessages,
+            ...longMessages,
+          ]..sort(),
           rmuiVersionConstraint: '^1.1.1',
           intlImport: 'package:test_project/src/intl/test_project_intl.dart',
         ),
@@ -348,9 +348,9 @@ ${messages.join('\n\n')}
 
 d.DirectoryDescriptor expectedSecondOutputFiles(
     {Iterable<d.Descriptor> additionalFilesInLib = const [],
-      List<String> messages = defaultMessages,
-      String rmuiVersionConstraint = '^1.1.1',
-      String intlImport = '${wIntl}/intl_wrapper.dart'}) {
+    List<String> messages = defaultMessages,
+    String rmuiVersionConstraint = '^1.1.1',
+    String intlImport = '${wIntl}/intl_wrapper.dart'}) {
   return d.dir('project', [
     // Note that the codemod doesn't currently add the intl dependency to the pubspec.
     d.file('pubspec.yaml', /*language=yaml*/ '''
@@ -366,8 +366,8 @@ dependencies:
     d.dir('lib', [
       ...additionalFilesInLib,
       d.file('usage.dart', /*language=dart*/ '''
-import 'package:react_material_ui/react_material_ui.dart' as mui;
 import 'package:test_project/src/intl/test_project_intl.dart';
+import 'package:react_material_ui/react_material_ui.dart' as mui;
 
 usage() => (mui.Button()..aria.label=TestProjectIntl.sortsLater)(TestProjectIntl.literalString);'''),
       d.dir('src', [

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -151,7 +151,7 @@ void main() {
               ...defaultMessages,
               ...annotatedMessages,
               ...longMessages
-            ]..sort()),
+            ]),
         args: ['--yes-to-all']);
 
     testCodemod('Import is updated without other modifications',
@@ -317,8 +317,8 @@ dependencies:
     d.dir('lib', [
       ...additionalFilesInLib,
       d.file('usage.dart', /*language=dart*/ '''
-import 'package:test_project/src/intl/test_project_intl.dart';
 import 'package:react_material_ui/react_material_ui.dart' as mui;
+import 'package:test_project/src/intl/test_project_intl.dart';
 
 usage() => (mui.Button()..aria.label=TestProjectIntl.sortsLater)(TestProjectIntl.literalString);'''),
       d.dir('src', [

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -38,13 +38,13 @@ void main() {
         expectedOutput: inputFiles(),
         expectedExitCode: 0,
         args: ['--help'], body: (out, err) {
-      expect(
-          condenseWhitespace(err),
-          allOf(
-            contains(condenseWhitespace(codemodArgParser.usage)),
-            contains('Migrates literal strings'),
-          ));
-    });
+          expect(
+              condenseWhitespace(err),
+              allOf(
+                contains(condenseWhitespace(codemodArgParser.usage)),
+                contains('Migrates literal strings'),
+              ));
+        });
 
     testCodemod('applies all patches via --yes-to-all,',
         script: script,
@@ -57,8 +57,8 @@ void main() {
         input: expectedOutputFiles(),
         expectedOutput: expectedOutputFiles(),
         args: ['--fail-on-changes'], body: (out, err) {
-      expect(out, contains('No changes needed.'));
-    });
+          expect(out, contains('No changes needed.'));
+        });
 
     testCodemod(
         '--fail-on-changes exits with non-zero when changes needed and does not update files',
@@ -180,8 +180,8 @@ someMoreStrings() => (mui.Button()..aria.label='orange')('aquamarine');''')
         expectedOutput: inputFiles(),
         args: ['--yes-to-all', 'lib/a_part_file.dart'],
         expectedExitCode: 1, body: (out, err) {
-      expect(err, contains('Only part files were specified'));
-    });
+          expect(err, contains('Only part files were specified'));
+        });
   }, tags: 'wsd');
 
   group('limit paths', () {
@@ -242,8 +242,8 @@ with multiple
 
 d.FileDescriptor extraOutput() {
   return d.file('more_stuff.dart',
-      /*language=dart*/ '''import 'package:test_project/src/intl/test_project_intl.dart';
-import 'package:react_material_ui/react_material_ui.dart' as mui;
+      /*language=dart*/ '''import 'package:react_material_ui/react_material_ui.dart' as mui;
+import 'package:test_project/src/intl/test_project_intl.dart';
 
 someMoreStrings() => (mui.Button()
   ..aria.label=TestProjectIntl.orange
@@ -301,9 +301,9 @@ const List<String> defaultMessages = [
 
 d.DirectoryDescriptor expectedOutputFiles(
     {Iterable<d.Descriptor> additionalFilesInLib = const [],
-    List<String> messages = defaultMessages,
-    String rmuiVersionConstraint = '^1.1.1',
-    String intlImport = '${wIntl}/intl_wrapper.dart'}) {
+      List<String> messages = defaultMessages,
+      String rmuiVersionConstraint = '^1.1.1',
+      String intlImport = '${wIntl}/intl_wrapper.dart'}) {
   return d.dir('project', [
     // Note that the codemod doesn't currently add the intl dependency to the pubspec.
     d.file('pubspec.yaml', /*language=yaml*/ '''
@@ -319,8 +319,8 @@ dependencies:
     d.dir('lib', [
       ...additionalFilesInLib,
       d.file('usage.dart', /*language=dart*/ '''
-import 'package:test_project/src/intl/test_project_intl.dart';
 import 'package:react_material_ui/react_material_ui.dart' as mui;
+import 'package:test_project/src/intl/test_project_intl.dart';
 
 usage() => (mui.Button()..aria.label=TestProjectIntl.sortsLater)(TestProjectIntl.literalString);'''),
       d.dir('src', [

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -84,7 +84,10 @@ void main() {
         expectedOutput: expectedOutputFiles(
             additionalFilesInLib: [extraOutput()],
             messages: [...defaultMessages, ...extraMessages, ...longMessages]
-              ..sort()),
+              ..sort(),
+          rmuiVersionConstraint: '^1.1.1',
+          intlImport: '${wIntl}/intl_wrapper.dart',
+        ),
         args: ['--yes-to-all']);
 
     // Test that additional information (desc, meaning) are preserved if we read and then rewrite the file.
@@ -102,9 +105,11 @@ void main() {
               ...defaultMessages,
               ...annotatedMessages,
               ...longMessages,
-            ]..sort()),
+            ]..sort(),
+          rmuiVersionConstraint: '^1.1.1',
+          intlImport: '${wIntl}/intl_wrapper.dart',
+        ),
         args: ['--yes-to-all']);
-
     // We've removed the file for some that were already in the _intl.dart file,
     // and we expect them to be removed.
     testCodemod('Unused messages are removed',
@@ -151,8 +156,11 @@ void main() {
               ...defaultMessages,
               ...annotatedMessages,
               ...longMessages
-            ]..sort()),
-        args: ['--yes-to-all']);
+            ]..sort(),
+          rmuiVersionConstraint: '^1.1.1',
+          intlImport: '${wIntl}/intl_wrapper.dart',
+        ),
+        args: ['--yes-to-all'] );
 
     testCodemod('Import is updated without other modifications',
         script: script,

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -81,7 +81,7 @@ void main() {
     testCodemod('Output is sorted',
         script: script,
         input: inputFiles(additionalFilesInLib: [extraInput()]),
-        expectedOutput: expectedOutputFiles(
+        expectedOutput: expectedSecondOutputFiles(
             additionalFilesInLib: [extraOutput()],
             messages: [...defaultMessages, ...extraMessages, ...longMessages]
               ..sort()),
@@ -96,7 +96,7 @@ void main() {
           ...defaultMessages,
           ...annotatedMessages,
         ]),
-        expectedOutput: expectedOutputFiles(
+        expectedOutput: expectedSecondOutputFiles(
             additionalFilesInLib: [extraOutput()],
             messages: [
               ...defaultMessages,
@@ -145,7 +145,7 @@ void main() {
           ...defaultMessages,
           ...annotatedMessages,
         ], intlImport: 'intl/intl.dart'),
-        expectedOutput: expectedOutputFiles(
+        expectedOutput: expectedSecondOutputFiles(
             additionalFilesInLib: [extraOutput()],
             messages: [
               ...defaultMessages,

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -157,8 +157,7 @@ void main() {
               ...defaultMessages,
               ...annotatedMessages,
               ...longMessages
-            ]..sort(),
-            intlImport: 'package:test_project/src/intl/test_project_intl.dart'),
+            ]..sort()),
         args: ['--yes-to-all']);
 
     testCodemod('Import is updated without other modifications',

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -146,18 +146,10 @@ void main() {
     testCodemod('Import is updated',
         script: script,
         input: expectedOutputFiles(additionalFilesInLib: [
-          d.file('more_stuff.dart', /*language=dart*/ '''
-import 'package:react_material_ui/react_material_ui.dart' as mui;
-import 'package:test_project/src/intl/test_project_intl.dart';
+          d.file('more_stuff.dart',
+              /*language=dart*/ '''import 'package:react_material_ui/react_material_ui.dart' as mui;
 
-someMoreStrings() => (mui.Button()
-  ..aria.label=TestProjectIntl.orange
-  ..label="""
-A long string
-with multiple
-   lines""")
-    (TestProjectIntl.aquamarine,
-     TestProjectIntl.twoAdjacentStringsOnSeparate);'''),
+someMoreStrings() => (mui.Button()..aria.label='Sorts later')('Literal String');''')
         ], messages: [
           ...defaultMessages,
           ...annotatedMessages,
@@ -169,7 +161,7 @@ with multiple
               ...annotatedMessages,
               ...longMessages
             ]..sort(),
-        ),
+            intlImport: 'package:test_project/src/intl/test_project_intl.dart'),
         args: ['--yes-to-all']);
 
     testCodemod('Import is updated without other modifications',

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -301,7 +301,7 @@ d.DirectoryDescriptor expectedOutputFiles(
     {Iterable<d.Descriptor> additionalFilesInLib = const [],
     List<String> messages = defaultMessages,
     String rmuiVersionConstraint = '^1.1.1',
-    String intlImport = 'package:w_intl/intl_wrapper.dart'}) {
+    String intlImport = '${wIntl}/intl_wrapper.dart'}) {
   return d.dir('project', [
     // Note that the codemod doesn't currently add the intl dependency to the pubspec.
     d.file('pubspec.yaml', /*language=yaml*/ '''
@@ -317,21 +317,21 @@ dependencies:
     d.dir('lib', [
       ...additionalFilesInLib,
       d.file('usage.dart', /*language=dart*/ '''
-import 'package:test_project/src/intl/test_project_intl.dart';      
+import 'package:test_project/src/intl/test_project_intl.dart';
 import 'package:react_material_ui/react_material_ui.dart' as mui;
 
 usage() => (mui.Button()..aria.label=TestProjectIntl.sortsLater)(TestProjectIntl.literalString);'''),
       d.dir('src', [
         d.dir('intl', [
           d.file('test_project_intl.dart', /*language=dart*/ '''
-import 'package:w_intl/intl_wrapper.dart';
+import 'package:${intlImport}';
 
 ${IntlMessages.introComment}
 
 //ignore_for_file: avoid_classes_with_only_static_members
 //ignore_for_file: unnecessary_brace_in_string_interps
 class TestProjectIntl {
-${messages}
+${messages.join('\n\n')}
 
 }''')
         ]),

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -146,7 +146,14 @@ void main() {
     testCodemod('Import is updated',
         script: script,
         input: expectedOutputFiles(additionalFilesInLib: [
-          extraInput()
+          d.file('more_stuff.dart', /*language=dart*/ '''
+import 'package:test_project/src/intl/test_project_intl.dart';
+import 'package:react_material_ui/react_material_ui.dart' as mui;
+
+someMoreStrings() => (mui.Button()
+  ..aria.label=TestProjectIntl.orange
+  ..label=TestProjectIntl.aLongStringwithMultipleLines)
+  (TestProjectIntl.aquamarine, TestProjectIntl.twoAdjacentStringsOnSeparate);'''),
         ], messages: [
           ...defaultMessages,
           ...annotatedMessages,
@@ -158,7 +165,6 @@ void main() {
               ...annotatedMessages,
               ...longMessages
             ]..sort(),
-          intlImport: 'package:react_material_ui/react_material_ui.dart as mui',
         ),
         args: ['--yes-to-all']);
 

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -153,8 +153,9 @@ import 'package:test_project/src/intl/test_project_intl.dart';
 someMoreStrings() => (mui.Button()
   ..aria.label=TestProjectIntl.orange
   ..label=TestProjectIntl.aLongStringwithMultipleLines)
-  (TestProjectIntl.aquamarine, 
-    TestProjectIntl.twoAdjacentStringsOnSeparate);''')
+    (TestProjectIntl.aquamarine, 
+     TestProjectIntl.twoAdjacentStringsOnSeparate);
+''')
         ], messages: [
           ...defaultMessages,
           ...annotatedMessages,

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -150,7 +150,7 @@ void main() {
         ], messages: [
           ...defaultMessages,
           ...annotatedMessages,
-        ], intlImport: 'intl/intl.dart'),
+        ], intlImport: '${wIntl}/intl_wrapper.dart'),
         expectedOutput: expectedSecondOutputFiles(
             additionalFilesInLib: [extraOutput()],
             messages: [
@@ -158,7 +158,7 @@ void main() {
               ...annotatedMessages,
               ...longMessages
             ]..sort(),
-            intlImport: '${wIntl}/intl_wrapper.dart'),
+            intlImport: 'package:test_project/src/intl/test_project_intl.dart'),
         args: ['--yes-to-all']);
 
     testCodemod('Import is updated without other modifications',

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -148,8 +148,13 @@ void main() {
         input: expectedOutputFiles(additionalFilesInLib: [
           d.file('more_stuff.dart',
               /*language=dart*/ '''import 'package:react_material_ui/react_material_ui.dart' as mui;
+import 'package:test_project/src/intl/test_project_intl.dart';
 
-someMoreStrings() => (mui.Button()..aria.label='Sorts later')('Literal String');''')
+someMoreStrings() => (mui.Button()
+  ..aria.label=TestProjectIntl.orange
+  ..label=TestProjectIntl.aLongStringwithMultipleLines)
+  (TestProjectIntl.aquamarine, 
+    TestProjectIntl.twoAdjacentStringsOnSeparate);''')
         ], messages: [
           ...defaultMessages,
           ...annotatedMessages,

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -154,21 +154,20 @@ someMoreStrings() => (mui.Button()
   ..aria.label=TestProjectIntl.orange
   ..label=TestProjectIntl.aLongStringwithMultipleLines)
   (TestProjectIntl.aquamarine,
-   TestProjectIntl.twoAdjacentStringsOnSeparate);
-''')
-        ], messages: [
-          ...defaultMessages,
-          ...annotatedMessages,
-        ], intlImport: 'intl/intl.dart'),
-        expectedOutput: expectedOutputFiles(
-            additionalFilesInLib: [extraOutput()],
-            messages: [
-              ...defaultMessages,
-              ...annotatedMessages,
-              ...longMessages
-            ]..sort(),
-            intlImport: 'package:w_intl/intl_wrapper.dart'),
-        args: ['--yes-to-all']);
+   TestProjectIntl.twoAdjacentStringsOnSeparate);''')
+  ], messages: [
+   ...defaultMessages,
+   ...annotatedMessages,
+  ], intlImport: 'intl/intl.dart'),
+  expectedOutput: expectedOutputFiles(
+    additionalFilesInLib: [extraOutput()],
+    messages: [
+     ...defaultMessages,
+     ...annotatedMessages,
+     ...longMessages
+    ]..sort(),
+     intlImport: 'package:w_intl/intl_wrapper.dart'),
+args: ['--yes-to-all']);
 
     testCodemod('Import is updated without other modifications',
         script: script,

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -82,12 +82,9 @@ void main() {
         script: script,
         input: inputFiles(additionalFilesInLib: [extraInput()]),
         expectedOutput: expectedOutputFiles(
-          additionalFilesInLib: [extraOutput()],
-          messages: [...defaultMessages, ...extraMessages, ...longMessages]
-            ..sort(),
-          rmuiVersionConstraint: '^1.1.1',
-          intlImport: 'package:test_project/src/intl/test_project_intl.dart',
-        ),
+            additionalFilesInLib: [extraOutput()],
+            messages: [...defaultMessages, ...extraMessages, ...longMessages]
+              ..sort()),
         args: ['--yes-to-all']);
 
     // Test that additional information (desc, meaning) are preserved if we read and then rewrite the file.
@@ -100,15 +97,12 @@ void main() {
           ...annotatedMessages,
         ]),
         expectedOutput: expectedOutputFiles(
-          additionalFilesInLib: [extraOutput()],
-          messages: [
-            ...defaultMessages,
-            ...annotatedMessages,
-            ...longMessages,
-          ]..sort(),
-          rmuiVersionConstraint: '^1.1.1',
-          intlImport: 'package:test_project/src/intl/test_project_intl.dart',
-        ),
+            additionalFilesInLib: [extraOutput()],
+            messages: [
+              ...defaultMessages,
+              ...annotatedMessages,
+              ...longMessages,
+            ]..sort()),
         args: ['--yes-to-all']);
 
     // We've removed the file for some that were already in the _intl.dart file,
@@ -151,7 +145,7 @@ void main() {
           ...defaultMessages,
           ...annotatedMessages,
         ], intlImport: 'intl/intl.dart'),
-        expectedOutput: expectedSecondOutputFiles(
+        expectedOutput: expectedOutputFiles(
             additionalFilesInLib: [extraOutput()],
             messages: [
               ...defaultMessages,
@@ -368,6 +362,7 @@ dependencies:
       d.file('usage.dart', /*language=dart*/ '''
 import 'package:react_material_ui/react_material_ui.dart' as mui;
 import 'package:test_project/src/intl/test_project_intl.dart';
+
 usage() => (mui.Button()..aria.label=TestProjectIntl.sortsLater)(TestProjectIntl.literalString);'''),
       d.dir('src', [
         d.dir('intl', [
@@ -387,4 +382,5 @@ ${messages.join('\n\n')}
     ]),
   ]);
 }
+
 const wIntl = 'w_intl';

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -324,8 +324,8 @@ dependencies:
     d.dir('lib', [
       ...additionalFilesInLib,
       d.file('usage.dart', /*language=dart*/ '''
-import 'package:test_project/src/intl/test_project_intl.dart';
 import 'package:react_material_ui/react_material_ui.dart' as mui;
+import 'package:test_project/src/intl/test_project_intl.dart';
 
 usage() => (mui.Button()..aria.label=TestProjectIntl.sortsLater)(TestProjectIntl.literalString);'''),
       d.dir('src', [
@@ -389,5 +389,4 @@ ${messages.join('\n\n')}
     ]),
   ]);
 }
-
 const wIntl = 'w_intl';

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -151,7 +151,7 @@ void main() {
               ...defaultMessages,
               ...annotatedMessages,
               ...longMessages
-            ]),
+            ]..sort()),
         args: ['--yes-to-all']);
 
     testCodemod('Import is updated without other modifications',
@@ -317,8 +317,8 @@ dependencies:
     d.dir('lib', [
       ...additionalFilesInLib,
       d.file('usage.dart', /*language=dart*/ '''
-import 'package:react_material_ui/react_material_ui.dart' as mui;
 import 'package:test_project/src/intl/test_project_intl.dart';
+import 'package:react_material_ui/react_material_ui.dart' as mui;
 
 usage() => (mui.Button()..aria.label=TestProjectIntl.sortsLater)(TestProjectIntl.literalString);'''),
       d.dir('src', [

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -38,13 +38,13 @@ void main() {
         expectedOutput: inputFiles(),
         expectedExitCode: 0,
         args: ['--help'], body: (out, err) {
-          expect(
-              condenseWhitespace(err),
-              allOf(
-                contains(condenseWhitespace(codemodArgParser.usage)),
-                contains('Migrates literal strings'),
-              ));
-        });
+      expect(
+          condenseWhitespace(err),
+          allOf(
+            contains(condenseWhitespace(codemodArgParser.usage)),
+            contains('Migrates literal strings'),
+          ));
+    });
 
     testCodemod('applies all patches via --yes-to-all,',
         script: script,
@@ -57,8 +57,8 @@ void main() {
         input: expectedOutputFiles(),
         expectedOutput: expectedOutputFiles(),
         args: ['--fail-on-changes'], body: (out, err) {
-          expect(out, contains('No changes needed.'));
-        });
+      expect(out, contains('No changes needed.'));
+    });
 
     testCodemod(
         '--fail-on-changes exits with non-zero when changes needed and does not update files',
@@ -84,8 +84,7 @@ void main() {
         expectedOutput: expectedOutputFiles(
             additionalFilesInLib: [extraOutput()],
             messages: [...defaultMessages, ...extraMessages, ...longMessages]
-              ..sort()
-        ),
+              ..sort()),
         args: ['--yes-to-all']);
 
     // Test that additional information (desc, meaning) are preserved if we read and then rewrite the file.
@@ -103,8 +102,7 @@ void main() {
               ...defaultMessages,
               ...annotatedMessages,
               ...longMessages,
-            ]..sort()
-        ),
+            ]..sort()),
         args: ['--yes-to-all']);
 
     // We've removed the file for some that were already in the _intl.dart file,
@@ -180,8 +178,8 @@ someMoreStrings() => (mui.Button()..aria.label='orange')('aquamarine');''')
         expectedOutput: inputFiles(),
         args: ['--yes-to-all', 'lib/a_part_file.dart'],
         expectedExitCode: 1, body: (out, err) {
-          expect(err, contains('Only part files were specified'));
-        });
+      expect(err, contains('Only part files were specified'));
+    });
   }, tags: 'wsd');
 
   group('limit paths', () {
@@ -301,9 +299,9 @@ const List<String> defaultMessages = [
 
 d.DirectoryDescriptor expectedOutputFiles(
     {Iterable<d.Descriptor> additionalFilesInLib = const [],
-      List<String> messages = defaultMessages,
-      String rmuiVersionConstraint = '^1.1.1',
-      String intlImport = '${wIntl}/intl_wrapper.dart'}) {
+    List<String> messages = defaultMessages,
+    String rmuiVersionConstraint = '^1.1.1',
+    String intlImport = '${wIntl}/intl_wrapper.dart'}) {
   return d.dir('project', [
     // Note that the codemod doesn't currently add the intl dependency to the pubspec.
     d.file('pubspec.yaml', /*language=yaml*/ '''

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -152,22 +152,22 @@ import 'package:test_project/src/intl/test_project_intl.dart';
 
 someMoreStrings() => (mui.Button()
   ..aria.label=TestProjectIntl.orange
-  ..label=TestProjectIntl.aLongStringwithMultipleLines)
-  (TestProjectIntl.aquamarine,
-   TestProjectIntl.twoAdjacentStringsOnSeparate);''')
-  ], messages: [
-   ...defaultMessages,
-   ...annotatedMessages,
-  ], intlImport: 'intl/intl.dart'),
-  expectedOutput: expectedOutputFiles(
-    additionalFilesInLib: [extraOutput()],
-    messages: [
-     ...defaultMessages,
-     ...annotatedMessages,
-     ...longMessages
-    ]..sort(),
-     intlImport: 'package:w_intl/intl_wrapper.dart'),
-args: ['--yes-to-all']);
+  ..label=TestProjectIntl.aLongStringwithMultipleLines)(TestProjectIntl.aquamarine, TestProjectIntl.twoAdjacentStringsOnSeparate);
+''')
+        ], messages: [
+          ...defaultMessages,
+          ...annotatedMessages,
+        ], intlImport: 'intl/intl.dart'),
+        expectedOutput: expectedOutputFiles(
+          additionalFilesInLib: [extraOutput()],
+          messages: [
+            ...defaultMessages,
+            ...annotatedMessages,
+            ...longMessages
+          ]..sort(),
+          intlImport: 'package:test_project/src/intl/test_project_intl.dart',
+        ),
+        args: ['--yes-to-all']);
 
     testCodemod('Import is updated without other modifications',
         script: script,

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -158,7 +158,7 @@ void main() {
               ...annotatedMessages,
               ...longMessages
             ]..sort(),
-          intlImport: 'package:test_project/src/intl/test_project_intl.dart',
+          intlImport: 'package:react_material_ui/react_material_ui.dart as mui',
         ),
         args: ['--yes-to-all']);
 
@@ -325,8 +325,8 @@ dependencies:
     d.dir('lib', [
       ...additionalFilesInLib,
       d.file('usage.dart', /*language=dart*/ '''
-import 'package:react_material_ui/react_material_ui.dart' as mui;
 import 'package:test_project/src/intl/test_project_intl.dart';
+import 'package:react_material_ui/react_material_ui.dart' as mui;
 
 usage() => (mui.Button()..aria.label=TestProjectIntl.sortsLater)(TestProjectIntl.literalString);'''),
       d.dir('src', [

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -153,7 +153,7 @@ import 'package:test_project/src/intl/test_project_intl.dart';
 someMoreStrings() => (mui.Button()
   ..aria.label=TestProjectIntl.orange
   ..label=TestProjectIntl.aLongStringwithMultipleLines)
-    (TestProjectIntl.aquamarine, 
+    (TestProjectIntl.aquamarine,
      TestProjectIntl.twoAdjacentStringsOnSeparate);
 ''')
         ], messages: [

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -86,7 +86,7 @@ void main() {
             messages: [...defaultMessages, ...extraMessages, ...longMessages]
               ..sort(),
           rmuiVersionConstraint: '^1.1.1',
-          intlImport: '${wIntl}/intl_wrapper.dart',
+          intlImport: 'package:test_project/src/intl/test_project_intl.dart',
         ),
         args: ['--yes-to-all']);
 
@@ -107,7 +107,7 @@ void main() {
               ...longMessages,
             ]..sort(),
           rmuiVersionConstraint: '^1.1.1',
-          intlImport: '${wIntl}/intl_wrapper.dart',
+          intlImport: 'package:test_project/src/intl/test_project_intl.dart',
         ),
         args: ['--yes-to-all']);
     // We've removed the file for some that were already in the _intl.dart file,
@@ -158,7 +158,7 @@ void main() {
               ...longMessages
             ]..sort(),
           rmuiVersionConstraint: '^1.1.1',
-          intlImport: '${wIntl}/intl_wrapper.dart',
+          intlImport: 'package:test_project/src/intl/test_project_intl.dart',
         ),
         args: ['--yes-to-all'] );
 

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -323,8 +323,8 @@ dependencies:
     d.dir('lib', [
       ...additionalFilesInLib,
       d.file('usage.dart', /*language=dart*/ '''
-import 'package:react_material_ui/react_material_ui.dart' as mui;
 import 'package:test_project/src/intl/test_project_intl.dart';
+import 'package:react_material_ui/react_material_ui.dart' as mui;
 
 usage() => (mui.Button()..aria.label=TestProjectIntl.sortsLater)(TestProjectIntl.literalString);'''),
       d.dir('src', [
@@ -366,9 +366,8 @@ dependencies:
     d.dir('lib', [
       ...additionalFilesInLib,
       d.file('usage.dart', /*language=dart*/ '''
-import 'package:test_project/src/intl/test_project_intl.dart';
 import 'package:react_material_ui/react_material_ui.dart' as mui;
-
+import 'package:test_project/src/intl/test_project_intl.dart';
 usage() => (mui.Button()..aria.label=TestProjectIntl.sortsLater)(TestProjectIntl.literalString);'''),
       d.dir('src', [
         d.dir('intl', [

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -110,6 +110,7 @@ void main() {
           intlImport: 'package:test_project/src/intl/test_project_intl.dart',
         ),
         args: ['--yes-to-all']);
+
     // We've removed the file for some that were already in the _intl.dart file,
     // and we expect them to be removed.
     testCodemod('Unused messages are removed',
@@ -157,10 +158,9 @@ void main() {
               ...annotatedMessages,
               ...longMessages
             ]..sort(),
-          rmuiVersionConstraint: '^1.1.1',
           intlImport: 'package:test_project/src/intl/test_project_intl.dart',
         ),
-        args: ['--yes-to-all'] );
+        args: ['--yes-to-all']);
 
     testCodemod('Import is updated without other modifications',
         script: script,
@@ -325,8 +325,8 @@ dependencies:
     d.dir('lib', [
       ...additionalFilesInLib,
       d.file('usage.dart', /*language=dart*/ '''
-import 'package:test_project/src/intl/test_project_intl.dart';
 import 'package:react_material_ui/react_material_ui.dart' as mui;
+import 'package:test_project/src/intl/test_project_intl.dart';
 
 usage() => (mui.Button()..aria.label=TestProjectIntl.sortsLater)(TestProjectIntl.literalString);'''),
       d.dir('src', [

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -152,8 +152,9 @@ import 'package:test_project/src/intl/test_project_intl.dart';
 
 someMoreStrings() => (mui.Button()
   ..aria.label=TestProjectIntl.orange
-  ..label=TestProjectIntl.aLongStringwithMultipleLines)(TestProjectIntl.aquamarine, TestProjectIntl.twoAdjacentStringsOnSeparate);
-''')
+  ..label=TestProjectIntl.aLongStringwithMultipleLines)
+    (TestProjectIntl.aquamarine,
+     TestProjectIntl.twoAdjacentStringsOnSeparate);''')
         ], messages: [
           ...defaultMessages,
           ...annotatedMessages,
@@ -257,11 +258,11 @@ d.FileDescriptor extraOutput() {
       /*language=dart*/ '''import 'package:react_material_ui/react_material_ui.dart' as mui;
 import 'package:test_project/src/intl/test_project_intl.dart';
 
-someMoreStrings() => (mui.Button()
-  ..aria.label=TestProjectIntl.orange
-  ..label=TestProjectIntl.aLongStringwithMultipleLines)
-    (TestProjectIntl.aquamarine, TestProjectIntl.twoAdjacentStringsOnSeparate);
-''');
+  someMoreStrings() => (mui.Button()
+    ..aria.label=TestProjectIntl.orange
+    ..label=TestProjectIntl.aLongStringwithMultipleLines)
+      (TestProjectIntl.aquamarine,
+       TestProjectIntl.twoAdjacentStringsOnSeparate);''');
 }
 
 List<String> extraMessages = [

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -161,7 +161,7 @@ someMoreStrings() => (mui.Button()..aria.label='Sorts later')('Literal String');
               ...annotatedMessages,
               ...longMessages
             ]..sort(),
-            intlImport: 'package:test_project/src/intl/test_project_intl.dart'),
+            intlImport: 'package:w_intl/intl_wrapper.dart'),
         args: ['--yes-to-all']);
 
     testCodemod('Import is updated without other modifications',

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -81,10 +81,11 @@ void main() {
     testCodemod('Output is sorted',
         script: script,
         input: inputFiles(additionalFilesInLib: [extraInput()]),
-        expectedOutput: expectedSecondOutputFiles(
+        expectedOutput: expectedOutputFiles(
             additionalFilesInLib: [extraOutput()],
             messages: [...defaultMessages, ...extraMessages, ...longMessages]
-              ..sort()),
+              ..sort()
+        ),
         args: ['--yes-to-all']);
 
     // Test that additional information (desc, meaning) are preserved if we read and then rewrite the file.
@@ -96,13 +97,14 @@ void main() {
           ...defaultMessages,
           ...annotatedMessages,
         ]),
-        expectedOutput: expectedSecondOutputFiles(
+        expectedOutput: expectedOutputFiles(
             additionalFilesInLib: [extraOutput()],
             messages: [
               ...defaultMessages,
               ...annotatedMessages,
               ...longMessages,
-            ]..sort()),
+            ]..sort()
+        ),
         args: ['--yes-to-all']);
 
     // We've removed the file for some that were already in the _intl.dart file,
@@ -145,7 +147,7 @@ void main() {
           ...defaultMessages,
           ...annotatedMessages,
         ], intlImport: 'intl/intl.dart'),
-        expectedOutput: expectedSecondOutputFiles(
+        expectedOutput: expectedOutputFiles(
             additionalFilesInLib: [extraOutput()],
             messages: [
               ...defaultMessages,
@@ -240,14 +242,14 @@ with multiple
 
 d.FileDescriptor extraOutput() {
   return d.file('more_stuff.dart',
-      /*language=dart*/ '''import 'package:react_material_ui/react_material_ui.dart' as mui;
-import 'package:test_project/src/intl/test_project_intl.dart';
+      /*language=dart*/ '''import 'package:test_project/src/intl/test_project_intl.dart';
+import 'package:react_material_ui/react_material_ui.dart' as mui;
 
-  someMoreStrings() => (mui.Button()
-    ..aria.label=TestProjectIntl.orange
-    ..label=TestProjectIntl.aLongStringwithMultipleLines)
-      (TestProjectIntl.aquamarine,
-       TestProjectIntl.twoAdjacentStringsOnSeparate);''');
+someMoreStrings() => (mui.Button()
+  ..aria.label=TestProjectIntl.orange
+  ..label=TestProjectIntl.aLongStringwithMultipleLines)
+    (TestProjectIntl.aquamarine,
+     TestProjectIntl.twoAdjacentStringsOnSeparate);''');
 }
 
 List<String> extraMessages = [
@@ -319,49 +321,6 @@ dependencies:
       d.file('usage.dart', /*language=dart*/ '''
 import 'package:test_project/src/intl/test_project_intl.dart';
 import 'package:react_material_ui/react_material_ui.dart' as mui;
-
-usage() => (mui.Button()..aria.label=TestProjectIntl.sortsLater)(TestProjectIntl.literalString);'''),
-      d.dir('src', [
-        d.dir('intl', [
-          d.file('test_project_intl.dart', /*language=dart*/ '''
-import 'package:${intlImport}';
-
-${IntlMessages.introComment}
-
-//ignore_for_file: avoid_classes_with_only_static_members
-//ignore_for_file: unnecessary_brace_in_string_interps
-class TestProjectIntl {
-${messages.join('\n\n')}
-
-}''')
-        ]),
-      ]),
-    ]),
-  ]);
-}
-
-d.DirectoryDescriptor expectedSecondOutputFiles(
-    {Iterable<d.Descriptor> additionalFilesInLib = const [],
-    List<String> messages = defaultMessages,
-    String rmuiVersionConstraint = '^1.1.1',
-    String intlImport = '${wIntl}/intl_wrapper.dart'}) {
-  return d.dir('project', [
-    // Note that the codemod doesn't currently add the intl dependency to the pubspec.
-    d.file('pubspec.yaml', /*language=yaml*/ '''
-name: test_project
-environment:
-  sdk: '>=2.11.0 <3.0.0'
-dependencies:
-  react_material_ui:
-    hosted:
-      name: react_material_ui
-      url: https://pub.workiva.org
-    version: $rmuiVersionConstraint'''),
-    d.dir('lib', [
-      ...additionalFilesInLib,
-      d.file('usage.dart', /*language=dart*/ '''
-import 'package:react_material_ui/react_material_ui.dart' as mui;
-import 'package:test_project/src/intl/test_project_intl.dart';
 
 usage() => (mui.Button()..aria.label=TestProjectIntl.sortsLater)(TestProjectIntl.literalString);'''),
       d.dir('src', [

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -301,7 +301,7 @@ d.DirectoryDescriptor expectedOutputFiles(
     {Iterable<d.Descriptor> additionalFilesInLib = const [],
     List<String> messages = defaultMessages,
     String rmuiVersionConstraint = '^1.1.1',
-    String intlImport = '${wIntl}/intl_wrapper.dart'}) {
+    String intlImport = 'package:w_intl/intl_wrapper.dart'}) {
   return d.dir('project', [
     // Note that the codemod doesn't currently add the intl dependency to the pubspec.
     d.file('pubspec.yaml', /*language=yaml*/ '''
@@ -317,21 +317,21 @@ dependencies:
     d.dir('lib', [
       ...additionalFilesInLib,
       d.file('usage.dart', /*language=dart*/ '''
+import 'package:test_project/src/intl/test_project_intl.dart';      
 import 'package:react_material_ui/react_material_ui.dart' as mui;
-import 'package:test_project/src/intl/test_project_intl.dart';
 
 usage() => (mui.Button()..aria.label=TestProjectIntl.sortsLater)(TestProjectIntl.literalString);'''),
       d.dir('src', [
         d.dir('intl', [
           d.file('test_project_intl.dart', /*language=dart*/ '''
-import 'package:${intlImport}';
+import 'package:w_intl/intl_wrapper.dart';
 
 ${IntlMessages.introComment}
 
 //ignore_for_file: avoid_classes_with_only_static_members
 //ignore_for_file: unnecessary_brace_in_string_interps
 class TestProjectIntl {
-${messages.join('\n\n')}
+${messages}
 
 }''')
         ]),

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -152,8 +152,12 @@ import 'package:test_project/src/intl/test_project_intl.dart';
 
 someMoreStrings() => (mui.Button()
   ..aria.label=TestProjectIntl.orange
-  ..label=TestProjectIntl.aLongStringwithMultipleLines)
-  (TestProjectIntl.aquamarine, TestProjectIntl.twoAdjacentStringsOnSeparate);'''),
+  ..label="""
+A long string
+with multiple
+   lines""")
+    (TestProjectIntl.aquamarine,
+     TestProjectIntl.twoAdjacentStringsOnSeparate);'''),
         ], messages: [
           ...defaultMessages,
           ...annotatedMessages,

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -146,19 +146,11 @@ void main() {
     testCodemod('Import is updated',
         script: script,
         input: expectedOutputFiles(additionalFilesInLib: [
-          d.file('more_stuff.dart',
-              /*language=dart*/ '''import 'package:react_material_ui/react_material_ui.dart' as mui;
-import 'package:test_project/src/intl/test_project_intl.dart';
-
-someMoreStrings() => (mui.Button()
-  ..aria.label=TestProjectIntl.orange
-  ..label=TestProjectIntl.aLongStringwithMultipleLines)
-    (TestProjectIntl.aquamarine,
-     TestProjectIntl.twoAdjacentStringsOnSeparate);''')
+          extraInput()
         ], messages: [
           ...defaultMessages,
           ...annotatedMessages,
-        ], intlImport: '${wIntl}/intl_wrapper.dart'),
+        ], intlImport: 'intl/intl.dart'),
         expectedOutput: expectedSecondOutputFiles(
             additionalFilesInLib: [extraOutput()],
             messages: [

--- a/test/intl_suggestors/intl_importer_test.dart
+++ b/test/intl_suggestors/intl_importer_test.dart
@@ -66,7 +66,6 @@ void main() {
               import 'package:over_react/over_react.dart';
               import 'package:test_project/src/intl/test_project_intl.dart';
               content() => TestProjectIntl.testString;
-              
             ''',
           );
         });

--- a/test/intl_suggestors/intl_importer_test.dart
+++ b/test/intl_suggestors/intl_importer_test.dart
@@ -366,7 +366,7 @@ void main() {
 
     test('should recognize import format as "relative" when there are only relative imports', () {
       final imports = [
-        "import '../../../src/intl/test_project_intl.dart';",
+        "import '../../src/intl/test_project_intl.dart';",
         "import '../lib/file.dart';",
       ];
       final hasPackageImports = imports.any((importStatement) => importStatement.startsWith("import 'package:"));
@@ -378,7 +378,7 @@ void main() {
     test('should recognize import format as "package" when there are both package and relative imports', () {
       final imports = [
         "import 'package:over_react/over_react.dart';",
-        "import '../../../src/intl/test_project_intl.dart';",
+        "import '../../src/intl/test_project_intl.dart';",
       ];
       final hasPackageImports = imports.any((importStatement) => importStatement.startsWith("import 'package:"));
       final hasRelativeImports = imports.any((importStatement) => importStatement.startsWith("import '../"));

--- a/test/intl_suggestors/intl_importer_test.dart
+++ b/test/intl_suggestors/intl_importer_test.dart
@@ -63,8 +63,8 @@ void main() {
             ''',
             isExpectedError: isUndefinedIntlError,
             expectedOutput: /*language=dart*/ '''
-              import 'package:over_react/over_react.dart';
               import 'package:test_project/src/intl/test_project_intl.dart';
+              import 'package:over_react/over_react.dart';
               
               content() => TestProjectIntl.testString;
             ''',
@@ -124,9 +124,9 @@ void main() {
             isExpectedError: (e) =>
                 isUndefinedIntlError(e) || isFakeUriError(e),
             expectedOutput: /*language=dart*/ '''
+              import 'package:test_project/src/intl/test_project_intl.dart';
               import 'package:over_react/over_react.dart';
               import 'package:over_react/components.dart';
-              import 'package:test_project/src/intl/test_project_intl.dart';
               import 'package:z_fake_package/z_fake_package_1.dart';
               import 'package:z_fake_package/z_fake_package_2.dart';
 
@@ -147,8 +147,8 @@ void main() {
             isExpectedError: (e) =>
                 isUndefinedIntlError(e) || isFakeUriError(e),
             expectedOutput: /*language=dart*/ '''
-              import 'package:over_react/over_react.dart';
               import 'package:test_project/src/intl/test_project_intl.dart';
+              import 'package:over_react/over_react.dart';
               import 'a/fake_relative_file.dart';
               
               content() => TestProjectIntl.testString;
@@ -240,8 +240,8 @@ void main() {
           ''',
           isExpectedError: (e) => isUndefinedIntlError(e) || isFakeUriError(e),
           expectedOutput: /*language=dart*/ '''
-              import 'package:over_react/over_react.dart';
               import 'package:test_project/src/intl/test_project_intl.dart';
+              import 'package:over_react/over_react.dart';
               part 'fake_part.dart';
 
               content() => TestProjectIntl.testString;
@@ -282,8 +282,8 @@ void main() {
           ''',
           isExpectedError: (e) => isUndefinedIntlError(e) || isFakeUriError(e),
           expectedOutput: /*language=dart*/ '''
-              import 'package:over_react/over_react.dart';
               import 'package:test_project/src/intl/test_project_intl.dart';
+              import 'package:over_react/over_react.dart';
               export 'package:over_react/over_react.dart';
               part 'fake_part.dart';
 

--- a/test/intl_suggestors/intl_importer_test.dart
+++ b/test/intl_suggestors/intl_importer_test.dart
@@ -159,7 +159,7 @@ void main() {
             expectedOutput: /*language=dart*/ '''
               import 'dart:html';
 
-              import '../../../../../src/intl/test_project_intl.dart';
+              import 'package:test_project/src/intl/test_project_intl.dart';
 
               content() => TestProjectIntl.testString;
             ''',

--- a/test/intl_suggestors/intl_importer_test.dart
+++ b/test/intl_suggestors/intl_importer_test.dart
@@ -108,18 +108,50 @@ void main() {
             ''',
           );
         });
-        test('when there are package imports',() {
-          var getStatus = decideImportFormat(true,false);
-          expect('package', equals(getStatus));
+
+        test('when there are only package imports', () {
+          final imports = [
+            'import \'package:over_react/over_react.dart\';',
+            'import \'package:package_two/file.dart\';',
+          ];
+          final hasPackageImports = imports.any((importStatement) => importStatement.startsWith('import \'package:'));
+          final hasRelativeImports = imports.any((importStatement) => importStatement.startsWith('import \'../'));
+          final importFormat = decideImportFormat(hasPackageImports, hasRelativeImports);
+          expect(importFormat, isTrue);
         });
-        test('when there are relative imports',(){
-          var getStatus = decideImportFormat(false,true);
-          expect('relative', equals(getStatus));
+
+        test('when there are only relative imports', () {
+          final imports = [
+            'import \'../../../src/intl/datatables_intl.dart\';',
+            'import \'../lib/file.dart\';',
+          ];
+          final hasPackageImports = imports.any((importStatement) => importStatement.startsWith('import \'package:'));
+          final hasRelativeImports = imports.any((importStatement) => importStatement.startsWith('import \'../'));
+          final importFormat = decideImportFormat(hasPackageImports, hasRelativeImports);
+          expect(importFormat, isTrue);
         });
-        test('when there are package and relative imports',(){
-          String importFormat = decideImportFormat(true,true);
-          expect('package', equals(importFormat));
+
+        test('when there are both package and relative imports', () {
+          final imports = [
+            'import \'package:package_one/file.dart\';',
+            'import \'../../../src/intl/datatables_intl.dart\';',
+          ];
+          final hasPackageImports = imports.any((importStatement) => importStatement.startsWith('import \'package:'));
+          final hasRelativeImports = imports.any((importStatement) => importStatement.startsWith('import \'../'));
+          final importFormat = decideImportFormat(hasPackageImports, hasRelativeImports);
+          expect(importFormat, isTrue);
         });
+
+        test('when there are no import statements', () {
+          final imports = <String>[];
+          final hasPackageImports = imports.any((importStatement) => importStatement.startsWith('import \'package:'));
+          final hasRelativeImports = imports.any((importStatement) => importStatement.startsWith('import \'../'));
+          final importFormat = decideImportFormat(hasPackageImports, hasRelativeImports);
+          expect(importFormat, isFalse);
+        });
+
+
+
         test('(more than one alphabetized before and after `TestProjectIntl`)',
             () async {
           await testSuggestor(

--- a/test/intl_suggestors/intl_importer_test.dart
+++ b/test/intl_suggestors/intl_importer_test.dart
@@ -403,6 +403,39 @@ void main() {
         );
       });
     });
+
+    test('when there are only package imports', () {
+      final imports = [
+        "import 'package:over_react/over_react.dart';",
+        "import 'package:react_material_ui/react_material_ui.dart';",
+      ];
+      final hasPackageImports = imports.any((importStatement) => importStatement.startsWith("import 'package:"));
+      final hasRelativeImports = imports.any((importStatement) => importStatement.startsWith("import '../"));
+      final importFormat = decideImportFormat(hasPackageImports, hasRelativeImports);
+      expect(importFormat, isTrue);
+    });
+
+    test('when there are only relative imports', () {
+      final imports = [
+        "import '../../../src/intl/datatables_intl.dart';",
+        "import '../lib/file.dart';",
+      ];
+      final hasPackageImports = imports.any((importStatement) => importStatement.startsWith("import 'package:"));
+      final hasRelativeImports = imports.any((importStatement) => importStatement.startsWith("import '../"));
+      final importFormat = decideImportFormat(hasPackageImports, hasRelativeImports);
+      expect(importFormat, isTrue);
+    });
+
+    test('when there are both package and relative imports', () {
+      final imports = [
+        "import 'package:over_react/over_react.dart';",
+        "import '../../../src/intl/datatables_intl.dart';",
+      ];
+      final hasPackageImports = imports.any((importStatement) => importStatement.startsWith("import 'package:"));
+      final hasRelativeImports = imports.any((importStatement) => importStatement.startsWith("import '../"));
+      final importFormat = decideImportFormat(hasPackageImports, hasRelativeImports);
+      expect(importFormat, isTrue);
+    });
   });
 }
 

--- a/test/intl_suggestors/intl_importer_test.dart
+++ b/test/intl_suggestors/intl_importer_test.dart
@@ -44,12 +44,11 @@ void main() {
       test('when there are no other imports', () async {
         await testSuggestor(
           input: /*language=dart*/ '''
-          
               content() => TestProjectIntl.testString;
           ''',
           isExpectedError: isUndefinedIntlError,
           expectedOutput: /*language=dart*/ '''
-              import '../../../../src/intl/test_project_intl.dart';
+              import '../../../../../src/intl/test_project_intl.dart';
               content() => TestProjectIntl.testString;
           ''',
         );
@@ -61,19 +60,14 @@ void main() {
             input: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
               content() => TestProjectIntl.testString;
-              
             ''',
             isExpectedError: isUndefinedIntlError,
-
             expectedOutput: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
               import 'package:test_project/src/intl/test_project_intl.dart';
-              
-              
               content() => TestProjectIntl.testString;
               
             ''',
-
           );
         });
 
@@ -81,7 +75,6 @@ void main() {
           await testSuggestor(
             input: /*language=dart*/ '''
               import 'package:z_fake_package/z_fake_package.dart';
-
               content() => TestProjectIntl.testString;
             ''',
             isExpectedError: (e) =>
@@ -89,7 +82,6 @@ void main() {
             expectedOutput: /*language=dart*/ '''
               import 'package:test_project/src/intl/test_project_intl.dart';
               import 'package:z_fake_package/z_fake_package.dart';
-
               content() => TestProjectIntl.testString;
             ''',
           );
@@ -100,7 +92,6 @@ void main() {
             input: /*language=dart*/ '''
                 import 'package:over_react/over_react.dart';
                 import 'package:z_fake_package/z_fake_package.dart';
-
               content() => TestProjectIntl.testString;
             ''',
             isExpectedError: (e) =>
@@ -109,7 +100,6 @@ void main() {
               import 'package:over_react/over_react.dart';
               import 'package:test_project/src/intl/test_project_intl.dart';
               import 'package:z_fake_package/z_fake_package.dart';
-
               content() => TestProjectIntl.testString;
             ''',
           );
@@ -123,7 +113,6 @@ void main() {
                 import 'package:over_react/components.dart';
                 import 'package:z_fake_package/z_fake_package_1.dart';
                 import 'package:z_fake_package/z_fake_package_2.dart';
-
               content() => TestProjectIntl.testString;
             ''',
             isExpectedError: (e) =>
@@ -134,7 +123,6 @@ void main() {
               import 'package:test_project/src/intl/test_project_intl.dart';
               import 'package:z_fake_package/z_fake_package_1.dart';
               import 'package:z_fake_package/z_fake_package_2.dart';
-
               content() => TestProjectIntl.testString;
             ''',
           );
@@ -145,19 +133,15 @@ void main() {
           await testSuggestor(
             input: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
-
               import 'a/fake_relative_file.dart';
-
               content() => TestProjectIntl.testString;
             ''',
             isExpectedError: (e) =>
                 isUndefinedIntlError(e) || isFakeUriError(e),
             expectedOutput: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
-              import '../../../../src/intl/test_project_intl.dart';
-
+              import '../../../../../src/intl/test_project_intl.dart';
               import 'a/fake_relative_file.dart';
-
               content() => TestProjectIntl.testString;
             ''',
           );
@@ -176,7 +160,7 @@ void main() {
             expectedOutput: /*language=dart*/ '''
               import 'dart:html';
 
-              import '../../../../src/intl/test_project_intl.dart';
+              import '../../../../../src/intl/test_project_intl.dart';
 
               content() => TestProjectIntl.testString;
             ''',

--- a/test/intl_suggestors/intl_importer_test.dart
+++ b/test/intl_suggestors/intl_importer_test.dart
@@ -92,11 +92,10 @@ void main() {
         test('(one alphabetized before and after `TestProjectIntl`)', () async {
           await testSuggestor(
             input: /*language=dart*/ '''
-                import 'package:test_project/src/intl/test_project_intl.dart';
                 import 'package:over_react/over_react.dart';
                 import 'package:z_fake_package/z_fake_package.dart';
 
-                content() => TestProjectIntl.testString;
+              content() => TestProjectIntl.testString;
             ''',
             isExpectedError: (e) =>
                 isUndefinedIntlError(e) || isFakeUriError(e),
@@ -373,7 +372,7 @@ void main() {
       final hasPackageImports = imports.any((importStatement) => importStatement.startsWith("import 'package:"));
       final hasRelativeImports = imports.any((importStatement) => importStatement.startsWith("import '../"));
       final importFormat = decideImportFormat(hasPackageImports, hasRelativeImports);
-      expect(importFormat, isTrue);
+      expect(importFormat, isFalse);
     });
 
     test('when there are both package and relative imports', () {

--- a/test/intl_suggestors/intl_importer_test.dart
+++ b/test/intl_suggestors/intl_importer_test.dart
@@ -151,7 +151,7 @@ void main() {
                 isUndefinedIntlError(e) || isFakeUriError(e),
             expectedOutput: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
-              import 'package:test_project/src/intl/test_project_intl.dart';
+              import '../../../../src/intl/test_project_intl.dart';
 
               import 'a/fake_relative_file.dart';
 

--- a/test/intl_suggestors/intl_importer_test.dart
+++ b/test/intl_suggestors/intl_importer_test.dart
@@ -60,17 +60,20 @@ void main() {
           await testSuggestor(
             input: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
-              import 'package:test_project/src/intl/test_project_intl.dart';
               content() => TestProjectIntl.testString;
+              
             ''',
             isExpectedError: isUndefinedIntlError,
+
             expectedOutput: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
               import 'package:test_project/src/intl/test_project_intl.dart';
               
               
               content() => TestProjectIntl.testString;
+              
             ''',
+
           );
         });
 
@@ -166,6 +169,7 @@ void main() {
               import 'dart:html';
 
               content() => TestProjectIntl.testString;
+              
             ''',
             isExpectedError: (e) =>
                 isUndefinedIntlError(e) || isFakeUriError(e),

--- a/test/intl_suggestors/intl_importer_test.dart
+++ b/test/intl_suggestors/intl_importer_test.dart
@@ -108,7 +108,18 @@ void main() {
             ''',
           );
         });
-
+        test('when there are package imports',() {
+          var getStatus = decideImportFormat(true,false);
+          expect('package', equals(getStatus));
+        });
+        test('when there are relative imports',(){
+          var getStatus = decideImportFormat(false,true);
+          expect('relative', equals(getStatus));
+        });
+        test('when there are package and relative imports',(){
+          String importFormat = decideImportFormat(true,true);
+          expect('package', equals(importFormat));
+        });
         test('(more than one alphabetized before and after `TestProjectIntl`)',
             () async {
           await testSuggestor(

--- a/test/intl_suggestors/intl_importer_test.dart
+++ b/test/intl_suggestors/intl_importer_test.dart
@@ -353,37 +353,45 @@ void main() {
       });
     });
 
-    test('when there are only package imports', () {
+    test('should recognize import format as "package" when there are only package imports', () {
       final imports = [
         "import 'package:over_react/over_react.dart';",
         "import 'package:react_material_ui/react_material_ui.dart';",
       ];
       final hasPackageImports = imports.any((importStatement) => importStatement.startsWith("import 'package:"));
       final hasRelativeImports = imports.any((importStatement) => importStatement.startsWith("import '../"));
-      final importFormat = decideImportFormat(hasPackageImports, hasRelativeImports);
-      expect(importFormat, isTrue);
+      expect(hasPackageImports, isTrue);
+      expect(hasRelativeImports, isFalse);
     });
 
-    test('when there are only relative imports', () {
+    test('should recognize import format as "relative" when there are only relative imports', () {
       final imports = [
-        "import '../../../src/intl/datatables_intl.dart';",
+        "import '../../../src/intl/test_project_intl.dart';",
         "import '../lib/file.dart';",
       ];
       final hasPackageImports = imports.any((importStatement) => importStatement.startsWith("import 'package:"));
       final hasRelativeImports = imports.any((importStatement) => importStatement.startsWith("import '../"));
-      final importFormat = decideImportFormat(hasPackageImports, hasRelativeImports);
-      expect(importFormat, isFalse);
+      expect(hasPackageImports, isFalse);
+      expect(hasRelativeImports, isTrue);
     });
 
-    test('when there are both package and relative imports', () {
+    test('should recognize import format as "package" when there are both package and relative imports', () {
       final imports = [
         "import 'package:over_react/over_react.dart';",
-        "import '../../../src/intl/datatables_intl.dart';",
+        "import '../../../src/intl/test_project_intl.dart';",
       ];
       final hasPackageImports = imports.any((importStatement) => importStatement.startsWith("import 'package:"));
       final hasRelativeImports = imports.any((importStatement) => importStatement.startsWith("import '../"));
-      final importFormat = decideImportFormat(hasPackageImports, hasRelativeImports);
-      expect(importFormat, isTrue);
+      expect(hasPackageImports, isTrue);
+      expect(hasRelativeImports, isFalse);
+    });
+
+    test('should recognize import format as "package" when there are no imports', () {
+      final imports = <String>[];
+      final hasPackageImports = imports.any((importStatement) => importStatement.startsWith("import 'package:"));
+      final hasRelativeImports = imports.any((importStatement) => importStatement.startsWith("import '../"));
+      expect(hasPackageImports, isTrue);
+      expect(hasRelativeImports, isFalse);
     });
   });
 }

--- a/test/intl_suggestors/intl_importer_test.dart
+++ b/test/intl_suggestors/intl_importer_test.dart
@@ -167,6 +167,25 @@ void main() {
         });
       });
 
+      test('when there are Dart  and Package', () async {
+        await testSuggestor(
+          input: /*language=dart*/ '''
+              import 'dart:html';
+              import 'package:over_react/over_react.dart';
+
+
+              content() => TestProjectIntl.testString;
+          ''',
+          isExpectedError: (e) => isUndefinedIntlError(e) || isFakeUriError(e),
+          expectedOutput: /*language=dart*/ '''
+              import 'dart:html';
+              import 'package:over_react/over_react.dart';
+              import 'package:test_project/src/intl/test_project_intl.dart';
+
+              content() => TestProjectIntl.testString;
+          ''',
+        );
+      });
       test('package import in the same package should produce relative import',
           () async {
         await testSuggestor(

--- a/test/intl_suggestors/intl_importer_test.dart
+++ b/test/intl_suggestors/intl_importer_test.dart
@@ -172,12 +172,12 @@ void main() {
           () async {
         await testSuggestor(
           input: /*language=dart*/ '''
-           import 'package:test_project/src/intl/test_project_intl.dart';
+           
             content() => TestProjectIntl.testString;
   ''',
           isExpectedError: (e) => isUndefinedIntlError(e) || isFakeUriError(e),
           expectedOutput: /*language=dart*/ '''
-          import '/src/intl/test_project_intl.dart';
+          import 'package:test_project/src/intl/test_project_intl.dart';
     content() => TestProjectIntl.testString;
   ''',
         );

--- a/test/intl_suggestors/intl_importer_test.dart
+++ b/test/intl_suggestors/intl_importer_test.dart
@@ -168,6 +168,21 @@ void main() {
         });
       });
 
+      test('package import in the same package should produce relative import',
+          () async {
+        await testSuggestor(
+          input: /*language=dart*/ '''
+           import 'package:test_project/src/intl/test_project_intl.dart';
+            content() => TestProjectIntl.testString;
+  ''',
+          isExpectedError: (e) => isUndefinedIntlError(e) || isFakeUriError(e),
+          expectedOutput: /*language=dart*/ '''
+          import '/src/intl/test_project_intl.dart';
+    content() => TestProjectIntl.testString;
+  ''',
+        );
+      });
+
       test('when there is just a library declaration', () async {
         await testSuggestor(
           input: /*language=dart*/ '''

--- a/test/intl_suggestors/intl_importer_test.dart
+++ b/test/intl_suggestors/intl_importer_test.dart
@@ -44,6 +44,7 @@ void main() {
       test('when there are no other imports', () async {
         await testSuggestor(
           input: /*language=dart*/ '''
+          
               content() => TestProjectIntl.testString;
           ''',
           isExpectedError: isUndefinedIntlError,
@@ -59,6 +60,7 @@ void main() {
           await testSuggestor(
             input: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
+              import 'package:test_project/src/intl/test_project_intl.dart';
               content() => TestProjectIntl.testString;
             ''',
             isExpectedError: isUndefinedIntlError,

--- a/test/intl_suggestors/intl_importer_test.dart
+++ b/test/intl_suggestors/intl_importer_test.dart
@@ -92,65 +92,23 @@ void main() {
         test('(one alphabetized before and after `TestProjectIntl`)', () async {
           await testSuggestor(
             input: /*language=dart*/ '''
+                import 'package:test_project/src/intl/test_project_intl.dart';
                 import 'package:over_react/over_react.dart';
                 import 'package:z_fake_package/z_fake_package.dart';
 
-              content() => TestProjectIntl.testString;
+                content() => TestProjectIntl.testString;
             ''',
             isExpectedError: (e) =>
                 isUndefinedIntlError(e) || isFakeUriError(e),
             expectedOutput: /*language=dart*/ '''
-              import 'package:over_react/over_react.dart';
               import 'package:test_project/src/intl/test_project_intl.dart';
+              import 'package:over_react/over_react.dart';
               import 'package:z_fake_package/z_fake_package.dart';
 
               content() => TestProjectIntl.testString;
             ''',
           );
         });
-
-        test('when there are only package imports', () {
-          final imports = [
-            'import \'package:over_react/over_react.dart\';',
-            'import \'package:package_two/file.dart\';',
-          ];
-          final hasPackageImports = imports.any((importStatement) => importStatement.startsWith('import \'package:'));
-          final hasRelativeImports = imports.any((importStatement) => importStatement.startsWith('import \'../'));
-          final importFormat = decideImportFormat(hasPackageImports, hasRelativeImports);
-          expect(importFormat, isTrue);
-        });
-
-        test('when there are only relative imports', () {
-          final imports = [
-            'import \'../../../src/intl/datatables_intl.dart\';',
-            'import \'../lib/file.dart\';',
-          ];
-          final hasPackageImports = imports.any((importStatement) => importStatement.startsWith('import \'package:'));
-          final hasRelativeImports = imports.any((importStatement) => importStatement.startsWith('import \'../'));
-          final importFormat = decideImportFormat(hasPackageImports, hasRelativeImports);
-          expect(importFormat, isTrue);
-        });
-
-        test('when there are both package and relative imports', () {
-          final imports = [
-            'import \'package:package_one/file.dart\';',
-            'import \'../../../src/intl/datatables_intl.dart\';',
-          ];
-          final hasPackageImports = imports.any((importStatement) => importStatement.startsWith('import \'package:'));
-          final hasRelativeImports = imports.any((importStatement) => importStatement.startsWith('import \'../'));
-          final importFormat = decideImportFormat(hasPackageImports, hasRelativeImports);
-          expect(importFormat, isTrue);
-        });
-
-        test('when there are no import statements', () {
-          final imports = <String>[];
-          final hasPackageImports = imports.any((importStatement) => importStatement.startsWith('import \'package:'));
-          final hasRelativeImports = imports.any((importStatement) => importStatement.startsWith('import \'../'));
-          final importFormat = decideImportFormat(hasPackageImports, hasRelativeImports);
-          expect(importFormat, isFalse);
-        });
-
-
 
         test('(more than one alphabetized before and after `TestProjectIntl`)',
             () async {
@@ -182,9 +140,8 @@ void main() {
           await testSuggestor(
             input: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
-
               import 'a/fake_relative_file.dart';
-
+      
               content() => TestProjectIntl.testString;
             ''',
             isExpectedError: (e) =>
@@ -192,9 +149,8 @@ void main() {
             expectedOutput: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
               import 'package:test_project/src/intl/test_project_intl.dart';
-
               import 'a/fake_relative_file.dart';
-
+              
               content() => TestProjectIntl.testString;
             ''',
           );
@@ -278,7 +234,6 @@ void main() {
         await testSuggestor(
           input: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
-
               part 'fake_part.dart';
 
               content() => TestProjectIntl.testString;
@@ -287,7 +242,6 @@ void main() {
           expectedOutput: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
               import 'package:test_project/src/intl/test_project_intl.dart';
-
               part 'fake_part.dart';
 
               content() => TestProjectIntl.testString;
@@ -321,9 +275,7 @@ void main() {
         await testSuggestor(
           input: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
-
               export 'package:over_react/over_react.dart';
-
               part 'fake_part.dart';
 
               content() => TestProjectIntl.testString;
@@ -332,9 +284,7 @@ void main() {
           expectedOutput: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
               import 'package:test_project/src/intl/test_project_intl.dart';
-
               export 'package:over_react/over_react.dart';
-
               part 'fake_part.dart';
 
               content() => TestProjectIntl.testString;

--- a/test/intl_suggestors/intl_importer_test.dart
+++ b/test/intl_suggestors/intl_importer_test.dart
@@ -48,7 +48,7 @@ void main() {
           ''',
           isExpectedError: isUndefinedIntlError,
           expectedOutput: /*language=dart*/ '''
-              import 'package:test_project/src/intl/test_project_intl.dart';
+              import '../../../../src/intl/test_project_intl.dart';
               content() => TestProjectIntl.testString;
           ''',
         );
@@ -63,8 +63,9 @@ void main() {
             ''',
             isExpectedError: isUndefinedIntlError,
             expectedOutput: /*language=dart*/ '''
-              import 'package:test_project/src/intl/test_project_intl.dart';
               import 'package:over_react/over_react.dart';
+              import 'package:test_project/src/intl/test_project_intl.dart';
+              
               
               content() => TestProjectIntl.testString;
             ''',
@@ -100,8 +101,8 @@ void main() {
             isExpectedError: (e) =>
                 isUndefinedIntlError(e) || isFakeUriError(e),
             expectedOutput: /*language=dart*/ '''
-              import 'package:test_project/src/intl/test_project_intl.dart';
               import 'package:over_react/over_react.dart';
+              import 'package:test_project/src/intl/test_project_intl.dart';
               import 'package:z_fake_package/z_fake_package.dart';
 
               content() => TestProjectIntl.testString;
@@ -123,9 +124,9 @@ void main() {
             isExpectedError: (e) =>
                 isUndefinedIntlError(e) || isFakeUriError(e),
             expectedOutput: /*language=dart*/ '''
-              import 'package:test_project/src/intl/test_project_intl.dart';
               import 'package:over_react/over_react.dart';
               import 'package:over_react/components.dart';
+              import 'package:test_project/src/intl/test_project_intl.dart';
               import 'package:z_fake_package/z_fake_package_1.dart';
               import 'package:z_fake_package/z_fake_package_2.dart';
 
@@ -139,17 +140,19 @@ void main() {
           await testSuggestor(
             input: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
+
               import 'a/fake_relative_file.dart';
-      
+
               content() => TestProjectIntl.testString;
             ''',
             isExpectedError: (e) =>
                 isUndefinedIntlError(e) || isFakeUriError(e),
             expectedOutput: /*language=dart*/ '''
-              import 'package:test_project/src/intl/test_project_intl.dart';
               import 'package:over_react/over_react.dart';
+              import 'package:test_project/src/intl/test_project_intl.dart';
+
               import 'a/fake_relative_file.dart';
-              
+
               content() => TestProjectIntl.testString;
             ''',
           );
@@ -167,7 +170,7 @@ void main() {
             expectedOutput: /*language=dart*/ '''
               import 'dart:html';
 
-              import 'package:test_project/src/intl/test_project_intl.dart';
+              import '../../../../src/intl/test_project_intl.dart';
 
               content() => TestProjectIntl.testString;
             ''',
@@ -233,14 +236,16 @@ void main() {
         await testSuggestor(
           input: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
+
               part 'fake_part.dart';
 
               content() => TestProjectIntl.testString;
           ''',
           isExpectedError: (e) => isUndefinedIntlError(e) || isFakeUriError(e),
           expectedOutput: /*language=dart*/ '''
-              import 'package:test_project/src/intl/test_project_intl.dart';
               import 'package:over_react/over_react.dart';
+              import 'package:test_project/src/intl/test_project_intl.dart';
+
               part 'fake_part.dart';
 
               content() => TestProjectIntl.testString;
@@ -274,16 +279,20 @@ void main() {
         await testSuggestor(
           input: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
+
               export 'package:over_react/over_react.dart';
+
               part 'fake_part.dart';
 
               content() => TestProjectIntl.testString;
           ''',
           isExpectedError: (e) => isUndefinedIntlError(e) || isFakeUriError(e),
           expectedOutput: /*language=dart*/ '''
-              import 'package:test_project/src/intl/test_project_intl.dart';
               import 'package:over_react/over_react.dart';
+              import 'package:test_project/src/intl/test_project_intl.dart';
+
               export 'package:over_react/over_react.dart';
+
               part 'fake_part.dart';
 
               content() => TestProjectIntl.testString;
@@ -351,47 +360,6 @@ void main() {
           ''',
         );
       });
-    });
-
-    test('should recognize import format as "package" when there are only package imports', () {
-      final imports = [
-        "import 'package:over_react/over_react.dart';",
-        "import 'package:react_material_ui/react_material_ui.dart';",
-      ];
-      final hasPackageImports = imports.any((importStatement) => importStatement.startsWith("import 'package:"));
-      final hasRelativeImports = imports.any((importStatement) => importStatement.startsWith("import '../"));
-      expect(hasPackageImports, isTrue);
-      expect(hasRelativeImports, isFalse);
-    });
-
-    test('should recognize import format as "relative" when there are only relative imports', () {
-      final imports = [
-        "import '../../src/intl/test_project_intl.dart';",
-        "import '../lib/file.dart';",
-      ];
-      final hasPackageImports = imports.any((importStatement) => importStatement.startsWith("import 'package:"));
-      final hasRelativeImports = imports.any((importStatement) => importStatement.startsWith("import '../"));
-      expect(hasPackageImports, isFalse);
-      expect(hasRelativeImports, isTrue);
-    });
-
-    test('should recognize import format as "package" when there are both package and relative imports', () {
-      final imports = [
-        "import 'package:over_react/over_react.dart';",
-        "import '../../src/intl/test_project_intl.dart';",
-      ];
-      final hasPackageImports = imports.any((importStatement) => importStatement.startsWith("import 'package:"));
-      final hasRelativeImports = imports.any((importStatement) => importStatement.startsWith("import '../"));
-      expect(hasPackageImports, isTrue);
-      expect(hasRelativeImports, isFalse);
-    });
-
-    test('should recognize import format as "package" when there are no imports', () {
-      final imports = <String>[];
-      final hasPackageImports = imports.any((importStatement) => importStatement.startsWith("import 'package:"));
-      final hasRelativeImports = imports.any((importStatement) => importStatement.startsWith("import '../"));
-      expect(hasPackageImports, isTrue);
-      expect(hasRelativeImports, isFalse);
     });
   });
 }

--- a/test/intl_suggestors/intl_importer_test.dart
+++ b/test/intl_suggestors/intl_importer_test.dart
@@ -48,7 +48,7 @@ void main() {
           ''',
           isExpectedError: isUndefinedIntlError,
           expectedOutput: /*language=dart*/ '''
-              import '../../../../../src/intl/test_project_intl.dart';
+              import 'package:test_project/src/intl/test_project_intl.dart';
               content() => TestProjectIntl.testString;
           ''',
         );


### PR DESCRIPTION
### Problem: 
  - Add the ability for the codemod to decide how the intl class import statement will be formatted, ie. package format vs. relative format. It should behave something like this:
      - If the file has only **package** imports, go with a **package** format
      - If the file has only **relative** imports, go with a **relative** format
      - If the file has a mix of both, go with the **package** format
      - If the file has no imports, go with the **package** format
  
 ### Solution:
  - Determine where to insert the import statement. The `_insertionLocationForPackageImport` function is responsible for this.
  - This function inspects the existing import directives in the file and calculates the appropriate insertion point for the `intl` import. 
  - Tracked whether the file has **package** or **relative** imports by iterating through the existing import directives.
  - After determining the insertion location and identifying existing imports, decide on the import format. This is done in the `decideImportFormat` function.
If there are **package** imports and no **relative** imports, it selects the **package** format.
Otherwise, it selects the **relative** format.
  