### PR TITLE
Start at fixing the constant migrator's date format detection

### DIFF
--- a/lib/src/intl_suggestors/intl_migrator.dart
+++ b/lib/src/intl_suggestors/intl_migrator.dart
@@ -119,18 +119,19 @@ class ConstantStringMigrator extends GeneralizingAstVisitor
       if (string.toUpperCase() == string) return;
       // Is the first character uppercase, excluding strings that start with two of the same
       // uppercase character, which has a good chance of being a date format (e.g. 'MM/dd/YYYY').
-      if (firstLetter != secondLetter &&
-          firstLetter.toLowerCase() != firstLetter) {
-        // Constant strings might be private.
-        var name = publicNameFor(node);
-        names.add(name);
-        final functionCall =
-            _messages.syntax.getterCall(literal, _className, name: name);
-        final functionDef =
-            _messages.syntax.getterDefinition(literal, _className, name: name);
-        yieldPatch('final String ${node.name} = $functionCall', start, end);
-        addMethodToClass(_messages, functionDef);
+      if (firstLetter == secondLetter &&
+          firstLetter.toUpperCase() == firstLetter) {
+        return;
       }
+      // Constant strings might be private.
+      var name = publicNameFor(node);
+      names.add(name);
+      final functionCall =
+          _messages.syntax.getterCall(literal, _className, name: name);
+      final functionDef =
+          _messages.syntax.getterDefinition(literal, _className, name: name);
+      yieldPatch('final String ${node.name} = $functionCall', start, end);
+      addMethodToClass(_messages, functionDef);
     }
   }
 

--- a/test/intl_suggestors/constant_migrator_test.dart
+++ b/test/intl_suggestors/constant_migrator_test.dart
@@ -61,10 +61,10 @@ void main() {
       test('non-matching standalone constant', () async {
         await testSuggestor(
           input: '''
-            const foo = 'probably-not';
+            const foo = 'probably_not';
             ''',
           expectedOutput: '''
-            const foo = 'probably-not';
+            const foo = 'probably_not';
             ''',
         );
         final expectedFileContent = '';
@@ -142,6 +142,33 @@ void main() {
             ''',
         );
         final expectedFileContent = '';
+        expect(messages.messageContents(), expectedFileContent);
+      });
+
+      test('date formats are ignored', () async {
+        await testSuggestor(
+          input: '''
+            const foo = 'MM/dd/yy';
+            ''',
+          expectedOutput: '''
+            const foo = 'MM/dd/yy';
+            ''',
+        );
+        final expectedFileContent = '';
+        expect(messages.messageContents(), expectedFileContent);
+      });
+
+      test('date format logic does not have false positives', () async {
+        await testSuggestor(
+          input: '''
+            const migrateMe = 'migrate me';
+            ''',
+          expectedOutput: '''
+            final String migrateMe = TestClassIntl.migrateMe;
+            ''',
+        );
+        final expectedFileContent =
+            '\n  static String get migrateMe => Intl.message(\'migrate me\', name: \'TestClassIntl_migrateMe\');\n';
         expect(messages.messageContents(), expectedFileContent);
       });
 


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

In attempting to work on something else I put in a constant of the form
const migrateMe = 'migrate me';
into a file, and then wondered why it wasn't getting migrated. Which led me to realize that the boolean expression for avoiding strings like 'MM/dd/yy' was incorrect. So I fixed it, and then realized that it broke a different test, where we screen out strings like 'probably-not' which are, we guess, maybe CSS selectors. But that's not great because it's possible if, um, 'un-likely' to have user-visible strings like that. So if we just fix this logic then it might start picking up other strings we didn't want. And it looks like we don't really actually have any logic for screening those out, though I could have sworn we did. There's some stuff in utils for filtering out pure camelCase alphabetics, but I didn't see this.

Also, the logic here is still questionable, because date formats don't necessarily start with upper case. We'd almost be equally well off just looking for an 'MM/' prefix.

Anyway, I'm leaving this for the moment, but left the code in place for posterity.


## Changes
  <!-- What this PR changes to fix the problem. -->

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
