### PR TITLE
Remove web_skin_dart all.dart export usages - manual fixup to use component-specific imports

### DIFF
--- a/test/executables/mui_migration_test.dart
+++ b/test/executables/mui_migration_test.dart
@@ -129,7 +129,7 @@ dependencies:'''),
           script: muiCodemodScript,
           input: inputFiles(additionalFilesInLib: [
             d.file('usage2.dart', /*language=dart*/ '''
-              import 'package:web_skin_dart/component2/all.dart';
+              
 
               usage() => ButtonToolbar()(
                 Button()(),
@@ -142,7 +142,7 @@ dependencies:'''),
           expectedOutput: expectedOutputFiles(additionalFilesInLib: [
             d.file('usage2.dart', /*language=dart*/ '''
               import 'package:react_material_ui/react_material_ui.dart' as mui;
-import 'package:web_skin_dart/component2/all.dart';
+
 
               usage() => ButtonToolbar()(
                 mui.Button()(),
@@ -158,7 +158,7 @@ import 'package:web_skin_dart/component2/all.dart';
           script: muiCodemodScript,
           input: inputFiles(additionalFilesInLib: [
             d.file('usage2.dart', /*language=dart*/ '''
-              import 'package:web_skin_dart/component2/all.dart';
+              
 
               usage() => ButtonToolbar()(
                 Button()(),
@@ -171,7 +171,7 @@ import 'package:web_skin_dart/component2/all.dart';
           expectedOutput: expectedOutputFiles(additionalFilesInLib: [
             d.file('usage2.dart', /*language=dart*/ '''
               import 'package:react_material_ui/react_material_ui.dart' as mui;
-import 'package:web_skin_dart/component2/all.dart';
+
 
               usage() => mui.ButtonToolbar()(
                 mui.Button()(),
@@ -196,7 +196,7 @@ import 'package:web_skin_dart/component2/all.dart';
           script: muiCodemodScript,
           input: inputFiles(additionalFilesInLib: [
             d.file('usage2.dart', /*language=dart*/ '''
-              import 'package:web_skin_dart/component2/all.dart';
+              
 
               usage() => ButtonToolbar()(
                 Button()(),

--- a/test/mui_suggestors/components/shared.dart
+++ b/test/mui_suggestors/components/shared.dart
@@ -14,8 +14,8 @@
 
 String withOverReactAndWsdImports(String source) => /*language=dart*/ '''
     import 'package:over_react/over_react.dart';
-    import 'package:web_skin_dart/component2/all.dart';
-    import 'package:web_skin_dart/component2/all.dart' as wsd_v2;
+    
+    
     import 'package:web_skin_dart/ui_components.dart' as wsd_v1;
     import 'package:web_skin_dart/component2/toolbars.dart' as toolbars_v2;
     import 'package:web_skin_dart/toolbars.dart' as toolbars_v1;

--- a/test/test_fixtures/wsd_project/lib/analysis_warmup.dart
+++ b/test/test_fixtures/wsd_project/lib/analysis_warmup.dart
@@ -1,7 +1,7 @@
 // This file imports WSD and over_react and can be analyzed to warm up an
 // analysis context during testing.
 
-import 'package:web_skin_dart/component2/all.dart';
+
 import 'package:over_react/over_react.dart';
 
 main() {

--- a/test/util/unused_import_remover_test.dart
+++ b/test/util/unused_import_remover_test.dart
@@ -112,13 +112,13 @@ void main() {
           input: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
               import 'package:web_skin_dart/ui_components.dart';
-              import 'package:web_skin_dart/component2/all.dart' as wsd2;
+              
           
               content() => wsd2.Button()();
           ''',
           expectedOutput: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
-              import 'package:web_skin_dart/component2/all.dart' as wsd2;
+              
           
               content() => wsd2.Button()();
           ''',
@@ -134,13 +134,13 @@ void main() {
           input: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
               import 'package:web_skin_dart/ui_components.dart';
-              import 'package:web_skin_dart/component2/all.dart' as wsd2;
+              
           
               content() => wsd2.Button()();
           ''',
           expectedOutput: /*language=dart*/ '''
               import 'package:web_skin_dart/ui_components.dart';
-              import 'package:web_skin_dart/component2/all.dart' as wsd2;
+              
           
               content() => wsd2.Button()();
           ''',


### PR DESCRIPTION
web_skin_dart has exports for individual components and an "all" export that has all components.  If everywhere uses the individual component exports, then the compiler will only have to consider the component code it needs, resulting in faster build times.  But, this only works if everywhere is using the individual component exports.
 
 This batch removes the all.dart import.  It will require manual fixup using an IDE's fix suggestions to import the component exports.  If you would like to help us fan out and do this simple manual work to get rid of all analyzer errors, that would be fantastic.  Once CI is green, you can review and merge it.  Be careful to only import `component2` exports.  If you import the old component1 symbols, your components may break or regress.
 
 Since the same symbols will be used, static analysis and CI passing should be sufficient for QA +1.
 
 For more info reach out to Tom Connell on Slack.

[_Created by Sourcegraph batch change `Workiva/web_skin_dart_all_import`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/web_skin_dart_all_import)