### PR TITLE
Synchronize with over_react impl; pull in AbstractProps fix

### DIFF
--- a/lib/src/util/get_all_props.dart
+++ b/lib/src/util/get_all_props.dart
@@ -1,4 +1,4 @@
-// Taken from https://github.com/Workiva/over_react/blob/master/tools/analyzer_plugin/lib/src/util/prop_declarations/get_all_props.dart
+// Taken from https://github.com/Workiva/over_react/blob/5c6e1742949ce4e739f7923b799cc00b1118279b/tools/analyzer_plugin/lib/src/util/prop_declarations/get_all_props.dart
 
 // Copyright 2024 Workiva Inc.
 //
@@ -70,7 +70,7 @@ List<FieldElement> getAllProps(InterfaceElement propsElement) {
     final isMixinBasedPropsMixin = interface is MixinElement &&
         interface.superclassConstraints.any((s) => s.element.name == 'UiProps');
     late final isLegacyPropsOrPropsMixinConsumerClass = !isFromGeneratedFile &&
-        interface.metadata.any(_isPropsOrPropsMixinAnnotation);
+        interface.metadata.any(_isOneOfThePropsAnnotations);
 
     if (!isMixinBasedPropsMixin && !isLegacyPropsOrPropsMixinConsumerClass) {
       continue;
@@ -95,11 +95,12 @@ List<FieldElement> getAllProps(InterfaceElement propsElement) {
   return allProps;
 }
 
-bool _isPropsOrPropsMixinAnnotation(ElementAnnotation e) {
+bool _isOneOfThePropsAnnotations(ElementAnnotation e) {
   // [2]
   final element = e.element;
   return element is ConstructorElement &&
-      const {'Props', 'PropsMixin'}.contains(element.enclosingElement.name);
+      const {'Props', 'PropsMixin', 'AbstractProps'}
+          .contains(element.enclosingElement.name);
 }
 
 bool _isPropsMixinAnnotation(ElementAnnotation e) {


### PR DESCRIPTION
## Motivation
There's a fix to the `getAllProps` impl that was copied from over_react: https://github.com/Workiva/over_react/pull/913

## Changes
Copy over the fix

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
