### PR TITLE
Unpin the meta dependency to allow the latest

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   glob: ^2.0.1
   json_annotation: ^4.8.0
   logging: ^1.0.1
-  meta: '>=1.7.0  <1.10.0'
+  meta: '>=1.7.0 <2.0.0'
   package_config: ^2.1.0
   path: ^1.8.0
   pub_semver: ^2.0.0


### PR DESCRIPTION
This PR raises unpins the meta dependency to allow the latest.
Passing CI should be sufficient for QA, so feel free to review and merge this once CI completes.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/meta_raise_min_v1_16_0`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/meta_raise_min_v1_16_0)