### PR TITLE
Raise the react_material_ui dependency min to v1.214.2

### DIFF
--- a/test/test_fixtures/rmui_project/pubspec.yaml
+++ b/test/test_fixtures/rmui_project/pubspec.yaml
@@ -7,4 +7,4 @@ dependencies:
     hosted:
       name: react_material_ui
       url: https://pub.workiva.org
-    version: ^1.121.0
+    version: ^1.214.2


### PR DESCRIPTION
This PR raises the min version of react_material_ui to 1.214.2. Passing CI
should be sufficient for QA, so feel free to review and merge this once CI completes.

For more info, reach out to `#support-uip` on Slack.

[_Created by Sourcegraph batch change `Workiva/react_material_ui_raise_min_v1_214_2`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/react_material_ui_raise_min_v1_214_2)