### PR TITLE
INTL-1581 : Add wiki link to exceptions Codemod Crash Information in our Wiki

### DIFF
--- a/lib/src/executables/dart2_9_upgrade.dart
+++ b/lib/src/executables/dart2_9_upgrade.dart
@@ -162,7 +162,10 @@ extension on RecursiveAstVisitor {
       try {
         sourceText = file.readAsStringSync();
       } catch (e, stack) {
-        logger.warning('Failed to read file: ${file.path} - More details: https://wiki.atl.workiva.net/display/FEF/Codemod+Exception+Handling', e, stack);
+        logger.warning(
+            'Failed to read file: ${file.path} - More details: https://wiki.atl.workiva.net/display/FEF/Codemod+Exception+Handling',
+            e,
+            stack);
         continue;
       }
 

--- a/lib/src/executables/dart2_9_upgrade.dart
+++ b/lib/src/executables/dart2_9_upgrade.dart
@@ -162,7 +162,7 @@ extension on RecursiveAstVisitor {
       try {
         sourceText = file.readAsStringSync();
       } catch (e, stack) {
-        logger.warning('Failed to read file: ${file.path}', e, stack);
+        logger.warning('Failed to read file: ${file.path} - More details: https://wiki.atl.workiva.net/display/FEF/Codemod+Exception+Handling', e, stack);
         continue;
       }
 

--- a/lib/src/executables/dependency_validator_ignore.dart
+++ b/lib/src/executables/dependency_validator_ignore.dart
@@ -65,10 +65,10 @@ void main(List<String> args) async {
       print('[${rec.level}] ${rec.message}');
     }
     if (rec.error != null) {
-      print(rec.error);
+      print('Error: ${rec.error} \n more details: https://wiki.atl.workiva.net/display/FEF/Codemod+Exception+Handling');
     }
     if (rec.stackTrace != null) {
-      print(rec.stackTrace);
+      print('Stack Trace: ${rec.stackTrace}\n more details: https://wiki.atl.workiva.net/display/FEF/Codemod+Exception+Handling');
     }
   });
 

--- a/lib/src/executables/dependency_validator_ignore.dart
+++ b/lib/src/executables/dependency_validator_ignore.dart
@@ -65,10 +65,12 @@ void main(List<String> args) async {
       print('[${rec.level}] ${rec.message}');
     }
     if (rec.error != null) {
-      print('Error: ${rec.error} \n more details: https://wiki.atl.workiva.net/display/FEF/Codemod+Exception+Handling');
+      print(
+          'Error: ${rec.error} \n more details: https://wiki.atl.workiva.net/display/FEF/Codemod+Exception+Handling');
     }
     if (rec.stackTrace != null) {
-      print('Stack Trace: ${rec.stackTrace}\n more details: https://wiki.atl.workiva.net/display/FEF/Codemod+Exception+Handling');
+      print(
+          'Stack Trace: ${rec.stackTrace}\n more details: https://wiki.atl.workiva.net/display/FEF/Codemod+Exception+Handling');
     }
   });
 

--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -194,7 +194,7 @@ void main(List<String> args) async {
     additionalHelpOutput: parser.usage,
   );
   if (exitCode != 0) return;
-  logWarning('^ Ignore the "codemod found no files" warning above for now.');
+  logWarning('^ Ignore the "codemod found no files" warning above for now, more details: https://wiki.atl.workiva.net/display/FEF/Codemod+Exception+Handling');
 
   for (String package in packageRoots) {
     await migratePackage(
@@ -273,7 +273,7 @@ Future<void> migratePackage(
     packageDartPaths =
         dartFilesToMigrateForPackage(package, processedPackages).toList();
   } on FileSystemException {
-    _log.info('${package} does not have a lib directory, moving on...');
+    _log.info('${package} does not have a lib directory, moving on...  more details: https://wiki.atl.workiva.net/display/FEF/Codemod+Exception+Handling');
     return;
   }
 
@@ -335,7 +335,7 @@ void sortPartsLast(List<String> dartPaths) {
 
   if (dartPaths.isNotEmpty && dartPaths.every(isPart)) {
     logShout(
-        'Only part files were specified. The containing library must be included for any part file, as it is needed for analysis context');
+        'Only part files were specified. The containing library must be included for any part file, as it is needed for analysis context \n more details: https://wiki.atl.workiva.net/display/FEF/Codemod+Exception+Handling');
     exit(1);
   }
   dartPaths.sort((a, b) {

--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -194,7 +194,8 @@ void main(List<String> args) async {
     additionalHelpOutput: parser.usage,
   );
   if (exitCode != 0) return;
-  logWarning('^ Ignore the "codemod found no files" warning above for now, more details: https://wiki.atl.workiva.net/display/FEF/Codemod+Exception+Handling');
+  logWarning(
+      '^ Ignore the "codemod found no files" warning above for now, more details: https://wiki.atl.workiva.net/display/FEF/Codemod+Exception+Handling');
 
   for (String package in packageRoots) {
     await migratePackage(
@@ -273,7 +274,8 @@ Future<void> migratePackage(
     packageDartPaths =
         dartFilesToMigrateForPackage(package, processedPackages).toList();
   } on FileSystemException {
-    _log.info('${package} does not have a lib directory, moving on...  more details: https://wiki.atl.workiva.net/display/FEF/Codemod+Exception+Handling');
+    _log.info(
+        '${package} does not have a lib directory, moving on...  more details: https://wiki.atl.workiva.net/display/FEF/Codemod+Exception+Handling');
     return;
   }
 

--- a/lib/src/intl_suggestors/intl_migrator.dart
+++ b/lib/src/intl_suggestors/intl_migrator.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: cast_nullable_to_non_nullable
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:codemod/codemod.dart';

--- a/lib/src/intl_suggestors/message_parser.dart
+++ b/lib/src/intl_suggestors/message_parser.dart
@@ -112,6 +112,7 @@ class MessageParser {
   String withCorrectedNameParameter(MethodDeclaration declaration) {
     var invocation = intlMethodInvocation(declaration);
     var nameParameter = nameParameterFrom(invocation);
+    // ignore: cast_nullable_to_non_nullable
     var className = (declaration.parent as ClassDeclaration).name.lexeme;
     var expected = "'${className}_${declaration.name.lexeme}'";
     var actual = nameParameter?.expression.toSource();

--- a/lib/src/react16_suggestors/react_style_maps_updater.dart
+++ b/lib/src/react16_suggestors/react_style_maps_updater.dart
@@ -162,6 +162,7 @@ class ReactStyleMapsUpdater extends GeneralizingAstVisitor
             // Handle `toRem(1).toString()`
             if (invocation.methodName.name == 'toString' &&
                 invocation.target is MethodInvocation) {
+              // ignore: cast_nullable_to_non_nullable
               invocation = invocation.target as MethodInvocation;
             }
 

--- a/test/dart2_9_suggestors/dart2_9_utilities_test.dart
+++ b/test/dart2_9_suggestors/dart2_9_utilities_test.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ignore_for_file: cast_nullable_to_non_nullable
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:over_react_codemod/src/dart2_9_suggestors/dart2_9_constants.dart';

--- a/test/util/component_usage_test.dart
+++ b/test/util/component_usage_test.dart
@@ -269,6 +269,7 @@ void main() {
                   expressionNode.argumentList.arguments.firstOrNull, isNotNull);
               expect(expressionNode.argumentList.arguments.firstOrNull,
                   isA<InvocationExpression>());
+              // ignore: cast_nullable_to_non_nullable
               childExpression = expressionNode
                   .argumentList.arguments.firstOrNull as InvocationExpression;
               expect(childExpression.toSource(), childSource);


### PR DESCRIPTION
## Problem
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
When we run `codemod` and fund any exception then we have no link in the guideline link in the error stack. INTL team created a document on wiki Codemod Exception [Handling](https://wiki.atl.workiva.net/display/FEF/Codemod+Exception+Handling) 
## Solution
  <!-- What this PR changes to fix the problem. -->
Add the Link of wiki [page]( https://wiki.atl.workiva.net/display/FEF/Codemod+Exception+Handling) in the error log. Like 
`logger.warning('Failed to read file: ${file.path} - More details: https://wiki.atl.workiva.net/display/FEF/Codemod+Exception+Handling', e, stack);`

       