### PR TITLE
INTL-1677: Exclude Pendo ID pattern in codemod

### DIFF
--- a/lib/src/intl_suggestors/intl_migrator.dart
+++ b/lib/src/intl_suggestors/intl_migrator.dart
@@ -95,7 +95,10 @@ class ConstantStringMigrator extends GeneralizingAstVisitor
   bool shouldMigrate(VariableDeclaration node) {
     if (isStatementIgnored(node)) return false;
     if (isFileIgnored(this.context.sourceText)) return false;
-    return true;
+    var string = node.initializer;
+    return string != null &&
+        (isValidStringLiteralNode(string) ||
+            isValidStringInterpolationNode(string));
   }
 
   @override

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -67,7 +67,7 @@ bool isValidStringLiteralNode(AstNode node) {
   if (text == null) return false;
   if (text.isEmpty) return false;
   if (double.tryParse(text) != null) return false;
-  if (quotedCamelCase(text)) return false;
+  if (isCamelCase(text)) return false;
   if (text.trim().length == 1) return false;
   // If there are no alphabetic characters, we can't do anything useful.
   if (hasNoAlphabeticCharacters(text)) return false;
@@ -230,15 +230,32 @@ bool excludeUnlikelyExpressions<E extends Expression>(
   if (source == "'.'") return true;
   if (source == "'('") return true;
   if (source == "')'") return true;
-  if (quotedCamelCase(source)) return true;
+  if (isCamelCase(source)) return true;
 
   return false;
 }
 
-// If a string value is wrapped in quotes, and is in lowerCamelCase or UpperCamelCase, it is most likely a key of some kind, not a human-readable, translatable string.
-bool quotedCamelCase(String str) => RegExp(
-        r"^'([a-z]+[A-Z0-9][a-z0-9]+[A-Za-z0-9]*)|([A-Z][a-z0-9]*[A-Z0-9][a-z0-9]+[A-Za-z0-9]*)'$")
-    .hasMatch(str);
+/// Matches, where
+///  lower = a lower case letter
+///  UPPER = an upper case letter
+///  ALPHANUM = upper case or digit or period.
+///  alphanum = lower case or digit or period.
+///  whatev = any letter, any case, digit, or period.
+///  a) (lower)+(ALPHANUM)(alphanum)+(whatev)*
+///  b) (UPPER)(alphanum)*(ALPHANUM)(alphanum)+(whatev*)
+///
+/// So basically camel case either starting lower case or upper case.
+final _camelRegexp = RegExp(
+    r"^([a-z]+[A-Z0-9][a-z0-9]+[A-Za-z0-9]*)|([A-Z][a-z0-9]*[A-Z0-9][a-z0-9]+[A-Za-z0-9]*)$");
+
+/// If a string value is in lowerCamelCase or UpperCamelCase or
+/// Period.Separated.Camels, it is most likely a key of some kind, not a
+/// human-readable, translatable string.
+bool isCamelCase(String str) {
+  // return str.split('').every((c) => c);
+  var looksLikeQuotedCamelCase = _camelRegexp.hasMatch(str);
+  return looksLikeQuotedCamelCase;
+}
 
 extension ReactTypes$DartType on DartType {
   bool get isComponentClass => element?.isComponentClass ?? false;

--- a/test/intl_suggestors/constant_migrator_test.dart
+++ b/test/intl_suggestors/constant_migrator_test.dart
@@ -71,6 +71,32 @@ void main() {
         expect(messages.messageContents(), expectedFileContent);
       });
 
+      test('CamelCase constant', () async {
+        await testSuggestor(
+          input: '''
+            const foo = 'ProbablyAnIdentifier';
+            ''',
+          expectedOutput: '''
+            const foo = 'ProbablyAnIdentifier';
+            ''',
+        );
+        final expectedFileContent = '';
+        expect(messages.messageContents(), expectedFileContent);
+      });
+
+      test('Pendo ID', () async {
+        await testSuggestor(
+          input: '''
+            const foo = 'Probably.An.Identifier';
+            ''',
+          expectedOutput: '''
+            const foo = 'Probably.An.Identifier';
+            ''',
+        );
+        final expectedFileContent = '';
+        expect(messages.messageContents(), expectedFileContent);
+      });
+
       test('ignored standalone constant', () async {
         var input = '''
             // ignore_statement: intl_message_migration

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -90,8 +90,8 @@ void main() {
               (props) {
 
                 return (Dom.div())(
-                  'testString1',
-                  'testString2',
+                  'test String1',
+                  'test String2',
                 );
               },
               _\$FooConfig, //ignore: undefined_identifier
@@ -113,7 +113,7 @@ void main() {
         );
 
         final expected =
-            "\n  static String get testString1 => Intl.message('testString1', name: 'TestClassIntl_testString1');\n\n  static String get testString2 => Intl.message('testString2', name: 'TestClassIntl_testString2');\n";
+            "\n  static String get testString1 => Intl.message('test String1', name: 'TestClassIntl_testString1');\n\n  static String get testString2 => Intl.message('test String2', name: 'TestClassIntl_testString2');\n";
         expect(messages.messageContents(), expected);
       });
 
@@ -1370,8 +1370,8 @@ void main() {
             'UiFactory<FooProps> Foo = uiFunction(\n'
             '  (props) {\n'
             '    return (Dom.div())(\n'
-            '      \'testString1\',\n'
-            '      \'testString2\',\n'
+            '      \'test String1\',\n'
+            '      \'test String2\',\n'
             '    );\n'
             '  },\n'
             '  _\$FooConfig, //ignore: undefined_identifier\n'
@@ -1381,8 +1381,8 @@ void main() {
             '  (props) {\n'
             '    //ignore_statement: intl_message_migration\n'
             '    return (Dom.div())(\n'
-            '      \'testString1\',\n'
-            '      \'testString2\',\n'
+            '      \'test String1\',\n'
+            '      \'test String2\',\n'
             '    );\n'
             '  },\n'
             '  _\$FooConfig, //ignore: undefined_identifier\n'
@@ -1406,8 +1406,8 @@ void main() {
             '  (props) {\n'
             '    //ignore_statement: intl_message_migration\n'
             '    return (Dom.div())(\n'
-            '      \'testString1\',\n'
-            '      \'testString2\',\n'
+            '      \'test String1\',\n'
+            '      \'test String2\',\n'
             '    );\n'
             '  },\n'
             '  _\$FooConfig, //ignore: undefined_identifier\n'
@@ -1433,7 +1433,7 @@ mixin FooProps on UiProps {}
         //ignore_statement: intl_message_migration
         ..value='bar'
         ..title='qux')(
-         'testString1',
+         'test String1',
         );
     },
     _\$FooConfig, //ignore: undefined_identifier
@@ -1477,7 +1477,7 @@ mixin FooProps on UiProps {}
             '    const String uploaderAutomationId = \'Shell.Rich.Body.Uploader\';'
             '    // ignore_statement: intl_message_migration \n'
             '    return (Dom.div())(\n'
-            '      \'testString1\',\n'
+            '      \'test String1\',\n'
             '      uploaderAutomationId,\n'
             '    );\n'
             '  },\n'
@@ -1487,8 +1487,8 @@ mixin FooProps on UiProps {}
             'UiFactory<FooProps> Bar = uiFunction(\n'
             '  (props) {\n'
             '    return (Dom.div())(\n'
-            '      \'testString1\',\n'
-            '      \'testString2\',\n'
+            '      \'test String1\',\n'
+            '      \'test String2\',\n'
             '    );\n'
             '  },\n'
             '  _\$FooConfig, //ignore: undefined_identifier\n'
@@ -1504,7 +1504,7 @@ mixin FooProps on UiProps {}
             '    const String uploaderAutomationId = \'Shell.Rich.Body.Uploader\';'
             '    // ignore_statement: intl_message_migration \n'
             '    return (Dom.div())(\n'
-            '      \'testString1\',\n'
+            '      \'test String1\',\n'
             '      uploaderAutomationId,\n'
             '    );\n'
             '  },\n'

--- a/test/intl_suggestors/utils_test.dart
+++ b/test/intl_suggestors/utils_test.dart
@@ -159,6 +159,10 @@ void main() {
         expect(isCamelCase("hello"), isFalse);
       });
 
+      test('Single words with upper case', () {
+        expect(isCamelCase("Hello"), isFalse);
+      });
+
       test('HelloWorld7 counts', () {
         expect(isCamelCase("HelloWorld7"), isTrue);
       });

--- a/test/intl_suggestors/utils_test.dart
+++ b/test/intl_suggestors/utils_test.dart
@@ -143,5 +143,32 @@ void main() {
         expect(toVariableName("Test's test'1"), 'testsTest1');
       });
     });
+
+    group('CamelCase', () {
+      test('helloWorld', () {
+        expect(isCamelCase("helloWorld"), isTrue);
+      });
+      test('HelloWorld', () {
+        expect(isCamelCase("HelloWorld"), isTrue);
+      });
+      test('Hello World', () {
+        expect(isCamelCase("Hello World"), isFalse);
+      });
+
+      test('Single words do not count', () {
+        expect(isCamelCase("hello"), isFalse);
+      });
+
+      test('HelloWorld7 counts', () {
+        expect(isCamelCase("HelloWorld7"), isTrue);
+      });
+
+      test('mixed-in digits', () {
+        expect(isCamelCase("If7MaidsWith7Mops"), isTrue);
+      });
+      test('Periods', () {
+        expect(isCamelCase("Hello.World.7"), isTrue);
+      });
+    });
   });
 }


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

Exclude Pendo IDs, or similar from conversion. Those are of the form Period.Separated.Uppercase.Words

## Changes
  <!-- What this PR changes to fix the problem. -->
- It turns out that our existing check for CamelCaseWords wasn't actually working. Or at least it was checking for quoted strings, meaning e.g. var foo = "'stuff'". Which are extremely rare. I didn't think this made any sense at all, so I just dropped the "quoted" requirement and allowed periods within the word. It also had no tests, so it's hard to know what the intent was. Added some tests.
- We also weren't using the checks for strings to exclude in the constant string migrator, so I started including them.
- We used strings that we expected to be converted in test cases, which met the camel case requirement (if we didn't have quotes), specifically 'testString1', 'testString2'. I turned those into 'test String 1' and 2.
- There were a number of regular expressions used in utils.dart which were being recreated every time through the method. Regular expressions are relatively expensive to initialize, so I pulled them out into variables.
- The camel case check is done via a very large RegExp. I considered rewriting it, but the logic is fairly complicated, so I settled for writing an extensive comment.

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [x] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
