### PR TITLE
FED-3248 Update non-defaulted state mixin fields to be optional

### DIFF
--- a/lib/src/dart3_suggestors/null_safety_prep/state_mixin_suggestor.dart
+++ b/lib/src/dart3_suggestors/null_safety_prep/state_mixin_suggestor.dart
@@ -1,0 +1,67 @@
+// Copyright 2024 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:over_react_codemod/src/dart3_suggestors/null_safety_prep/utils/hint_detection.dart';
+import 'package:over_react_codemod/src/util.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+
+import '../../util/class_suggestor.dart';
+
+/// Suggestor to assist with preparations for null-safety by adding
+/// nullability (`?`) hints to state field types.
+///
+/// This is intended to be run after [ClassComponentRequiredInitialStateMigrator]
+/// to make the rest of the state fields nullable.
+class StateMixinSuggestor extends RecursiveAstVisitor<void>
+    with ClassSuggestor {
+  @override
+  void visitVariableDeclaration(VariableDeclaration node) {
+    super.visitVariableDeclaration(node);
+
+    final isStateClass = (node.declaredElement?.enclosingElement
+            ?.tryCast<InterfaceElement>()
+            ?.allSupertypes
+            .any((s) => s.element.name == 'UiState') ??
+        false);
+    if (!isStateClass) return;
+
+    final fieldDeclaration = node.parentFieldDeclaration;
+    if (fieldDeclaration == null) return;
+    if (fieldDeclaration.isStatic) return;
+    if (fieldDeclaration.fields.isConst) return;
+
+    final type = fieldDeclaration.fields.type;
+    if (type != null &&
+        (requiredHintAlreadyExists(type) || nullableHintAlreadyExists(type))) {
+      return;
+    }
+
+    // Make state field optional.
+    if (type != null) {
+      yieldPatch(nullableHint, type.end, type.end);
+    }
+  }
+
+  @override
+  Future<void> generatePatches() async {
+    final r = await context.getResolvedUnit();
+    if (r == null) {
+      throw Exception(
+          'Could not get resolved result for "${context.relativePath}"');
+    }
+    r.unit.accept(this);
+  }
+}

--- a/lib/src/executables/null_safety_migrator_companion.dart
+++ b/lib/src/executables/null_safety_migrator_companion.dart
@@ -21,6 +21,7 @@ import 'package:over_react_codemod/src/util.dart';
 
 import '../dart3_suggestors/null_safety_prep/callback_ref_hint_suggestor.dart';
 import '../dart3_suggestors/null_safety_prep/state_mixin_suggestor.dart';
+import '../util/package_util.dart';
 
 const _changesRequiredOutput = """
   To update your code, run the following commands in your repository:
@@ -37,6 +38,8 @@ void main(List<String> args) async {
   final parser = ArgParser.allowAnything();
 
   final parsedArgs = parser.parse(args);
+  final packageRoot = findPackageRootFor('.');
+  await runPubGetIfNeeded(packageRoot);
   final dartPaths = allDartPathsExceptHiddenAndGenerated();
 
   exitCode = await runInteractiveCodemodSequence(

--- a/lib/src/executables/null_safety_migrator_companion.dart
+++ b/lib/src/executables/null_safety_migrator_companion.dart
@@ -16,16 +16,16 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:codemod/codemod.dart';
-import 'package:over_react_codemod/src/dart3_suggestors/null_safety_prep/class_component_required_default_props.dart';
 import 'package:over_react_codemod/src/dart3_suggestors/null_safety_prep/class_component_required_initial_state.dart';
 import 'package:over_react_codemod/src/util.dart';
 
 import '../dart3_suggestors/null_safety_prep/callback_ref_hint_suggestor.dart';
+import '../dart3_suggestors/null_safety_prep/state_mixin_suggestor.dart';
 
 const _changesRequiredOutput = """
   To update your code, run the following commands in your repository:
-  pub global activate over_react_codemod
-  pub global run over_react_codemod:null_safety_prep
+  dart pub global activate over_react_codemod
+  dart pub global run over_react_codemod:null_safety_migrator_companion
 """;
 
 /// Codemods in this executable add nullability "hints" to assist with a
@@ -39,13 +39,37 @@ void main(List<String> args) async {
   final parsedArgs = parser.parse(args);
   final dartPaths = allDartPathsExceptHiddenAndGenerated();
 
-  exitCode = await runInteractiveCodemod(
+  exitCode = await runInteractiveCodemodSequence(
     dartPaths,
-    aggregate([
+    [
       CallbackRefHintSuggestor(),
-      ClassComponentRequiredDefaultPropsMigrator(),
+    ],
+    defaultYes: true,
+    args: parsedArgs.rest,
+    additionalHelpOutput: parser.usage,
+    changesRequiredOutput: _changesRequiredOutput,
+  );
+
+  if (exitCode != 0) return;
+
+  exitCode = await runInteractiveCodemodSequence(
+    dartPaths,
+    [
       ClassComponentRequiredInitialStateMigrator(),
-    ]),
+    ],
+    defaultYes: true,
+    args: parsedArgs.rest,
+    additionalHelpOutput: parser.usage,
+    changesRequiredOutput: _changesRequiredOutput,
+  );
+
+  if (exitCode != 0) return;
+
+  exitCode = await runInteractiveCodemodSequence(
+    dartPaths,
+    [
+      StateMixinSuggestor(),
+    ],
     defaultYes: true,
     args: parsedArgs.rest,
     additionalHelpOutput: parser.usage,

--- a/test/dart3_suggestors/null_safety_prep/state_mixin_suggestor_test.dart
+++ b/test/dart3_suggestors/null_safety_prep/state_mixin_suggestor_test.dart
@@ -1,0 +1,151 @@
+// Copyright 2024 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react_codemod/src/dart3_suggestors/null_safety_prep/state_mixin_suggestor.dart';
+import 'package:test/test.dart';
+
+import '../../resolved_file_context.dart';
+import '../../util.dart';
+import '../../util/component_usage_migrator_test.dart' show withOverReactImport;
+
+void main() {
+  final resolvedContext = SharedAnalysisContext.overReact;
+
+  // Warm up analysis in a setUpAll so that if getting the resolved AST times out
+  // (which is more common for the WSD context), it fails here instead of failing the first test.
+  setUpAll(resolvedContext.warmUpAnalysis);
+
+  group('StateMixinSuggestor', () {
+    late SuggestorTester testSuggestor;
+
+    setUp(() {
+      testSuggestor = getSuggestorTester(
+        StateMixinSuggestor(),
+        resolvedContext: resolvedContext,
+      );
+    });
+
+    test('patches state fields in mixins', () async {
+      await testSuggestor(
+        // expectedPatchCount: 5,
+        input: withOverReactImport(/*language=dart*/ r'''
+            // ignore: undefined_identifier
+            UiFactory<FooProps> Foo = castUiFactory(_$Foo);
+            mixin FooProps on UiProps {
+              String prop1;
+            }
+            mixin FooStateMixin on UiState {
+              String state1;
+              num state2;
+              /// This is a doc comment
+              /*late*/ String/*!*/ alreadyPatched;
+              /*late*/ String/*?*/ alreadyPatchedButNoDocComment;
+              String/*?*/ alreadyPatchedOptional;
+            }
+            mixin SomeOtherStateMixin on UiState {
+              String state3;
+              String/*?*/ alreadyPatchedOptional2;
+            }
+            class FooState = UiState with FooStateMixin, SomeOtherStateMixin;
+            class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+              @override
+              render() => null;
+            }
+          '''),
+        expectedOutput: withOverReactImport(/*language=dart*/ r'''
+            // ignore: undefined_identifier
+            UiFactory<FooProps> Foo = castUiFactory(_$Foo);
+            mixin FooProps on UiProps {
+              String prop1;
+            }
+            mixin FooStateMixin on UiState {
+              String/*?*/ state1;
+              num/*?*/ state2;
+              /// This is a doc comment
+              /*late*/ String/*!*/ alreadyPatched;
+              /*late*/ String/*?*/ alreadyPatchedButNoDocComment;
+              String/*?*/ alreadyPatchedOptional;
+            }
+            mixin SomeOtherStateMixin on UiState {
+              String/*?*/ state3;
+              String/*?*/ alreadyPatchedOptional2;
+            }
+            class FooState = UiState with FooStateMixin, SomeOtherStateMixin;
+            class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+              @override
+              render() => null;
+            }
+          '''),
+      );
+    });
+
+    test('patches initialized state in legacy classes', () async {
+      await testSuggestor(
+        // expectedPatchCount: 3,
+        input: withOverReactImport(/*language=dart*/ r'''
+            @Factory()
+            UiFactory<FooProps> Foo = _$Foo; // ignore: undefined_identifier
+            @Props()
+            class FooProps extends UiProps {
+              String prop1;
+            }
+            @StateMixin()
+            mixin SomeOtherStateMixin on UiState {
+              num state1;
+            }
+            @State()
+            class FooState extends UiState with SomeOtherStateMixin {
+              String state2;
+              num state3;
+              /// This is a doc comment
+              /*late*/ String/*!*/ alreadyPatched;
+              /*late*/ String/*?*/ alreadyPatchedButNoDocComment;
+              String/*?*/ alreadyPatchedOptional;
+            }
+            @Component()
+            class FooComponent extends UiStatefulComponent<FooProps, FooState> {
+              @override
+              render() => null;
+            }
+          '''),
+        expectedOutput: withOverReactImport(/*language=dart*/ r'''
+            @Factory()
+            UiFactory<FooProps> Foo = _$Foo; // ignore: undefined_identifier
+            @Props()
+            class FooProps extends UiProps {
+              String prop1;
+            }
+            @StateMixin()
+            mixin SomeOtherStateMixin on UiState {
+              num/*?*/ state1;
+            }
+            @State()
+            class FooState extends UiState with SomeOtherStateMixin {
+              String/*?*/ state2;
+              num/*?*/ state3;
+              /// This is a doc comment
+              /*late*/ String/*!*/ alreadyPatched;
+              /*late*/ String/*?*/ alreadyPatchedButNoDocComment;
+              String/*?*/ alreadyPatchedOptional;
+            }
+            @Component()
+            class FooComponent extends UiStatefulComponent<FooProps, FooState> {
+              @override
+              render() => null;
+            }
+          '''),
+      );
+    });
+  });
+}

--- a/test/dart3_suggestors/null_safety_prep/state_mixin_suggestor_test.dart
+++ b/test/dart3_suggestors/null_safety_prep/state_mixin_suggestor_test.dart
@@ -90,7 +90,7 @@ void main() {
       );
     });
 
-    test('patches initialized state in legacy classes', () async {
+    test('patches state fields in legacy classes', () async {
       await testSuggestor(
         expectedPatchCount: 3,
         input: withOverReactImport(/*language=dart*/ r'''

--- a/test/dart3_suggestors/null_safety_prep/state_mixin_suggestor_test.dart
+++ b/test/dart3_suggestors/null_safety_prep/state_mixin_suggestor_test.dart
@@ -38,7 +38,7 @@ void main() {
 
     test('patches state fields in mixins', () async {
       await testSuggestor(
-        // expectedPatchCount: 5,
+        expectedPatchCount: 3,
         input: withOverReactImport(/*language=dart*/ r'''
             // ignore: undefined_identifier
             UiFactory<FooProps> Foo = castUiFactory(_$Foo);
@@ -92,7 +92,7 @@ void main() {
 
     test('patches initialized state in legacy classes', () async {
       await testSuggestor(
-        // expectedPatchCount: 3,
+        expectedPatchCount: 3,
         input: withOverReactImport(/*language=dart*/ r'''
             @Factory()
             UiFactory<FooProps> Foo = _$Foo; // ignore: undefined_identifier

--- a/test/executables/null_safety_migrator_companion_test.dart
+++ b/test/executables/null_safety_migrator_companion_test.dart
@@ -1,0 +1,75 @@
+// Copyright 2024 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:over_react_codemod/src/util/package_util.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+import 'required_props_collect_and_codemod_test.dart';
+
+void main() {
+  group('null_safety_migrator_companion codemod, end-to-end behavior:', () {
+    final companionScript = p.join(findPackageRootFor(p.current),
+        'bin/null_safety_migrator_companion.dart');
+
+    const name = 'test_package';
+    late d.DirectoryDescriptor projectDir;
+
+    setUp(() async {
+      projectDir = d.DirectoryDescriptor.fromFilesystem(
+          name,
+          p.join(findPackageRootFor(p.current),
+              'test/test_fixtures/required_props/test_package'));
+      await projectDir.create();
+    });
+
+    test('adds hints as expected in different cases', () async {
+      await testCodemod(
+        script: companionScript,
+        args: [
+          '--yes-to-all',
+        ],
+        input: projectDir,
+        expectedOutput: d.dir(projectDir.name, [
+          d.dir('lib', [
+            d.dir('src', [
+              d.file('test_state.dart', contains('''
+mixin FooProps on UiProps {
+  int prop1;
+}
+
+mixin FooState on UiState {
+  String/*?*/ state1;
+  /*late*/ int/*!*/ initializedState;
+  void Function()/*?*/ state2;
+}
+
+class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+  @override
+  get initialState => (newState()..initializedState = 1);
+
+  @override
+  render() {
+    ButtonElement/*?*/ _ref;
+    return (Dom.div()..ref = (ButtonElement/*?*/ r) => _ref = r)();
+  }
+}''')),
+            ]),
+          ]),
+        ]),
+      );
+    });
+  }, timeout: Timeout(Duration(minutes: 2)));
+}

--- a/test/test_fixtures/required_props/test_package/lib/src/test_state.dart
+++ b/test/test_fixtures/required_props/test_package/lib/src/test_state.dart
@@ -1,0 +1,30 @@
+import 'dart:html';
+
+import 'package:over_react/over_react.dart';
+
+// ignore: uri_has_not_been_generated
+part 'test_state.over_react.g.dart';
+
+UiFactory<FooProps> Foo =
+    castUiFactory(_$Foo); // ignore: undefined_identifier
+
+mixin FooProps on UiProps {
+  int prop1;
+}
+
+mixin FooState on UiState {
+  String state1;
+  int initializedState;
+  void Function() state2;
+}
+
+class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+  @override
+  get initialState => (newState()..initializedState = 1);
+
+  @override
+  render() {
+    ButtonElement _ref;
+    return (Dom.div()..ref = (ButtonElement r) => _ref = r)();
+  }
+}


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
When working on a different codemod, we noticed that `ClassComponentRequiredInitialStateMigrator` migrates defaulted state mixin fields, but there's no codemod to migrate the rest of state mixin fields - we should add one to set all other fields to optional.
## Changes
  <!-- What this PR changes to fix the problem. -->
- Added `StateMixinSuggestor` to make all state mixin fields optional and run it after `ClassComponentRequiredInitialStateMigrator`
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
      - [ ] CI passes
      - [ ] Good test coverage
      - [ ] Run the codemod on a repo (ex. WSD)
        - [ ] `dart pub global activate --source path .`
        - [ ] `dart pub global run over_react_codemod:null_safety_migrator_companion`
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
