### PR TITLE
INTL-1685: improve failure message

### DIFF
--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -22,6 +22,7 @@ import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:glob/glob.dart';
 import 'package:glob/list_local_fs.dart';
+import 'package:io/ansi.dart' as ansi;
 import 'package:logging/logging.dart';
 import 'package:over_react_codemod/src/intl_suggestors/intl_configs_migrator.dart';
 import 'package:over_react_codemod/src/intl_suggestors/intl_importer.dart';
@@ -210,7 +211,7 @@ void main(List<String> args) async {
 }
 
 void printInBlue(String text) {
-  print('\x1B[34m$text\x1B[0m');
+  print(ansi.blue.wrap(text));
 }
 
 void printUsage() {

--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -199,6 +199,18 @@ void main(List<String> args) async {
     await migratePackage(
         package, packageNameLookup, processedPackages, codemodArgs, dartPaths);
   }
+
+  if (exitCode != 0) {
+    printInBlue(
+        'To resolve these changes, please execute the codemod locally by running :');
+    printInBlue('dart pub global activate --overwrite over_react_codemod');
+    printInBlue(
+        'dart pub global run over_react_codemod:intl_message_migration --migrate-constants --prune-unused');
+  }
+}
+
+void printInBlue(String text) {
+  print('\x1B[34m$text\x1B[0m');
 }
 
 void printUsage() {

--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -206,7 +206,7 @@ void main(List<String> args) async {
         'To resolve these changes, please execute the codemod locally by running :');
     printInBlue('dart pub global activate --overwrite over_react_codemod');
     printInBlue(
-        'dart pub global run over_react_codemod:intl_message_migration --migrate-constants --prune-unused');
+        'dart pub global run over_react_codemod:intl_message_migration');
   }
 }
 


### PR DESCRIPTION
## Motivation

When engineers see a CI check failure, they are not provided any indication of next steps.

> 1 change(s) needed.

## Changes

- modified failure message to include instructions on how to run the INTLcodemod locally

![Screenshot 2023-10-26 at 10 07 04 AM](https://github.com/Workiva/over_react_codemod/assets/2326518/013e96ad-ea04-4ae2-bab1-0ab9191de32c)



#### Release Notes
modify failure message to include instructions on how to run the INTL codemod locally

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
