### PR TITLE
Allow consumption of null-safe over_react and over_react_test versions

### DIFF
--- a/test/test_fixtures/over_react_project/pubspec.yaml
+++ b/test/test_fixtures/over_react_project/pubspec.yaml
@@ -2,4 +2,4 @@ name: over_react_project
 environment:
   sdk: '>=2.11.0 <3.0.0'
 dependencies:
-  over_react: ^4.2.0
+  over_react: '>=4.2.0 <6.0.0'

--- a/test/test_fixtures/rmui_project/pubspec.yaml
+++ b/test/test_fixtures/rmui_project/pubspec.yaml
@@ -2,7 +2,7 @@ name: rmui_project
 environment:
   sdk: '>=2.11.0 <3.0.0'
 dependencies:
-  over_react: ^4.2.0
+  over_react: '>=4.2.0 <6.0.0'
   react_material_ui:
     hosted:
       name: react_material_ui

--- a/test/test_fixtures/wsd_project/pubspec.yaml
+++ b/test/test_fixtures/wsd_project/pubspec.yaml
@@ -2,7 +2,7 @@ name: wsd_project
 environment:
   sdk: '>=2.11.0 <3.0.0'
 dependencies:
-  over_react: ^4.2.0
+  over_react: '>=4.2.0 <6.0.0'
   web_skin_dart:
     hosted:
       name: web_skin_dart


### PR DESCRIPTION
This PR widens the allowable version ranges to over_react 5.0.0 / over_react_test 3.0.0 so that all repos at Workiva can consume without updating all repositories in lock step.
These major versions are a critical step towards unlocking null safety in Workiva's Dart ecosystem - and **have already been tested and verified as safe for consumption** using the `over_react_codemod` test PR [listed in this SourceGraph batch](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/over_react_5_test).
Due to the exhaustive consumption testing already performed in this repository by the FED team prior to releasing over_react 5.0.0, **these changes can be merged without approval from a FED team member.**

---

For more information about these changes, see [this post](https://workiva.slack.com/archives/C05GYDT1Z0E/p1711564946578809) in the [#frontend-advocate-network](https://workiva.enterprise.slack.com/archives/C05GYDT1Z0E) channel. Otherwise, reach out to the FED team in [#support-ui-platform](https://workiva.enterprise.slack.com/archives/CEFTMBPAA) with any specific questions or concerns.

[_Created by Sourcegraph batch change `Workiva/over_react-5.0_raise-upper`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/over_react-5.0_raise-upper)