### PR TITLE
FED-3209 Remove explicit null passed to useRef

### DIFF
--- a/test/dart3_suggestors/null_safety_prep/use_ref_init_migration_test.dart
+++ b/test/dart3_suggestors/null_safety_prep/use_ref_init_migration_test.dart
@@ -104,5 +104,25 @@ void main() {
             '''),
       );
     });
+
+    test('removes unnecessary null arguments', () async {
+      await testSuggestor(
+        expectedPatchCount: 2,
+        input: withOverReactImport('''
+              useTestHook() {
+                final foo = useRef(null);
+                final bar = useRef<String>(null);
+                return [foo, bar];
+              }
+            '''),
+        expectedOutput: withOverReactImport('''
+              useTestHook() {
+                final foo = useRef();
+                final bar = useRef<String>();
+                return [foo, bar];
+              }
+            '''),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Motivation
The null_safety_prep codemod updates cases like `useRef<Element>(null)` to `useRefInit<Element>(null)`, which, while not incorrect and won't cause issues during migrations, isn't ideal.

## Changes
- Handle the explicit `null` value
- Add tests

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - CI passes
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
