### PR TITLE
Remove web_skin_dart ui_component.dart and ui_core.dart usages; use granular imports

### DIFF
--- a/test/mui_suggestors/components/shared.dart
+++ b/test/mui_suggestors/components/shared.dart
@@ -18,7 +18,7 @@ String withOverReactAndWsdImports(String source) => /*language=dart*/ '''
     import 'package:over_react/over_react.dart';
     import 'package:web_skin_dart/component2/all.dart';
     import 'package:web_skin_dart/component2/all.dart' as wsd_v2;
-    import 'package:web_skin_dart/ui_components.dart' as wsd_v1;
+    import 'package:web_skin/web_skin.dart'; import 'package:web_skin_dart/constants.dart'; import 'package:web_skin_dart/shared.dart' hide getMeasuredTextWidth;
     import 'package:web_skin_dart/component2/toolbars.dart' as toolbars_v2;
     import 'package:web_skin_dart/toolbars.dart' as toolbars_v1;
     

--- a/test/rmui_preparation_suggestors/dart_script_adder_test.dart
+++ b/test/rmui_preparation_suggestors/dart_script_adder_test.dart
@@ -181,9 +181,9 @@ void _dartScriptAdderTests(
                     dartHeaders: const [
                       "import 'package:web_skin/web_skin.dart';",
                       "import 'package:platform_detect/decorator.dart';",
-                      "import 'package:web_skin_dart/ui_core.dart';",
+                      "import 'package:over_react/over_react.dart';  import 'package:web_skin_dart/ui_core_utils.dart';",
                       "import 'package:over_react/over_react.dart';",
-                      "import 'package:web_skin_dart/ui_components.dart';",
+                      "import 'package:web_skin/web_skin.dart'; import 'package:web_skin_dart/constants.dart'; import 'package:web_skin_dart/shared.dart' hide getMeasuredTextWidth;",
                     ],
                     htmlHeaders: const [
                       '${scriptStrings.join('\',\n\'')}',
@@ -204,9 +204,9 @@ void _dartScriptAdderTests(
                     dartHeaders: const [
                       "import 'package:web_skin/web_skin.dart';",
                       "import 'package:platform_detect/decorator.dart';",
-                      "import 'package:web_skin_dart/ui_core.dart';",
+                      "import 'package:over_react/over_react.dart';  import 'package:web_skin_dart/ui_core_utils.dart';",
                       "import 'package:over_react/over_react.dart';",
-                      "import 'package:web_skin_dart/ui_components.dart';",
+                      "import 'package:web_skin/web_skin.dart'; import 'package:web_skin_dart/constants.dart'; import 'package:web_skin_dart/shared.dart' hide getMeasuredTextWidth;",
                     ],
                     htmlHeaders: const [
                       '${scriptStrings.join('\',\n\'')}',

--- a/test/unify_package_rename_suggestors/import_renamer_test.dart
+++ b/test/unify_package_rename_suggestors/import_renamer_test.dart
@@ -95,7 +95,7 @@ void main() {
           input: '''
               import 'package:react_material_ui/react_material_ui.dart';
               import 'package:over_react/over_react.dart';
-              import 'package:web_skin_dart/ui_components.dart';
+              import 'package:web_skin/web_skin.dart'; import 'package:web_skin_dart/constants.dart'; import 'package:web_skin_dart/shared.dart' hide getMeasuredTextWidth;
               import 'package:react_material_ui/for_cp_use_only/styled.dart';
               import 'package:react_material_ui/components/mui_list.dart';
               import 'package:react_material_ui/styles/styled.dart';
@@ -112,7 +112,7 @@ void main() {
               '''unify_ui/styles/styled.dart';
               import 'package:'''
               '''unify_ui/unify_ui.dart';
-              import 'package:web_skin_dart/ui_components.dart';
+              import 'package:web_skin/web_skin.dart'; import 'package:web_skin_dart/constants.dart'; import 'package:web_skin_dart/shared.dart' hide getMeasuredTextWidth;
           
               content() => Dom.div()();
           ''',

--- a/test/util/unused_import_remover_test.dart
+++ b/test/util/unused_import_remover_test.dart
@@ -48,7 +48,7 @@ void main() {
         await testSuggestor(
           input: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
-              import 'package:web_skin_dart/ui_components.dart';
+              import 'package:web_skin/web_skin.dart'; import 'package:web_skin_dart/constants.dart'; import 'package:web_skin_dart/shared.dart' hide getMeasuredTextWidth;
           
               content() => Dom.div()();
           ''',
@@ -63,7 +63,7 @@ void main() {
       test('when it is the first import and token', () async {
         await testSuggestor(
           input: /*language=dart*/ '''
-              import 'package:web_skin_dart/ui_components.dart';
+              import 'package:web_skin/web_skin.dart'; import 'package:web_skin_dart/constants.dart'; import 'package:web_skin_dart/shared.dart' hide getMeasuredTextWidth;
               import 'package:over_react/over_react.dart';
           
               content() => Dom.div()();
@@ -81,7 +81,7 @@ void main() {
           input: /*language=dart*/ '''
               library lib;
           
-              import 'package:web_skin_dart/ui_components.dart';
+              import 'package:web_skin/web_skin.dart'; import 'package:web_skin_dart/constants.dart'; import 'package:web_skin_dart/shared.dart' hide getMeasuredTextWidth;
               import 'package:over_react/over_react.dart';
           
               content() => Dom.div()();
@@ -100,7 +100,7 @@ void main() {
         await testSuggestor(
           input: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
-              import 'package:web_skin_dart/ui_components.dart';
+              import 'package:web_skin/web_skin.dart'; import 'package:web_skin_dart/constants.dart'; import 'package:web_skin_dart/shared.dart' hide getMeasuredTextWidth;
           
               content() => Button()();
           ''',
@@ -111,7 +111,7 @@ void main() {
         await testSuggestor(
           input: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
-              import 'package:web_skin_dart/ui_components.dart';
+              import 'package:web_skin/web_skin.dart'; import 'package:web_skin_dart/constants.dart'; import 'package:web_skin_dart/shared.dart' hide getMeasuredTextWidth;
               import 'package:web_skin_dart/component2/all.dart' as wsd2;
           
               content() => wsd2.Button()();
@@ -133,13 +133,13 @@ void main() {
         await testSuggestor(
           input: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
-              import 'package:web_skin_dart/ui_components.dart';
+              import 'package:web_skin/web_skin.dart'; import 'package:web_skin_dart/constants.dart'; import 'package:web_skin_dart/shared.dart' hide getMeasuredTextWidth;
               import 'package:web_skin_dart/component2/all.dart' as wsd2;
           
               content() => wsd2.Button()();
           ''',
           expectedOutput: /*language=dart*/ '''
-              import 'package:web_skin_dart/ui_components.dart';
+              import 'package:web_skin/web_skin.dart'; import 'package:web_skin_dart/constants.dart'; import 'package:web_skin_dart/shared.dart' hide getMeasuredTextWidth;
               import 'package:web_skin_dart/component2/all.dart' as wsd2;
           
               content() => wsd2.Button()();


### PR DESCRIPTION
web_skin_dart has exports for individual components and an "ui_component" export that has all components.  If everywhere uses the individual component exports, then the compiler will only have to consider the component code it needs, resulting in faster build times.  But, this only works if everywhere is using the individual component exports.
 
 This batch:
 1. removes the ui_components.dart import. (And the deprecated ui_core.dart, opportunistically)
 2. puts in imports of every one of the individual components
 3. Uses `dart fix` to remove unused imports, unnecessary imports and duplicate_imports, which will get rid of components you don't need.
   * This may cause some side effects in other files if there are imports that are caught by one of the fixers.
   * There are some redundant imports that are not caught by the fixers, so you may need to manually remove them.
   * Namespaced imports will need manual repair
 
 Once CI is green, you can review and merge it.
 
 Since the same symbols will be used, static analysis and CI passing should be sufficient for QA +1.
 
 For more info reach out to Tom Connell on Slack.

[_Created by Sourcegraph batch change `Workiva/web_skin_dart_UI-component_import`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/web_skin_dart_UI-component_import)