### PR TITLE
FED-2994 Update class component defaults codemod to take public-ness into account

### DIFF
--- a/lib/src/dart3_suggestors/null_safety_prep/class_component_required_default_props.dart
+++ b/lib/src/dart3_suggestors/null_safety_prep/class_component_required_default_props.dart
@@ -21,6 +21,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:over_react_codemod/src/vendor/over_react_analyzer_plugin/get_all_props.dart';
 import 'package:pub_semver/pub_semver.dart';
 
+import '../required_props/codemod/recommender.dart';
 import 'utils/class_component_required_fields.dart';
 
 /// Suggestor to assist with preparations for null-safety by adding
@@ -76,7 +77,9 @@ import 'utils/class_component_required_fields.dart';
 /// ```
 class ClassComponentRequiredDefaultPropsMigrator
     extends ClassComponentRequiredFieldsMigrator<PropAssignment> {
-  ClassComponentRequiredDefaultPropsMigrator([Version? sdkVersion])
+  final PropRequirednessRecommender? _propRequirednessRecommender;
+
+  ClassComponentRequiredDefaultPropsMigrator([Version? sdkVersion, this._propRequirednessRecommender])
       : super('defaultProps', 'getDefaultProps', sdkVersion);
 
   @override
@@ -105,6 +108,6 @@ class ClassComponentRequiredDefaultPropsMigrator
         .map((assignment) => PropAssignment(assignment))
         .where((prop) => prop.node.writeElement?.displayName != null);
 
-    patchFieldDeclarations(getAllProps, cascadedDefaultProps, node);
+    patchFieldDeclarations(getAllProps, cascadedDefaultProps, node, _propRequirednessRecommender);
   }
 }

--- a/lib/src/dart3_suggestors/null_safety_prep/class_component_required_default_props.dart
+++ b/lib/src/dart3_suggestors/null_safety_prep/class_component_required_default_props.dart
@@ -79,7 +79,8 @@ class ClassComponentRequiredDefaultPropsMigrator
     extends ClassComponentRequiredFieldsMigrator<PropAssignment> {
   final PropRequirednessRecommender? _propRequirednessRecommender;
 
-  ClassComponentRequiredDefaultPropsMigrator([Version? sdkVersion, this._propRequirednessRecommender])
+  ClassComponentRequiredDefaultPropsMigrator(
+      [Version? sdkVersion, this._propRequirednessRecommender])
       : super('defaultProps', 'getDefaultProps', sdkVersion);
 
   @override
@@ -108,6 +109,7 @@ class ClassComponentRequiredDefaultPropsMigrator
         .map((assignment) => PropAssignment(assignment))
         .where((prop) => prop.node.writeElement?.displayName != null);
 
-    patchFieldDeclarations(getAllProps, cascadedDefaultProps, node, _propRequirednessRecommender);
+    patchFieldDeclarations(
+        getAllProps, cascadedDefaultProps, node, _propRequirednessRecommender);
   }
 }

--- a/lib/src/dart3_suggestors/null_safety_prep/utils/class_component_required_fields.dart
+++ b/lib/src/dart3_suggestors/null_safety_prep/utils/class_component_required_fields.dart
@@ -53,8 +53,8 @@ abstract class ClassComponentRequiredFieldsMigrator<
   void patchFieldDeclarations(
       Iterable<FieldElement> Function(InterfaceElement) getAll,
       Iterable<Assignment> cascadedDefaultPropsOrInitialState,
-      CascadeExpression node, [PropRequirednessRecommender? _propRequirednessRecommender]) {
-
+      CascadeExpression node,
+      [PropRequirednessRecommender? _propRequirednessRecommender]) {
     for (final field in cascadedDefaultPropsOrInitialState) {
       final isDefaultedToNull =
           field.node.rightHandSide.staticType!.isDartCoreNull;
@@ -71,10 +71,13 @@ abstract class ClassComponentRequiredFieldsMigrator<
       final element = fieldDeclaration.declaredElement;
 
       // Don't set as required if the prop is publicly exported.
-      if(_propRequirednessRecommender != null && element is FieldElement) {
+      if (_propRequirednessRecommender != null && element is FieldElement) {
         final isPublic = _propRequirednessRecommender
-            .getRecommendation(element)?.reason?.isPublic ?? false;
-        if(isPublic) continue;
+                .getRecommendation(element)
+                ?.reason
+                ?.isPublic ??
+            false;
+        if (isPublic) continue;
       }
 
       fieldData.add(DefaultedOrInitializedDeclaration(

--- a/lib/src/dart3_suggestors/null_safety_prep/utils/class_component_required_fields.dart
+++ b/lib/src/dart3_suggestors/null_safety_prep/utils/class_component_required_fields.dart
@@ -73,10 +73,7 @@ abstract class ClassComponentRequiredFieldsMigrator<
       // Don't set as required if the prop is publicly exported.
       if (_propRequirednessRecommender != null && element is FieldElement) {
         final isPublic = _propRequirednessRecommender
-                .getRecommendation(element)
-                ?.reason
-                ?.isPublic ??
-            false;
+            .isPropsPublicForMixingIn(element.enclosingElement);
         if (isPublic) continue;
       }
 

--- a/lib/src/dart3_suggestors/required_props/bin/codemod.dart
+++ b/lib/src/dart3_suggestors/required_props/bin/codemod.dart
@@ -24,6 +24,7 @@ import 'package:over_react_codemod/src/util/args.dart';
 import 'package:over_react_codemod/src/util/command_runner.dart';
 import 'package:over_react_codemod/src/util/package_util.dart';
 
+import '../../null_safety_prep/class_component_required_default_props.dart';
 import '../codemod/recommender.dart';
 import '../collect/aggregated_data.sg.dart';
 
@@ -146,6 +147,16 @@ class CodemodCommand extends Command {
           parsedArgs.argValueAsNumber(_Options.publicRequirednessThreshold),
       publicMaxAllowedSkipRate:
           parsedArgs.argValueAsNumber(_Options.publicMaxAllowedSkipRate),
+    );
+
+    exitCode = await runInteractiveCodemodSequence(
+      dartPaths,
+      [
+        ClassComponentRequiredDefaultPropsMigrator(null, recommender),
+      ],
+      defaultYes: true,
+      args: codemodArgs,
+      additionalHelpOutput: argParser.usage,
     );
 
     exitCode = await runInteractiveCodemodSequence(

--- a/lib/src/dart3_suggestors/required_props/codemod/recommender.dart
+++ b/lib/src/dart3_suggestors/required_props/codemod/recommender.dart
@@ -64,7 +64,7 @@ class PropRequirednessRecommender {
         isPublic ? publicRequirednessThreshold : privateRequirednessThreshold;
 
     if (totalRequirednessRate < requirednessThreshold) {
-      final reason = RequirednessThresholdOptionalReason();
+      final reason = RequirednessThresholdOptionalReason(isPublic: isPublic);
       return PropRecommendation.optional(reason);
     } else {
       return const PropRecommendation.required();
@@ -146,11 +146,14 @@ class PropRecommendation {
   const PropRecommendation.optional(this.reason) : isRequired = false;
 }
 
-abstract class OptionalReason {}
+abstract class OptionalReason {
+  abstract final bool isPublic;
+}
 
 class SkipRateOptionalReason extends OptionalReason {
   final num skipRate;
   final num maxAllowedSkipRate;
+  @override
   final bool isPublic;
 
   SkipRateOptionalReason({
@@ -161,5 +164,8 @@ class SkipRateOptionalReason extends OptionalReason {
 }
 
 class RequirednessThresholdOptionalReason extends OptionalReason {
-  RequirednessThresholdOptionalReason();
+  @override
+  final bool isPublic;
+
+  RequirednessThresholdOptionalReason({required this.isPublic});
 }

--- a/lib/src/dart3_suggestors/required_props/codemod/recommender.dart
+++ b/lib/src/dart3_suggestors/required_props/codemod/recommender.dart
@@ -64,7 +64,7 @@ class PropRequirednessRecommender {
         isPublic ? publicRequirednessThreshold : privateRequirednessThreshold;
 
     if (totalRequirednessRate < requirednessThreshold) {
-      final reason = RequirednessThresholdOptionalReason(isPublic: isPublic);
+      final reason = RequirednessThresholdOptionalReason();
       return PropRecommendation.optional(reason);
     } else {
       return const PropRecommendation.required();
@@ -77,6 +77,9 @@ class PropRequirednessRecommender {
     return _propRequirednessResults.mixinResultsByIdByPackage[packageName]
         ?[propsId];
   }
+
+  bool isPropsPublicForMixingIn(Element propsElement) =>
+      _getMixinResult(propsElement)?.visibility.isPublicForMixingIn ?? false;
 
   SkipRateOptionalReason? _getMixinSkipRateReason(MixinResult mixinResults) {
     final skipRate = mixinResults.usageSkipRate;
@@ -146,14 +149,11 @@ class PropRecommendation {
   const PropRecommendation.optional(this.reason) : isRequired = false;
 }
 
-abstract class OptionalReason {
-  abstract final bool isPublic;
-}
+abstract class OptionalReason {}
 
 class SkipRateOptionalReason extends OptionalReason {
   final num skipRate;
   final num maxAllowedSkipRate;
-  @override
   final bool isPublic;
 
   SkipRateOptionalReason({
@@ -164,8 +164,5 @@ class SkipRateOptionalReason extends OptionalReason {
 }
 
 class RequirednessThresholdOptionalReason extends OptionalReason {
-  @override
-  final bool isPublic;
-
-  RequirednessThresholdOptionalReason({required this.isPublic});
+  RequirednessThresholdOptionalReason();
 }

--- a/lib/src/executables/null_safety_migrator_companion.dart
+++ b/lib/src/executables/null_safety_migrator_companion.dart
@@ -16,7 +16,6 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:codemod/codemod.dart';
-import 'package:over_react_codemod/src/dart3_suggestors/null_safety_prep/class_component_required_default_props.dart';
 import 'package:over_react_codemod/src/dart3_suggestors/null_safety_prep/class_component_required_initial_state.dart';
 import 'package:over_react_codemod/src/util.dart';
 
@@ -43,7 +42,6 @@ void main(List<String> args) async {
     dartPaths,
     aggregate([
       CallbackRefHintSuggestor(),
-      ClassComponentRequiredDefaultPropsMigrator(),
       ClassComponentRequiredInitialStateMigrator(),
     ]),
     defaultYes: true,

--- a/test/executables/required_props_collect_and_codemod_test.dart
+++ b/test/executables/required_props_collect_and_codemod_test.dart
@@ -87,6 +87,24 @@ mixin TestPrivateProps on UiProps {
   $noDataTodoComment
   String/*?*/ set0percent;
 }''')),
+              d.file('test_class_component_defaults.dart', contains('''
+mixin TestPrivatePropsMixin on UiProps {
+  String/*?*/ notDefaultedOptional;
+  /*late*/ String notDefaultedAlwaysSet;
+  /*late*/ String/*?*/ defaultedNullable;
+  /*late*/ num/*!*/ defaultedNonNullable;
+}
+
+mixin SomeOtherPropsMixin on UiProps {
+  /*late*/ num/*!*/ anotherDefaultedNonNullable;
+}''')),
+              d.file('test_class_component_defaults.dart', contains('''
+mixin TestPublic2PropsMixin on UiProps {
+  String/*?*/ notDefaultedOptional;
+  /*late*/ String notDefaultedAlwaysSet;
+  String/*?*/ defaultedNullable;
+  num/*?*/ defaultedNonNullable;
+}''')),
               d.file('test_private_dynamic.dart', contains('''
 // TODO(orcm.required_props): This codemod couldn't reliably determine requiredness for these props
 //  because 75% of usages of components with these props (> max allowed 20% for private props)

--- a/test/test_fixtures/required_props/test_package/lib/entrypoint.dart
+++ b/test/test_fixtures/required_props/test_package/lib/entrypoint.dart
@@ -1,3 +1,4 @@
+export 'src/test_class_component_defaults.dart' show TestPublic2, TestPublic2PropsMixin;
 export 'src/test_public.dart';
 export 'src/test_public_dynamic.dart';
 export 'src/test_public_multiple_components.dart';

--- a/test/test_fixtures/required_props/test_package/lib/src/test_class_component_defaults.dart
+++ b/test/test_fixtures/required_props/test_package/lib/src/test_class_component_defaults.dart
@@ -13,7 +13,8 @@ mixin SomeOtherPropsMixin on UiProps {
   num anotherDefaultedNonNullable;
 }
 
-class TestPrivateProps = UiProps with TestPrivatePropsMixin, SomeOtherPropsMixin;
+class TestPrivateProps = UiProps
+    with TestPrivatePropsMixin, SomeOtherPropsMixin;
 
 UiFactory<TestPrivateProps> TestPrivate =
     castUiFactory(_$TestPrivate); // ignore: undefined_identifier
@@ -37,10 +38,11 @@ mixin TestPublic2PropsMixin on UiProps {
   num defaultedNonNullable;
 }
 
-class TestPublic2Props = UiProps with TestPublic2PropsMixin, SomeOtherPropsMixin;
+class TestPublic2Props = UiProps
+    with TestPublic2PropsMixin, SomeOtherPropsMixin;
 
 UiFactory<TestPublic2Props> TestPublic2 =
-castUiFactory(_$TestPublic2); // ignore: undefined_identifier
+    castUiFactory(_$TestPublic2); // ignore: undefined_identifier
 
 class TestPublic2Component extends UiComponent2<TestPublic2Props> {
   @override
@@ -61,9 +63,14 @@ usages() {
     ..notDefaultedAlwaysSet = 'abc'
     ..defaultedNullable = 'abc'
     ..defaultedNonNullable = 1
-    ..anotherDefaultedNonNullable = 2)();
+    ..anotherDefaultedNonNullable = 2
+  )();
   (TestPublic2()..notDefaultedAlwaysSet = 'abc')();
-  (TestPublic2()..notDefaultedAlwaysSet = 'abc'..notDefaultedOptional = 'abc'..defaultedNullable = 'abc'
+  (TestPublic2()
+    ..notDefaultedAlwaysSet = 'abc'
+    ..notDefaultedOptional = 'abc'
+    ..defaultedNullable = 'abc'
     ..defaultedNonNullable = 1
-    ..anotherDefaultedNonNullable = 2)();
+    ..anotherDefaultedNonNullable = 2
+  )();
 }

--- a/test/test_fixtures/required_props/test_package/lib/src/test_class_component_defaults.dart
+++ b/test/test_fixtures/required_props/test_package/lib/src/test_class_component_defaults.dart
@@ -1,0 +1,69 @@
+import 'package:over_react/over_react.dart';
+
+part 'test_class_component_defaults.over_react.g.dart';
+
+mixin TestPrivatePropsMixin on UiProps {
+  String notDefaultedOptional;
+  String notDefaultedAlwaysSet;
+  String defaultedNullable;
+  num defaultedNonNullable;
+}
+
+mixin SomeOtherPropsMixin on UiProps {
+  num anotherDefaultedNonNullable;
+}
+
+class TestPrivateProps = UiProps with TestPrivatePropsMixin, SomeOtherPropsMixin;
+
+UiFactory<TestPrivateProps> TestPrivate =
+    castUiFactory(_$TestPrivate); // ignore: undefined_identifier
+
+class TestPrivateComponent extends UiComponent2<TestPrivateProps> {
+  @override
+  get defaultProps => (newProps()
+    ..defaultedNullable = null
+    ..defaultedNonNullable = 2.1
+    ..anotherDefaultedNonNullable = 1.1
+  );
+
+  @override
+  render() {}
+}
+
+mixin TestPublic2PropsMixin on UiProps {
+  String notDefaultedOptional;
+  String notDefaultedAlwaysSet;
+  String defaultedNullable;
+  num defaultedNonNullable;
+}
+
+class TestPublic2Props = UiProps with TestPublic2PropsMixin, SomeOtherPropsMixin;
+
+UiFactory<TestPublic2Props> TestPublic2 =
+castUiFactory(_$TestPublic2); // ignore: undefined_identifier
+
+class TestPublic2Component extends UiComponent2<TestPublic2Props> {
+  @override
+  get defaultProps => (newProps()
+    ..defaultedNullable = null
+    ..defaultedNonNullable = 2.1
+    ..anotherDefaultedNonNullable = 1.1
+  );
+
+  @override
+  render() {}
+}
+
+usages() {
+  (TestPrivate()..notDefaultedAlwaysSet = 'abc')();
+  (TestPrivate()
+    ..notDefaultedOptional = 'abc'
+    ..notDefaultedAlwaysSet = 'abc'
+    ..defaultedNullable = 'abc'
+    ..defaultedNonNullable = 1
+    ..anotherDefaultedNonNullable = 2)();
+  (TestPublic2()..notDefaultedAlwaysSet = 'abc')();
+  (TestPublic2()..notDefaultedAlwaysSet = 'abc'..notDefaultedOptional = 'abc'..defaultedNullable = 'abc'
+    ..defaultedNonNullable = 1
+    ..anotherDefaultedNonNullable = 2)();
+}


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Right now, the class component codemod always makes defaulted props required, but that goes against our guidance (see [here](https://github.com/Workiva/over_react/blob/master/doc/null_safety/null_safe_migration.md#prop-nullability)) in cases where those props are public.

This codemod should only make those props required when classes are private.
## Changes
  <!-- What this PR changes to fix the problem. -->
- Move class defaulted props codemod into prop requiredness codemod to use public api info to only make defaulted props required if they are not public
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
      - [ ] CI passes
      - [ ] Good test coverage
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
