### PR TITLE
RM-276934 Release over_react_codemod 2.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.34.0
+- Null safety codemod improvements
+    - Add required prop validation ignores for `connect`-ed props, matching (see more info in [migration guide](https://github.com/Workiva/over_react/blob/master/doc/null_safety/null_safe_migration.md#connect))
+    - Don't add migrator tool hint comments to files that have already been migrated to null safety  
+    - Only make defaulted class component props required when they're not public, to avoid breakages and align with [migration guide guidance](https://github.com/Workiva/over_react/blob/master/doc/null_safety/null_safe_migration.md#prop-requiredness-and-nullability)
+      - Note: defaulted prop hints are now added via the `null_safety_required_props` executable instead of via `null_safety_migrator_companion`
+    - Add optional (`/*?*/`) hint to non-defaulted state fields, just like for props
+    - `useRef<…>(null)` is now migrated to `useRef<…>()` instead of `useRefInit<…>(null)` (the old behavior wasn't problematic, just not as clean as it could have been)
+- Unpin `meta` dependency
+
 ## 2.33.0
 - Add `null_safety_required_props` executable to help [migrate over_react props to nulls safety](https://github.com/Workiva/over_react/blob/master/doc/null_safety/null_safe_migration.md)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.34.0
 - Null safety codemod improvements
-    - Add required prop validation ignores for `connect`-ed props, matching (see more info in [migration guide](https://github.com/Workiva/over_react/blob/master/doc/null_safety/null_safe_migration.md#connect))
     - Don't add migrator tool hint comments to files that have already been migrated to null safety  
+    - Add required prop validation ignores for `connect`-ed props (see more info in [migration guide](https://github.com/Workiva/over_react/blob/master/doc/null_safety/null_safe_migration.md#connect))
     - Only make defaulted class component props required when they're not public, to avoid breakages and align with [migration guide guidance](https://github.com/Workiva/over_react/blob/master/doc/null_safety/null_safe_migration.md#prop-requiredness-and-nullability)
       - Note: defaulted prop hints are now added via the `null_safety_required_props` executable instead of via `null_safety_migrator_companion`
     - Add optional (`/*?*/`) hint to non-defaulted state fields, just like for props

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_codemod
-version: 2.33.0
+version: 2.34.0
 homepage: https://github.com/Workiva/over_react_codemod
 
 description: >


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FED-3209 Remove explicit null passed to useRef](https://github.com/Workiva/over_react_codemod/pull/296)
	* [FED-2994 Update class component defaults codemod to take public-ness into account](https://github.com/Workiva/over_react_codemod/pull/297)
	* [FED-3248 Update non-defaulted state mixin fields to be optional](https://github.com/Workiva/over_react_codemod/pull/298)
	* [Raise the react_material_ui dependency min to v1.214.2](https://github.com/Workiva/over_react_codemod/pull/300)
	* [Unpin the meta dependency to allow the latest](https://github.com/Workiva/over_react_codemod/pull/301)
	* [FED-3143 Null Safety Codemod for connect props](https://github.com/Workiva/over_react_codemod/pull/302)
	* [FED-2554 Companion codemods should not run on null-safe files](https://github.com/Workiva/over_react_codemod/pull/303)


Requested by: @greglittlefield-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react_codemod/compare/2.33.0...Workiva:release_over_react_codemod_2.34.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react_codemod/compare/2.33.0...2.34.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6153708125028352/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6153708125028352/?repo_name=Workiva%2Fover_react_codemod&pull_number=304)