### PR TITLE
TEST: react_material_ui null safety

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,3 +55,14 @@ executables:
   intl_message_migration:
   sort_intl:
   unify_package_rename:
+
+dependency_overrides:
+  unify_ui:
+    git:
+      url: https://github.com/Workiva/react_material_ui.git
+      ref: null-safety-integration-branch-dev
+  react_material_ui:
+    git:
+      url: https://github.com/Workiva/react_material_ui.git
+      ref: null-safety-integration-branch-dev
+      path: react_material_ui

--- a/test/test_fixtures/over_react_project/pubspec.yaml
+++ b/test/test_fixtures/over_react_project/pubspec.yaml
@@ -3,3 +3,14 @@ environment:
   sdk: '>=2.11.0 <3.0.0'
 dependencies:
   over_react: ^5.0.0
+
+dependency_overrides:
+  unify_ui:
+    git:
+      url: https://github.com/Workiva/react_material_ui.git
+      ref: null-safety-integration-branch-dev
+  react_material_ui:
+    git:
+      url: https://github.com/Workiva/react_material_ui.git
+      ref: null-safety-integration-branch-dev
+      path: react_material_ui

--- a/test/test_fixtures/required_props/test_consuming_package/pubspec.yaml
+++ b/test/test_fixtures/required_props/test_consuming_package/pubspec.yaml
@@ -5,3 +5,14 @@ dependencies:
   over_react: ^5.0.0
   test_package:
     path: ../test_package
+
+dependency_overrides:
+  unify_ui:
+    git:
+      url: https://github.com/Workiva/react_material_ui.git
+      ref: null-safety-integration-branch-dev
+  react_material_ui:
+    git:
+      url: https://github.com/Workiva/react_material_ui.git
+      ref: null-safety-integration-branch-dev
+      path: react_material_ui

--- a/test/test_fixtures/required_props/test_package/pubspec.yaml
+++ b/test/test_fixtures/required_props/test_package/pubspec.yaml
@@ -4,3 +4,14 @@ environment:
 dependencies:
   meta: ^1.3.0
   over_react: ^5.0.0
+
+dependency_overrides:
+  unify_ui:
+    git:
+      url: https://github.com/Workiva/react_material_ui.git
+      ref: null-safety-integration-branch-dev
+  react_material_ui:
+    git:
+      url: https://github.com/Workiva/react_material_ui.git
+      ref: null-safety-integration-branch-dev
+      path: react_material_ui

--- a/test/test_fixtures/rmui_project/pubspec.yaml
+++ b/test/test_fixtures/rmui_project/pubspec.yaml
@@ -8,3 +8,14 @@ dependencies:
       name: react_material_ui
       url: https://pub.workiva.org
     version: ^1.121.0
+
+dependency_overrides:
+  unify_ui:
+    git:
+      url: https://github.com/Workiva/react_material_ui.git
+      ref: null-safety-integration-branch-dev
+  react_material_ui:
+    git:
+      url: https://github.com/Workiva/react_material_ui.git
+      ref: null-safety-integration-branch-dev
+      path: react_material_ui

--- a/test/test_fixtures/wsd_project/pubspec.yaml
+++ b/test/test_fixtures/wsd_project/pubspec.yaml
@@ -8,3 +8,14 @@ dependencies:
       name: web_skin_dart
       url: https://pub.workiva.org
     version: ^2.56.0
+
+dependency_overrides:
+  unify_ui:
+    git:
+      url: https://github.com/Workiva/react_material_ui.git
+      ref: null-safety-integration-branch-dev
+  react_material_ui:
+    git:
+      url: https://github.com/Workiva/react_material_ui.git
+      ref: null-safety-integration-branch-dev
+      path: react_material_ui


### PR DESCRIPTION
DO NOT MERGE. This PR adds dependency overrides to https://github.com/Workiva/react_material_ui/tree/null-safety-integration-branch
in order to test all consumers before merging and releasing them.
For more info, reach out to `#support-ui-platform` on Slack.

[_Created by Sourcegraph batch change `Workiva/rmui_null_safety_test`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/rmui_null_safety_test)