### PR TITLE
FED-2554 Companion codemods should not run on null-safe files

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.18.7, 2.19.6 ]
+        sdk: [ 2.19.6 ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2
@@ -35,7 +35,7 @@ jobs:
 
       - name: Validate formatting
         run: dart run dart_dev format --check
-        if: always() && steps.install.outcome == 'success' && matrix.sdk == '2.18.7'
+        if: always() && steps.install.outcome == 'success'
 
       - name: Analyze project source
         run: dart analyze
@@ -45,14 +45,14 @@ jobs:
         run: |
           dart run build_runner build --delete-conflicting-outputs
           git diff --exit-code
-        if: always() && steps.install.outcome == 'success' && matrix.sdk == '2.19.6'
+        if: always() && steps.install.outcome == 'success'
 
   test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.18.7, 2.19.6 ]
+        sdk: [ 2.19.6 ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2
@@ -74,8 +74,6 @@ jobs:
 
       - name: Create SBOM Release Asset
         uses: anchore/sbom-action@v0
-        # This fails if it runs more than once within a given build
-        if: matrix.sdk != '2.18.7'
         with:
           path: ./
           format: cyclonedx-json

--- a/lib/src/dart3_suggestors/null_safety_prep/callback_ref_hint_suggestor.dart
+++ b/lib/src/dart3_suggestors/null_safety_prep/callback_ref_hint_suggestor.dart
@@ -141,6 +141,11 @@ class CallbackRefHintSuggestor extends RecursiveAstVisitor<void>
           'Could not get resolved result for "${context.relativePath}"');
     }
     result = r;
+    // Don't make any updates if the file is already null safe.
+    if (result.libraryElement.isNonNullableByDefault) {
+      return;
+    }
+
     result.unit.visitChildren(this);
   }
 }

--- a/lib/src/dart3_suggestors/null_safety_prep/class_component_required_default_props.dart
+++ b/lib/src/dart3_suggestors/null_safety_prep/class_component_required_default_props.dart
@@ -86,6 +86,11 @@ class ClassComponentRequiredDefaultPropsMigrator
 
   @override
   Future<void> visitCascadeExpression(CascadeExpression node) async {
+    // Don't make any updates if the file is already null safe.
+    if (result.libraryElement.isNonNullableByDefault) {
+      return;
+    }
+
     super.visitCascadeExpression(node);
 
     final isDefaultProps = node.ancestors.any((ancestor) {

--- a/lib/src/dart3_suggestors/null_safety_prep/class_component_required_initial_state.dart
+++ b/lib/src/dart3_suggestors/null_safety_prep/class_component_required_initial_state.dart
@@ -80,6 +80,11 @@ class ClassComponentRequiredInitialStateMigrator
 
   @override
   Future<void> visitCascadeExpression(CascadeExpression node) async {
+    // Don't make any updates if the file is already null safe.
+    if (result.libraryElement.isNonNullableByDefault) {
+      return;
+    }
+
     super.visitCascadeExpression(node);
 
     final isInitialState = [relevantGetterName, relevantMethodName].contains(

--- a/lib/src/dart3_suggestors/null_safety_prep/connect_required_props.dart
+++ b/lib/src/dart3_suggestors/null_safety_prep/connect_required_props.dart
@@ -75,6 +75,10 @@ class ConnectRequiredProps extends RecursiveAstVisitor with ClassSuggestor {
       throw Exception(
           'Could not get resolved result for "${context.relativePath}"');
     }
+    // Don't make any updates if the file is already null safe.
+    if (result.libraryElement.isNonNullableByDefault) {
+      return;
+    }
     result.unit.accept(this);
 
     // Add the patches at the end so that all the props to be ignored can be collected

--- a/lib/src/dart3_suggestors/null_safety_prep/state_mixin_suggestor.dart
+++ b/lib/src/dart3_suggestors/null_safety_prep/state_mixin_suggestor.dart
@@ -62,6 +62,11 @@ class StateMixinSuggestor extends RecursiveAstVisitor<void>
       throw Exception(
           'Could not get resolved result for "${context.relativePath}"');
     }
+
+    // Don't make any updates if the file is already null safe.
+    if (r.libraryElement.isNonNullableByDefault) {
+      return;
+    }
     r.unit.accept(this);
   }
 }

--- a/lib/src/dart3_suggestors/required_props/codemod/required_props_suggestor.dart
+++ b/lib/src/dart3_suggestors/required_props/codemod/required_props_suggestor.dart
@@ -42,6 +42,11 @@ class RequiredPropsSuggestor extends RecursiveAstVisitor<void>
       throw Exception(
           'Could not get resolved result for "${context.relativePath}"');
     }
+
+    // Don't make any updates if the file is already null safe.
+    if (result.libraryElement.isNonNullableByDefault) {
+      return;
+    }
     result.unit.accept(this);
   }
 

--- a/test/dart3_suggestors/null_safety_prep/class_component_required_initial_state_test.dart
+++ b/test/dart3_suggestors/null_safety_prep/class_component_required_initial_state_test.dart
@@ -383,7 +383,7 @@ void main() {
           ''', filePrefix: '// @dart=2.11\n'),
           // Ignore error on language version comment.
           isExpectedError: (error) =>
-          error.errorCode.name.toLowerCase() ==
+              error.errorCode.name.toLowerCase() ==
               'illegal_language_version_override',
         );
       });

--- a/test/dart3_suggestors/null_safety_prep/state_mixin_suggestor_test.dart
+++ b/test/dart3_suggestors/null_safety_prep/state_mixin_suggestor_test.dart
@@ -147,5 +147,104 @@ void main() {
           '''),
       );
     });
+
+    group('makes no update if file is already on a null safe Dart version', () {
+      final resolvedContext = SharedAnalysisContext.overReactNullSafe;
+
+      // Warm up analysis in a setUpAll so that if getting the resolved AST times out
+      // (which is more common for the WSD context), it fails here instead of failing the first test.
+      setUpAll(resolvedContext.warmUpAnalysis);
+
+      late SuggestorTester nullSafeTestSuggestor;
+
+      setUp(() {
+        nullSafeTestSuggestor = getSuggestorTester(
+          StateMixinSuggestor(),
+          resolvedContext: resolvedContext,
+        );
+      });
+
+      test('', () async {
+        await nullSafeTestSuggestor(
+          expectedPatchCount: 0,
+          input: withOverReactImport(/*language=dart*/ r'''
+            // ignore: undefined_identifier
+            UiFactory<FooProps> Foo = castUiFactory(_$Foo);
+            mixin FooProps on UiProps {
+              String? prop1;
+            }
+            mixin FooStateMixin on UiState {
+              String? state1;
+              late num state2;
+            }
+            mixin SomeOtherStateMixin on UiState {
+              String? state3;
+            }
+            class FooState = UiState with FooStateMixin, SomeOtherStateMixin;
+            class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+              @override
+              render() => null;
+            }
+          '''),
+        );
+      });
+
+      test('unless there is a lang version comment', () async {
+        await nullSafeTestSuggestor(
+          input: withOverReactImport(/*language=dart*/ r'''
+            // ignore: undefined_identifier
+            UiFactory<FooProps> Foo = castUiFactory(_$Foo);
+            mixin FooProps on UiProps {
+              String prop1;
+            }
+            mixin FooStateMixin on UiState {
+              String state1;
+              num state2;
+              /// This is a doc comment
+              /*late*/ String/*!*/ alreadyPatched;
+              /*late*/ String/*?*/ alreadyPatchedButNoDocComment;
+              String/*?*/ alreadyPatchedOptional;
+            }
+            mixin SomeOtherStateMixin on UiState {
+              String state3;
+              String/*?*/ alreadyPatchedOptional2;
+            }
+            class FooState = UiState with FooStateMixin, SomeOtherStateMixin;
+            class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+              @override
+              render() => null;
+            }
+          ''', filePrefix: '// @dart=2.11\n'),
+          expectedOutput: withOverReactImport(/*language=dart*/ r'''
+            // ignore: undefined_identifier
+            UiFactory<FooProps> Foo = castUiFactory(_$Foo);
+            mixin FooProps on UiProps {
+              String prop1;
+            }
+            mixin FooStateMixin on UiState {
+              String/*?*/ state1;
+              num/*?*/ state2;
+              /// This is a doc comment
+              /*late*/ String/*!*/ alreadyPatched;
+              /*late*/ String/*?*/ alreadyPatchedButNoDocComment;
+              String/*?*/ alreadyPatchedOptional;
+            }
+            mixin SomeOtherStateMixin on UiState {
+              String/*?*/ state3;
+              String/*?*/ alreadyPatchedOptional2;
+            }
+            class FooState = UiState with FooStateMixin, SomeOtherStateMixin;
+            class FooComponent extends UiStatefulComponent2<FooProps, FooState> {
+              @override
+              render() => null;
+            }
+          ''', filePrefix: '// @dart=2.11\n'),
+          // Ignore error on language version comment.
+          isExpectedError: (error) =>
+              error.errorCode.name.toLowerCase() ==
+              'illegal_language_version_override',
+        );
+      });
+    });
   });
 }

--- a/test/resolved_file_context.dart
+++ b/test/resolved_file_context.dart
@@ -51,6 +51,12 @@ class SharedAnalysisContext {
   static final overReact = SharedAnalysisContext(p.join(
       findPackageRootFor(p.current), 'test/test_fixtures/over_react_project'));
 
+  /// A context root located at `test/test_fixtures/over_react_null_safe_project`
+  /// that depends on the `over_react` package and a null-safe Dart version.
+  static final overReactNullSafe = SharedAnalysisContext(p.join(
+      findPackageRootFor(p.current),
+      'test/test_fixtures/over_react_null_safe_project'));
+
   /// A context root located at `test/test_fixtures/over_react_project`
   /// that depends on the internal `web_skin_dart` package (as well as `over_react`).
   static final wsd = SharedAnalysisContext(

--- a/test/test_fixtures/over_react_null_safe_project/README.md
+++ b/test/test_fixtures/over_react_null_safe_project/README.md
@@ -1,0 +1,3 @@
+A null-safe package that depends on over_react, and can be used as a context root for tests that require a resolved analysis context with access to over_react APIs and on a null-safe Dart version.
+
+To use, see `SharedAnalysisContext.overReactNullSafe`.

--- a/test/test_fixtures/over_react_null_safe_project/lib/analysis_warmup.dart
+++ b/test/test_fixtures/over_react_null_safe_project/lib/analysis_warmup.dart
@@ -1,0 +1,8 @@
+// This file imports over_react and can be analyzed to warm up an
+// analysis context during testing.
+
+import 'package:over_react/over_react.dart';
+
+main() {
+  Dom.div()();
+}

--- a/test/test_fixtures/over_react_null_safe_project/lib/src/test_lang_version_comment.dart
+++ b/test/test_fixtures/over_react_null_safe_project/lib/src/test_lang_version_comment.dart
@@ -1,0 +1,33 @@
+// @dart=2.11
+import 'package:over_react/over_react.dart';
+
+part 'test_private.over_react.g.dart';
+
+mixin TestPrivateProps on UiProps {
+  String set100percent;
+  String set80percent;
+  String set20percent;
+  String set0percent;
+}
+
+UiFactory<TestPrivateProps> TestPrivate = uiFunction(
+  (props) {},
+  _$TestPrivateConfig, // ignore: undefined_identifier
+);
+
+usages() {
+  (TestPrivate()
+    ..set100percent = ''
+    ..set80percent = ''
+    ..set20percent = '')();
+  (TestPrivate()
+    ..set100percent = ''
+    ..set80percent = '')();
+  (TestPrivate()
+    ..set100percent = ''
+    ..set80percent = '')();
+  (TestPrivate()
+    ..set100percent = ''
+    ..set80percent = '')();
+  (TestPrivate()..set100percent = '')();
+}

--- a/test/test_fixtures/over_react_null_safe_project/lib/src/test_null_safe.dart
+++ b/test/test_fixtures/over_react_null_safe_project/lib/src/test_null_safe.dart
@@ -1,0 +1,32 @@
+import 'package:over_react/over_react.dart';
+
+part 'test_private.over_react.g.dart';
+
+mixin TestPrivateProps on UiProps {
+  late String set100percent;
+  String? set80percent;
+  String? set20percent;
+  String? set0percent;
+}
+
+UiFactory<TestPrivateProps> TestPrivate = uiFunction(
+  (props) {},
+  _$TestPrivateConfig, // ignore: undefined_identifier
+);
+
+usages() {
+  (TestPrivate()
+    ..set100percent = ''
+    ..set80percent = ''
+    ..set20percent = '')();
+  (TestPrivate()
+    ..set100percent = ''
+    ..set80percent = '')();
+  (TestPrivate()
+    ..set100percent = ''
+    ..set80percent = '')();
+  (TestPrivate()
+    ..set100percent = ''
+    ..set80percent = '')();
+  (TestPrivate()..set100percent = '')();
+}

--- a/test/test_fixtures/over_react_null_safe_project/pubspec.yaml
+++ b/test/test_fixtures/over_react_null_safe_project/pubspec.yaml
@@ -1,0 +1,5 @@
+name: over_react_null_safe_project
+environment:
+  sdk: '>=2.19.0 <3.0.0'
+dependencies:
+  over_react: ^5.0.0

--- a/test/util/component_usage_migrator_test.dart
+++ b/test/util/component_usage_migrator_test.dart
@@ -1690,8 +1690,8 @@ class GenericMigrator extends ComponentUsageMigrator {
 
 const overReactImport = "import 'package:over_react/over_react.dart';";
 
-String withOverReactImport(String source) {
-  return '$overReactImport\n$source';
+String withOverReactImport(String source, {String filePrefix = ''}) {
+  return '$filePrefix$overReactImport\n$source';
 }
 
 String fileWithCascadeOnUsage(String cascade) {


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
During null safety migrations, some repos will be incrementally migrated, and there's a good chance the over_react null safety companion set of codemods (the one that inserts nullability hints) will get run on a mixture of not-yet-migrated and already-migrated code.

To avoid adding a bunch of nullability hints to files that have already been migrated to null safety, which would have to be manually removed, we should update our codemods to not run on files that are already null-safe.
## Changes
  <!-- What this PR changes to fix the problem. -->
- Add short circuit to all companion codemod suggestors if the file is already null safe
- Add tests
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
      - [ ] CI passes
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
