### PR TITLE
INTL-1591: Handle non-arrow intl functions

### DIFF
--- a/lib/src/intl_suggestors/message_parser.dart
+++ b/lib/src/intl_suggestors/message_parser.dart
@@ -88,16 +88,17 @@ class MessageParser {
   /// partially rewritten.
   String withCorrectFunctionTypes(
       MethodDeclaration declaration, String currentSource) {
-    // Split out the body and just do a simple string replace. The conditions
-    // for a false positive on this seem unlikely, so just do it and cross our
-    // fingers. If it's in a function name it will be followed by a parenthesis.
-    // This is only used for formattedMessage, so it won't be a getter. And if
-    // you name a parameter that ends in Function it'll presumably be followed
-    // by either a comma or a close-paren.
-    var declarationParts = currentSource.split('=>');
+    // Split out the body and just do a simple string replace on the header. The
+    // conditions for a false positive on this seem unlikely, so just do it and
+    // cross our fingers. If it's in a function name it will be followed by a
+    // parenthesis. This is only used for formattedMessage, so it won't be a
+    // getter. And if you name a parameter that ends in Function it'll
+    // presumably be followed by either a comma or a close-paren.
+    var splitString = (declaration.body is BlockFunctionBody) ? '{' : '=>';
+    var declarationParts = currentSource.split(splitString);
     var newBeginning =
         declarationParts.first.replaceAll('Function ', 'Object ');
-    return '$newBeginning=>${declarationParts.last}';
+    return '$newBeginning$splitString${declarationParts.last}';
   }
 
   /// Find the parameter `name:` from the invocation, or return null if there
@@ -125,16 +126,23 @@ class MessageParser {
   }
 
   /// The invocation of the internal Intl method. That is, the part after the
-  /// '=>'.  We know there's only ever one. Used for determining what sort of
-  /// method this is message/plural/select/formattedMessage.
+  /// '=>' or the first statement inside the {}.  We expect only one. Used for
+  /// determining what sort of method this is
+  /// message/plural/select/formattedMessage.
   MethodInvocation intlMethodInvocation(MethodDeclaration method) {
-    var invocation = method.body.childEntities.toList()[1];
-    if (invocation is MethodInvocation) {
-      return invocation;
+    var node = method.body;
+    if (node is ExpressionFunctionBody) {
+      return node.expression as MethodInvocation;
+    } else if (node is BlockFunctionBody) {
+      var children = node.block.statements.first.childEntities.toList();
+      var methods = children.whereType<MethodInvocation>().toList();
+      if (methods.length > 1)
+        throw ArgumentError(
+            'A message can only contain a single call, which must be to an Intl function');
+      return methods.first;
     } else {
-      print('ERROR: Invalid Intl method: $method');
-      // We expect this to throw
-      return invocation as MethodInvocation;
+      throw ArgumentError(
+          'Cannot parse $node. It needs to be a function with a single expression which is an Intl method invocation');
     }
   }
 

--- a/test/intl_suggestors/intl_messages_test.dart
+++ b/test/intl_suggestors/intl_messages_test.dart
@@ -24,6 +24,7 @@ void main() {
         'function',
         'aPlural',
         'formatted',
+        'formattedNonArrow',
         'someSelect'
       ]);
     });
@@ -117,7 +118,7 @@ void main() {
     });
 
     test('messages found', () {
-      expect(messages.methods.length, 7);
+      expect(messages.methods.length, 8);
       expect(messages.methods.keys, [
         'orange',
         'aquamarine',
@@ -125,6 +126,7 @@ void main() {
         'function',
         'aPlural',
         'formatted',
+        'formattedNonArrow',
         'someSelect'
       ]);
       expect(messages.methods.values.map((each) => each.source).toList(),
@@ -182,7 +184,7 @@ void main() {
       var otherName = messages.nameForString('function', r'www${x}def');
       tweakedMore = tweakedMore.replaceAll('function', otherName);
       messages.addMethod(tweakedMore);
-      expect(messages.methods.length, 9);
+      expect(messages.methods.length, 10);
       expect(messages.methods['function']?.source, sampleMethods[3]);
       expect(messages.methods['function1']?.source, tweaked);
       expect(messages.methods['function2']?.source, contains(r'www${x}def'));
@@ -202,7 +204,7 @@ class TestProjectIntl {${methods.isNotEmpty ? '\n' : ''}$methods
 }''';
 
 List<String> sampleMethods = [
-  "  static String get orange => Intl.message('orange', name: 'TestProjectIntl_orange', desc: 'The color.');",
+  "  static String get orange {return Intl.message('orange', name: 'TestProjectIntl_orange', desc: 'The color.');}",
   "  static String get aquamarine => Intl.message('aquamarine', name: 'TestProjectIntl_aquamarine', desc: 'The color', meaning: 'blueish');",
   """  static String get long => Intl.message('''multi
 line 
@@ -210,12 +212,13 @@ string''', name: 'TestProjectIntl_long');""",
   """  static String function(String x) => Intl.message('abc\${x}def', name: 'TestProjectIntl_function');""",
   """  static String aPlural(int n) => Intl.plural(n, zero: 'zero', other: 'other', name: 'TestProjectIntl_aPlural', args: [n]);""",
   """  static List<Object> formatted(Object f) => Intl.formattedMessage([f, 'foo'], name: 'TestProjectIntl_formatted', args: [f]);""",
+  """  static List<Object> formattedNonArrow(Object f) {Intl.formattedMessage([f, 'foo'], name: 'TestProjectIntl_formattedNonArrow', args: [f]);}""",
   """  static String someSelect(Object choice) => Intl.select(choice, {'a' : 'b'}, name: 'TestProjectIntl_someSelect', args: [choice]);"""
 ];
 
 // The sample methods in a hard-coded sorted order.
 List<String> get sortedSampleMethods =>
-    [4, 1, 5, 3, 2, 0, 6].map((i) => sampleMethods[i]).toList();
+    [4, 1, 5, 6, 3, 2, 0, 7].map((i) => sampleMethods[i]).toList();
 
 // A test utility to be invoked from the debug console to see where subtly-different long strings differ.
 void firstDifference(String a, String b) {


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
The intl_suggestors are hard-coded to expect arrow functions, and crash with a parse error if you add one by hand and then try to run the codemod. This is sub-optimal. And pretty easy to fix. One place assumes you can split a string on the '=>' substring, and another place assumes AST structure, but can be easily adapted.

This is analogous to INTL-1589

## Changes
  <!-- What this PR changes to fix the problem. -->
Fixes, as above.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
