### PR TITLE
FED-3281 Update rename codemod

### DIFF
--- a/lib/src/executables/unify_package_rename.dart
+++ b/lib/src/executables/unify_package_rename.dart
@@ -20,12 +20,10 @@ import 'package:over_react_codemod/src/executables/mui_migration.dart';
 import 'package:over_react_codemod/src/rmui_bundle_update_suggestors/constants.dart';
 import 'package:over_react_codemod/src/rmui_bundle_update_suggestors/dart_script_updater.dart';
 import 'package:over_react_codemod/src/rmui_bundle_update_suggestors/html_script_updater.dart';
-import 'package:over_react_codemod/src/unify_package_rename_suggestors/constants.dart';
 import 'package:over_react_codemod/src/unify_package_rename_suggestors/import_renamer.dart';
 import 'package:over_react_codemod/src/unify_package_rename_suggestors/unify_rename_suggestor.dart';
 import 'package:over_react_codemod/src/util.dart';
 
-import '../util/importer.dart';
 import '../util/unused_import_remover.dart';
 
 const _changesRequiredOutput = """
@@ -88,13 +86,6 @@ void main(List<String> args) async {
   exitCode = await runCodemods([
     // Make main rename updates.
     CodemodInfo(paths: dartPaths, sequence: [UnifyRenameSuggestor()]),
-    // Add WSD entrypoint imports as needed.
-    CodemodInfo(paths: dartPaths, sequence: [
-      importerSuggestorBuilder(
-        importUri: unifyWsdUri,
-        importNamespace: unifyWsdNamespace,
-      )
-    ]),
     // Update rmui imports to unify.
     CodemodInfo(paths: dartPaths, sequence: [
       importRenamerSuggestorBuilder(

--- a/lib/src/executables/unify_package_rename.dart
+++ b/lib/src/executables/unify_package_rename.dart
@@ -100,8 +100,6 @@ void main(List<String> args) async {
       importRenamerSuggestorBuilder(
         oldPackageName: 'react_material_ui',
         newPackageName: 'unify_ui',
-        oldPackageNamespace: 'mui',
-        newPackageNamespace: 'unify',
       )
     ]),
     // Remove any left over unused imports.

--- a/lib/src/unify_package_rename_suggestors/constants.dart
+++ b/lib/src/unify_package_rename_suggestors/constants.dart
@@ -50,10 +50,6 @@ final rmuiImportsToUpdate = [
   UnifyImportInfo(
     'package:unify_ui/styles/styled.dart',
     rmuiUri: 'package:react_material_ui/for_cp_use_only/styled.dart',
-  ),
-  UnifyImportInfo(
-    'package:unify_ui/styles/theme_provider.dart',
-    rmuiUri: 'package:react_material_ui/styles/theme_provider.dart',
   )
 ];
 

--- a/lib/src/unify_package_rename_suggestors/constants.dart
+++ b/lib/src/unify_package_rename_suggestors/constants.dart
@@ -124,8 +124,5 @@ const rmuiToUnifyIdentifierRenames = {
       'TablePaginationLabelDisplayedRowsArgs',
 };
 
-/// The namespace that will be used for the `unify_ui/components/wsd.dart` import that is added.
-const unifyWsdNamespace = 'unify_wsd';
-
 /// The uri for the `unify_ui/components/wsd.dart` import that is added.
 const unifyWsdUri = 'package:unify_ui/components/wsd.dart';

--- a/lib/src/unify_package_rename_suggestors/constants.dart
+++ b/lib/src/unify_package_rename_suggestors/constants.dart
@@ -50,6 +50,11 @@ final rmuiImportsToUpdate = [
   UnifyImportInfo(
     'package:unify_ui/styles/styled.dart',
     rmuiUri: 'package:react_material_ui/for_cp_use_only/styled.dart',
+  ),
+  UnifyImportInfo(
+    'package:unify_ui/components/usage_must_be_approved_by_unify_team_for_legal_reasons/data_grid_premium.dart',
+    rmuiUri:
+        'package:react_material_ui/components/usage_must_be_approved_by_unify_team_for_legal_reasons_rmui/data_grid_premium.dart',
   )
 ];
 

--- a/lib/src/unify_package_rename_suggestors/constants.dart
+++ b/lib/src/unify_package_rename_suggestors/constants.dart
@@ -14,20 +14,13 @@
 
 /// Info on a unify_ui import.
 class UnifyImportInfo {
-  UnifyImportInfo(this.uri,
-      {this.rmuiUri,
-      this.namespace,
-      this.possibleMuiNamespaces,
-      this.showHideInfo});
+  UnifyImportInfo(this.uri, {this.rmuiUri, this.namespace, this.showHideInfo});
 
   /// Unify import URI.
   String uri;
 
   /// Recommended Unify version of the import namespace, if applicable.
   String? namespace;
-
-  /// List of common RMUI versions of the namespace for the import, if applicable.
-  List<String>? possibleMuiNamespaces;
 
   /// Previous RMUI import URI (if it's different from the unify_ui path).
   String? rmuiUri;
@@ -44,15 +37,11 @@ final rmuiImportsToUpdate = [
   UnifyImportInfo(
     'package:unify_ui/unify_ui.dart',
     rmuiUri: 'package:react_material_ui/react_material_ui.dart',
-    namespace: 'unify',
-    possibleMuiNamespaces: ['mui', 'rmui'],
   ),
   UnifyImportInfo(
     'package:unify_ui/z_alpha_may_break_at_runtime_do_not_release_to_customers.dart',
     rmuiUri:
         'package:react_material_ui/z_alpha_may_break_at_runtime_do_not_release_to_customers.dart',
-    namespace: 'alpha_unify',
-    possibleMuiNamespaces: ['alpha_mui', 'mui_alpha'],
   ),
   UnifyImportInfo(
     'package:unify_ui/components/list.dart',
@@ -62,10 +51,10 @@ final rmuiImportsToUpdate = [
     'package:unify_ui/styles/styled.dart',
     rmuiUri: 'package:react_material_ui/for_cp_use_only/styled.dart',
   ),
-  UnifyImportInfo('package:unify_ui/styles/theme_provider.dart',
-      rmuiUri: 'package:react_material_ui/styles/theme_provider.dart',
-      namespace: 'unify_theme',
-      possibleMuiNamespaces: ['mui_theme'])
+  UnifyImportInfo(
+    'package:unify_ui/styles/theme_provider.dart',
+    rmuiUri: 'package:react_material_ui/styles/theme_provider.dart',
+  )
 ];
 
 /// A map of RMUI component names to their new names in unify_ui.

--- a/lib/src/unify_package_rename_suggestors/import_renamer.dart
+++ b/lib/src/unify_package_rename_suggestors/import_renamer.dart
@@ -62,10 +62,9 @@ Suggestor importRenamerSuggestorBuilder({
         // Collect info on new imports to add.
         newImportsInfo.add(UnifyImportInfo(newImportUri,
             namespace: namespace,
-            showHideInfo: import.combinators
-                .map((c) => c.toSource())
-                .toList()
-                .join(' ')));
+            showHideInfo: import.combinators.isEmpty
+                ? null
+                : import.combinators.map((c) => c.toSource()).join(' ')));
       }
 
       final prevTokenEnd = import.beginToken.previous?.end;

--- a/lib/src/unify_package_rename_suggestors/import_renamer.dart
+++ b/lib/src/unify_package_rename_suggestors/import_renamer.dart
@@ -22,8 +22,6 @@ import 'constants.dart';
 Suggestor importRenamerSuggestorBuilder({
   required String oldPackageName,
   required String newPackageName,
-  required String oldPackageNamespace,
-  required String newPackageNamespace,
 }) {
   return (context) async* {
     final libraryResult = await context.getResolvedLibrary();
@@ -52,29 +50,18 @@ Suggestor importRenamerSuggestorBuilder({
       final namespace = import.prefix?.name;
       var newImportUri = importUri?.replaceFirst(
           'package:$oldPackageName/', 'package:$newPackageName/');
-      var newNamespace =
-          namespace == oldPackageNamespace ? newPackageNamespace : namespace;
 
       // Check for special cases where the unify_ui import path does not match the previous RMUI path.
       final specialCaseRmuiImport =
           rmuiImportsToUpdate.where((i) => importUri == i.rmuiUri);
       if (specialCaseRmuiImport.isNotEmpty) {
         newImportUri = specialCaseRmuiImport.single.uri;
-
-        final specialCaseNamespace = specialCaseRmuiImport.single.namespace;
-        if (namespace != null &&
-            specialCaseNamespace != null &&
-            (specialCaseRmuiImport.single.possibleMuiNamespaces
-                    ?.contains(namespace) ??
-                false)) {
-          newNamespace = specialCaseNamespace;
-        }
       }
 
       if (newImportUri != null) {
         // Collect info on new imports to add.
         newImportsInfo.add(UnifyImportInfo(newImportUri,
-            namespace: newNamespace,
+            namespace: namespace,
             showHideInfo: import.combinators
                 .map((c) => c.toSource())
                 .toList()

--- a/lib/src/unify_package_rename_suggestors/unify_rename_suggestor.dart
+++ b/lib/src/unify_package_rename_suggestors/unify_rename_suggestor.dart
@@ -15,7 +15,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:codemod/codemod.dart';
-import 'package:collection/collection.dart';
 import 'package:logging/logging.dart';
 
 import '../util.dart';
@@ -104,7 +103,12 @@ class UnifyRenameSuggestor extends GeneralizingAstVisitor with ClassSuggestor {
       if (identifier?.name == 'Badge' || identifier?.name == 'LinearProgress') {
         yieldInsertionPatch(
             lineComment(
-                'FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, remove this FIXME - no action is required; otherwise, migrate this component back to Web Skin Dart.'),
+                'FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, manually QA this component and remove this FIXME; otherwise, migrate this component back to Web Skin Dart.'),
+            node.offset);
+      } else if (identifier?.name == 'Alert') {
+        yieldInsertionPatch(
+            lineComment(
+                'FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, update this to `Alert` from `unify_ui/components/alert.dart`, manually QA this component, and remove this FIXME; otherwise, remove this FIXME.'),
             node.offset);
       }
     }

--- a/lib/src/unify_package_rename_suggestors/unify_rename_suggestor.dart
+++ b/lib/src/unify_package_rename_suggestors/unify_rename_suggestor.dart
@@ -71,18 +71,20 @@ class UnifyRenameSuggestor extends GeneralizingAstVisitor with ClassSuggestor {
         // Update WSD constant properties objects to use the WSD versions if applicable.
         yieldWsdRenamePatchIfApplicable(
             Expression node, String? objectName, String? propertyName) {
-          const alertConstantNames = [
+          const wsdConstantNames = [
             'AlertSize',
             'AlertColor',
             'AlertVariant',
-            'AlertSeverity'
+            'AlertSeverity',
+            'LinkButtonType',
+            'LinkButtonSize',
           ];
           if (objectName == 'ButtonColor' &&
               (propertyName?.startsWith('wsd') ?? false)) {
             isFromWsdEntrypoint = true;
             yieldPatch('$unifyWsdNamespace.WsdButtonColor.$propertyName',
                 node.offset, node.end);
-          } else if (alertConstantNames.contains(objectName)) {
+          } else if (wsdConstantNames.contains(objectName)) {
             isFromWsdEntrypoint = true;
             yieldPatch('$unifyWsdNamespace.Wsd$objectName.$propertyName',
                 node.offset, node.end);
@@ -105,10 +107,11 @@ class UnifyRenameSuggestor extends GeneralizingAstVisitor with ClassSuggestor {
             lineComment(
                 'FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, manually QA this component and remove this FIXME; otherwise, migrate this component back to Web Skin Dart.'),
             node.offset);
-      } else if (identifier?.name == 'Alert') {
+      } else if (identifier?.name == 'Alert' ||
+          identifier?.name == 'AlertPropsMixin') {
         yieldInsertionPatch(
             lineComment(
-                'FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, update this to `Alert` from `unify_ui/components/alert.dart`, manually QA this component, and remove this FIXME; otherwise, remove this FIXME.'),
+                'FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, update this to `${identifier?.name}` from `unify_ui/components/alert.dart`, manually QA this component, and remove this FIXME; otherwise, remove this FIXME.'),
             node.offset);
       }
     }

--- a/test/unify_package_rename_suggestors/import_renamer_test.dart
+++ b/test/unify_package_rename_suggestors/import_renamer_test.dart
@@ -96,7 +96,9 @@ void main() {
               import 'package:web_skin_dart/ui_components.dart';
               import 'package:react_material_ui/for_cp_use_only/styled.dart';
               import 'package:react_material_ui/components/mui_list.dart';
+              import 'package:react_material_ui/components/usage_must_be_approved_by_unify_team_for_legal_reasons_rmui/data_grid_premium.dart';
               import 'package:react_material_ui/styles/styled.dart';
+              
           
               content() => Dom.div()();
           ''',
@@ -104,6 +106,8 @@ void main() {
               import 'package:over_react/over_react.dart';
               import 'package:'''
               '''unify_ui/components/list.dart';
+              import 'package:'''
+              '''unify_ui/components/usage_must_be_approved_by_unify_team_for_legal_reasons/data_grid_premium.dart';
               import 'package:'''
               '''unify_ui/styles/styled.dart';
               import 'package:'''

--- a/test/unify_package_rename_suggestors/import_renamer_test.dart
+++ b/test/unify_package_rename_suggestors/import_renamer_test.dart
@@ -23,8 +23,6 @@ void main() {
       importRenamerSuggestorBuilder(
         oldPackageName: 'react_material_ui',
         newPackageName: 'unify_ui',
-        oldPackageNamespace: 'mui',
-        newPackageNamespace: 'unify',
       ),
     );
 
@@ -79,9 +77,9 @@ void main() {
           ''',
           expectedOutput: '''
               import 'package:'''
-              '''unify_ui/styles/styled.dart' as unify;
+              '''unify_ui/styles/styled.dart' as mui;
               import 'package:'''
-              '''unify_ui/unify_ui.dart' as unify;
+              '''unify_ui/unify_ui.dart' as mui;
           
               content() => Dom.div()();
           ''',
@@ -141,15 +139,15 @@ void main() {
               import 'package:'''
               '''unify_ui/components/alert.dart' as something_else;
               import 'package:'''
-              '''unify_ui/components/badge.dart' as unify;
+              '''unify_ui/components/badge.dart' as mui;
               import 'package:'''
-              '''unify_ui/styles/theme_provider.dart' as unify_theme show UnifyThemeProvider;
+              '''unify_ui/styles/theme_provider.dart' as mui_theme show UnifyThemeProvider;
               import 'package:'''
-              '''unify_ui/unify_ui.dart' as unify;
+              '''unify_ui/unify_ui.dart' as mui;
               import 'package:'''
-              '''unify_ui/z_alpha_may_break_at_runtime_do_not_release_to_customers.dart' as alpha_unify;
+              '''unify_ui/z_alpha_may_break_at_runtime_do_not_release_to_customers.dart' as alpha_mui;
               import 'package:'''
-              '''unify_ui/z_alpha_may_break_at_runtime_do_not_release_to_customers.dart' as alpha_unify;
+              '''unify_ui/z_alpha_may_break_at_runtime_do_not_release_to_customers.dart' as mui_alpha;
           
               content() => Dom.div()();
           ''',
@@ -173,11 +171,11 @@ void main() {
               import 'package:'''
               '''unify_ui/components/badge.dart' show Badge hide BadgeColor;
               import 'package:'''
-              '''unify_ui/styles/theme_provider.dart' as unify_theme show UnifyThemeProvider;
+              '''unify_ui/styles/theme_provider.dart' as mui_theme show UnifyThemeProvider;
               import 'package:'''
               '''unify_ui/unify_ui.dart' hide Alert;
               import 'package:'''
-              '''unify_ui/z_alpha_may_break_at_runtime_do_not_release_to_customers.dart' as alpha_unify hide Alert show LinearProgress;
+              '''unify_ui/z_alpha_may_break_at_runtime_do_not_release_to_customers.dart' as mui_alpha hide Alert show LinearProgress;
               
               content() => Dom.div()();
           ''',
@@ -210,8 +208,6 @@ void main() {
           importRenamerSuggestorBuilder(
             oldPackageName: 'old',
             newPackageName: 'new',
-            oldPackageNamespace: 'o',
-            newPackageNamespace: 'n',
           ),
         );
         await testSuggestor(
@@ -228,7 +224,7 @@ void main() {
               import 'package:'''
               '''new/components/badge.dart';
               import 'package:'''
-              '''new/old.dart' as n;
+              '''new/old.dart' as o;
               import 'package:over_react/over_react.dart';
           
               content() => Dom.div()();

--- a/test/unify_package_rename_suggestors/unify_rename_suggestor_test.dart
+++ b/test/unify_package_rename_suggestors/unify_rename_suggestor_test.dart
@@ -64,11 +64,15 @@ void main() {
       mui.Alert()();
       mui.Alert();
       mui.Alert;
+      mui.AlertPropsMixin;
       mui.AlertSize.small;
       AlertSize.small;
+      LinkButtonSize.small;
+      LinkButtonType.submit;
       AlertSeverity.error;
       mui.AlertColor.warning;
       mui.AlertVariant.outlined;
+      mui.LinkButtonSize.xxsmall;
       Alert()();
       random_rmui_namespace.Alert()();
       mui.LinkButton()();
@@ -93,11 +97,16 @@ void main() {
       unify_wsd.WsdAlert();
       // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, update this to `Alert` from `unify_ui/components/alert.dart`, manually QA this component, and remove this FIXME; otherwise, remove this FIXME.
       unify_wsd.WsdAlert;
+      // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, update this to `AlertPropsMixin` from `unify_ui/components/alert.dart`, manually QA this component, and remove this FIXME; otherwise, remove this FIXME.
+      unify_wsd.WsdAlertPropsMixin;
       unify_wsd.WsdAlertSize.small;
       unify_wsd.WsdAlertSize.small;
+      unify_wsd.WsdLinkButtonSize.small;
+      unify_wsd.WsdLinkButtonType.submit;
       unify_wsd.WsdAlertSeverity.error;
       unify_wsd.WsdAlertColor.warning;
       unify_wsd.WsdAlertVariant.outlined;
+      unify_wsd.WsdLinkButtonSize.xxsmall;
       // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, update this to `Alert` from `unify_ui/components/alert.dart`, manually QA this component, and remove this FIXME; otherwise, remove this FIXME.
       unify_wsd.WsdAlert()();
       // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, update this to `Alert` from `unify_ui/components/alert.dart`, manually QA this component, and remove this FIXME; otherwise, remove this FIXME.

--- a/test/unify_package_rename_suggestors/unify_rename_suggestor_test.dart
+++ b/test/unify_package_rename_suggestors/unify_rename_suggestor_test.dart
@@ -31,10 +31,9 @@ void main() {
       resolvedContext: resolvedContext,
     );
 
-    test('does not update namespaces',
-          () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
+    test('does not update namespaces', () async {
+      await testSuggestor(
+        input: /*language=dart*/ '''
     import 'package:react_material_ui/react_material_ui.dart' as mui;
     import 'package:react_material_ui/react_material_ui.dart' as abc;
     import 'package:react_material_ui/styles/color_utils.dart' as mui;
@@ -49,7 +48,7 @@ void main() {
       abc.Button()();
     }
 ''',
-        );
+      );
     });
 
     group('renames', () {
@@ -255,5 +254,6 @@ void main() {
         );
       });
     });
-  });
+    // Run in private Skynet unit tests with wsd-related tests.
+  }, tags: 'wsd');
 }

--- a/test/unify_package_rename_suggestors/unify_rename_suggestor_test.dart
+++ b/test/unify_package_rename_suggestors/unify_rename_suggestor_test.dart
@@ -89,31 +89,32 @@ void main() {
     import 'package:react_material_ui/react_material_ui.dart';
     import 'package:react_material_ui/react_material_ui.dart' as random_rmui_namespace;
     import 'package:react_material_ui/components/providers/workiva_mui_theme_provider.dart';
+    import 'package:unify_ui/components/wsd.dart';
 
     content() {
       // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, update this to `Alert` from `unify_ui/components/alert.dart`, manually QA this component, and remove this FIXME; otherwise, remove this FIXME.
-      unify_wsd.WsdAlert()();
+      WsdAlert()();
       // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, update this to `Alert` from `unify_ui/components/alert.dart`, manually QA this component, and remove this FIXME; otherwise, remove this FIXME.
-      unify_wsd.WsdAlert();
+      WsdAlert();
       // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, update this to `Alert` from `unify_ui/components/alert.dart`, manually QA this component, and remove this FIXME; otherwise, remove this FIXME.
-      unify_wsd.WsdAlert;
+      WsdAlert;
       // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, update this to `AlertPropsMixin` from `unify_ui/components/alert.dart`, manually QA this component, and remove this FIXME; otherwise, remove this FIXME.
-      unify_wsd.WsdAlertPropsMixin;
-      unify_wsd.WsdAlertSize.small;
-      unify_wsd.WsdAlertSize.small;
-      unify_wsd.WsdLinkButtonSize.small;
-      unify_wsd.WsdLinkButtonType.submit;
-      unify_wsd.WsdAlertSeverity.error;
-      unify_wsd.WsdAlertColor.warning;
-      unify_wsd.WsdAlertVariant.outlined;
-      unify_wsd.WsdLinkButtonSize.xxsmall;
+      WsdAlertPropsMixin;
+      WsdAlertSize.small;
+      WsdAlertSize.small;
+      WsdLinkButtonSize.small;
+      WsdLinkButtonType.submit;
+      WsdAlertSeverity.error;
+      WsdAlertColor.warning;
+      WsdAlertVariant.outlined;
+      WsdLinkButtonSize.xxsmall;
       // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, update this to `Alert` from `unify_ui/components/alert.dart`, manually QA this component, and remove this FIXME; otherwise, remove this FIXME.
-      unify_wsd.WsdAlert()();
+      WsdAlert()();
       // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, update this to `Alert` from `unify_ui/components/alert.dart`, manually QA this component, and remove this FIXME; otherwise, remove this FIXME.
-      unify_wsd.WsdAlert()();
-      unify_wsd.WsdLinkButton()();
-      unify_wsd.WsdLinkButton()();
-      unify_wsd.WsdLinkButton()();
+      WsdAlert()();
+      WsdLinkButton()();
+      WsdLinkButton()();
+      WsdLinkButton()();
       mui.UnifyList()();
       UnifyList()();
       random_rmui_namespace.UnifyList()();
@@ -176,16 +177,17 @@ void main() {
           expectedOutput: /*language=dart*/ '''
     import 'package:react_material_ui/react_material_ui.dart' as mui;
     import 'package:react_material_ui/react_material_ui.dart';
+    import 'package:unify_ui/components/wsd.dart';
     
     content() {
       mui.ButtonColor.success;
-      unify_wsd.WsdButtonColor.wsdBtnInverse;
-      unify_wsd.WsdButtonColor.wsdBtnLight;
-      unify_wsd.WsdButtonColor.wsdBtnWhite;
+      WsdButtonColor.wsdBtnInverse;
+      WsdButtonColor.wsdBtnLight;
+      WsdButtonColor.wsdBtnWhite;
       ButtonColor.success;
-      unify_wsd.WsdButtonColor.wsdBtnInverse;
-      unify_wsd.WsdButtonColor.wsdBtnLight;
-      unify_wsd.WsdButtonColor.wsdBtnWhite;
+      WsdButtonColor.wsdBtnInverse;
+      WsdButtonColor.wsdBtnLight;
+      WsdButtonColor.wsdBtnWhite;
     }
 ''',
         );

--- a/test/unify_package_rename_suggestors/unify_rename_suggestor_test.dart
+++ b/test/unify_package_rename_suggestors/unify_rename_suggestor_test.dart
@@ -87,15 +87,20 @@ void main() {
     import 'package:react_material_ui/components/providers/workiva_mui_theme_provider.dart';
 
     content() {
+      // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, update this to `Alert` from `unify_ui/components/alert.dart`, manually QA this component, and remove this FIXME; otherwise, remove this FIXME.
       unify_wsd.WsdAlert()();
+      // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, update this to `Alert` from `unify_ui/components/alert.dart`, manually QA this component, and remove this FIXME; otherwise, remove this FIXME.
       unify_wsd.WsdAlert();
+      // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, update this to `Alert` from `unify_ui/components/alert.dart`, manually QA this component, and remove this FIXME; otherwise, remove this FIXME.
       unify_wsd.WsdAlert;
       unify_wsd.WsdAlertSize.small;
       unify_wsd.WsdAlertSize.small;
       unify_wsd.WsdAlertSeverity.error;
       unify_wsd.WsdAlertColor.warning;
       unify_wsd.WsdAlertVariant.outlined;
+      // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, update this to `Alert` from `unify_ui/components/alert.dart`, manually QA this component, and remove this FIXME; otherwise, remove this FIXME.
       unify_wsd.WsdAlert()();
+      // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, update this to `Alert` from `unify_ui/components/alert.dart`, manually QA this component, and remove this FIXME; otherwise, remove this FIXME.
       unify_wsd.WsdAlert()();
       unify_wsd.WsdLinkButton()();
       unify_wsd.WsdLinkButton()();
@@ -224,13 +229,13 @@ void main() {
     import 'package:react_material_ui/react_material_ui.dart';
 
     content() {
-      // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, remove this FIXME - no action is required; otherwise, migrate this component back to Web Skin Dart.
+      // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, manually QA this component and remove this FIXME; otherwise, migrate this component back to Web Skin Dart.
       mui.Badge()();
-      // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, remove this FIXME - no action is required; otherwise, migrate this component back to Web Skin Dart.
+      // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, manually QA this component and remove this FIXME; otherwise, migrate this component back to Web Skin Dart.
       Badge()();
-      // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, remove this FIXME - no action is required; otherwise, migrate this component back to Web Skin Dart.
+      // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, manually QA this component and remove this FIXME; otherwise, migrate this component back to Web Skin Dart.
       mui.LinearProgress()();
-      // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, remove this FIXME - no action is required; otherwise, migrate this component back to Web Skin Dart.
+      // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, manually QA this component and remove this FIXME; otherwise, migrate this component back to Web Skin Dart.
       LinearProgress()();
     }
 ''',

--- a/test/unify_package_rename_suggestors/unify_rename_suggestor_test.dart
+++ b/test/unify_package_rename_suggestors/unify_rename_suggestor_test.dart
@@ -31,198 +31,25 @@ void main() {
       resolvedContext: resolvedContext,
     );
 
-    group('namespace on component usage', () {
-      test('mui namespace from react_material_ui is migrated to unify',
+    test('does not update namespaces',
           () async {
         await testSuggestor(
           input: /*language=dart*/ '''
     import 'package:react_material_ui/react_material_ui.dart' as mui;
+    import 'package:react_material_ui/react_material_ui.dart' as abc;
     import 'package:react_material_ui/styles/color_utils.dart' as mui;
+    import 'package:react_material_ui/z_alpha_may_break_at_runtime_do_not_release_to_customers.dart' as alpha_mui;
     
     content() {
       mui.Button()();
-      mui.Checkbox()();
       mui.ButtonColor.success;
       mui.useTheme();
       mui.UnifyIcons.expandMore()();
-      mui.Button;
-      mui.Button();
-      mui.darken('abc', 1);
-    }
-''',
-          expectedOutput: /*language=dart*/ '''
-    import 'package:react_material_ui/react_material_ui.dart' as mui;
-    import 'package:react_material_ui/styles/color_utils.dart' as mui;
-    
-    content() {
-      unify.Button()();
-      unify.Checkbox()();
-      unify.ButtonColor.success;
-      unify.useTheme();
-      unify.UnifyIcons.expandMore()();
-      unify.Button;
-      unify.Button();
-      unify.darken('abc', 1);
-    }
-''',
-        );
-      });
-
-      test('alpha namespace from react_material_ui is migrated to unify',
-          () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
-    import 'package:react_material_ui/z_alpha_may_break_at_runtime_do_not_release_to_customers.dart' as alpha_mui;
-    import 'package:react_material_ui/z_alpha_may_break_at_runtime_do_not_release_to_customers.dart' as mui_alpha;
-    
-    content() {
       alpha_mui.Rating()();
-      mui_alpha.Rating()();
-      alpha_mui.TimelinePosition.left;
-      alpha_mui.useGridApiRef();
-      alpha_mui.Popper;
-      alpha_mui.Popper();
-      mui_alpha.TimelinePosition.left;
-      mui_alpha.useGridApiRef();
-      mui_alpha.Popper;
-      mui_alpha.Popper();
-    }
-''',
-          expectedOutput: /*language=dart*/ '''
-    import 'package:react_material_ui/z_alpha_may_break_at_runtime_do_not_release_to_customers.dart' as alpha_mui;
-    import 'package:react_material_ui/z_alpha_may_break_at_runtime_do_not_release_to_customers.dart' as mui_alpha;
-    
-    content() {
-      alpha_unify.Rating()();
-      alpha_unify.Rating()();
-      alpha_unify.TimelinePosition.left;
-      alpha_unify.useGridApiRef();
-      alpha_unify.Popper;
-      alpha_unify.Popper();
-      alpha_unify.TimelinePosition.left;
-      alpha_unify.useGridApiRef();
-      alpha_unify.Popper;
-      alpha_unify.Popper();
-    }
-''',
-        );
-      });
-
-      test('nested component implementations', () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
-    import 'package:react_material_ui/react_material_ui.dart' as mui;
-    import 'package:over_react/over_react.dart';
-    
-    content() {
-      Fragment()(mui.ButtonToolbar()(
-        (mui.Button()..color = mui.ButtonColor.wsdBtnLight)('Foo'),
-        (mui.Button()
-          ..size = mui.ButtonSize.small
-          ..color = mui.ButtonColor.primary
-        )(
-          'Bar',
-        ),
-      ));
-      
-      return (mui.Autocomplete()
-        ..componentsProps = {
-          'popper': mui.Popper()..placement = 'top-end',
-          'popupIndicator': mui.IconButton()..sx = {'width': '20px'},
-        }
-        ..sx = {
-          'color': (mui.Theme theme) =>
-                  mui.getThemePalette(theme).common.white
-        }
-        ..renderInput = mui.wrapRenderInput((textFieldProps) => (mui.TextField()
-          ..addProps(textFieldProps)
-          ..InputLabelProps = (mui.InputLabel()
-            ..shrink = false)
-        )())
-      );
-    }
-''',
-          expectedOutput: /*language=dart*/ '''
-    import 'package:react_material_ui/react_material_ui.dart' as mui;
-    import 'package:over_react/over_react.dart';
-    
-    content() {
-      Fragment()(unify.ButtonToolbar()(
-        (unify.Button()..color = unify_wsd.WsdButtonColor.wsdBtnLight)('Foo'),
-        (unify.Button()
-          ..size = unify.ButtonSize.small
-          ..color = unify.ButtonColor.primary
-        )(
-          'Bar',
-        ),
-      ));
-      
-      return (unify.Autocomplete()
-        ..componentsProps = {
-          'popper': unify.Popper()..placement = 'top-end',
-          'popupIndicator': unify.IconButton()..sx = {'width': '20px'},
-        }
-        ..sx = {
-          'color': (unify.Theme theme) =>
-                  unify.getThemePalette(theme).common.white
-        }
-        ..renderInput = unify.wrapRenderInput((textFieldProps) => (unify.TextField()
-          ..addProps(textFieldProps)
-          ..InputLabelProps = (unify.InputLabel()
-            ..shrink = false)
-        )())
-      );
-    }
-''',
-        );
-      });
-
-      test('mui namespace from a different package is not migrated', () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
-    import 'package:over_react/over_react.dart' as mui;
-    import 'package:over_react/over_react.dart' as alpha_mui;
-    import 'package:over_react/over_react.dart' as mui_alpha;
-    
-    content() {
-      mui.Fragment()();
-      alpha_mui.Fragment()();
-      mui_alpha.Fragment()();
-      mui.useRef();
-    }
-''',
-        );
-      });
-
-      test('non-mui namespace on a react_material_ui import', () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
-    import 'package:react_material_ui/react_material_ui.dart' as abc;
-    import 'package:react_material_ui/z_alpha_may_break_at_runtime_do_not_release_to_customers.dart' as other;
-    import 'package:react_material_ui/z_alpha_may_break_at_runtime_do_not_release_to_customers.dart' as something;
-    
-    content() {
       abc.Button()();
-      abc.Checkbox()();
-      other.Rating;
-      something.Rating();
     }
 ''',
         );
-      });
-
-      test('no namespace on a react_material_ui import', () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
-    import 'package:react_material_ui/react_material_ui.dart';
-    
-    content() {
-      Button()();
-      Checkbox()();
-    }
-''',
-        );
-      });
     });
 
     group('renames', () {
@@ -274,7 +101,7 @@ void main() {
       unify_wsd.WsdLinkButton()();
       unify_wsd.WsdLinkButton()();
       unify_wsd.WsdLinkButton()();
-      unify.UnifyList()();
+      mui.UnifyList()();
       UnifyList()();
       random_rmui_namespace.UnifyList()();
       UnifyThemeProvider()();
@@ -305,8 +132,8 @@ void main() {
     import 'package:react_material_ui/react_material_ui.dart' as random_rmui_namespace;
     
     content() {
-      unify.AutocompleteChangeDetails;
-      unify.AutocompleteChangeDetails();
+      mui.AutocompleteChangeDetails;
+      mui.AutocompleteChangeDetails();
       random_rmui_namespace.BackdropObject;
       BadgeOriginHorizontal;
       MenuPopoverOrigin();
@@ -338,7 +165,7 @@ void main() {
     import 'package:react_material_ui/react_material_ui.dart';
     
     content() {
-      unify.ButtonColor.success;
+      mui.ButtonColor.success;
       unify_wsd.WsdButtonColor.wsdBtnInverse;
       unify_wsd.WsdButtonColor.wsdBtnLight;
       unify_wsd.WsdButtonColor.wsdBtnWhite;
@@ -399,11 +226,11 @@ void main() {
 
     content() {
       // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, remove this FIXME - no action is required; otherwise, migrate this component back to Web Skin Dart.
-      unify.Badge()();
+      mui.Badge()();
       // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, remove this FIXME - no action is required; otherwise, migrate this component back to Web Skin Dart.
       Badge()();
       // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, remove this FIXME - no action is required; otherwise, migrate this component back to Web Skin Dart.
-      unify.LinearProgress()();
+      mui.LinearProgress()();
       // FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, remove this FIXME - no action is required; otherwise, migrate this component back to Web Skin Dart.
       LinearProgress()();
     }
@@ -428,6 +255,5 @@ void main() {
         );
       });
     });
-    // Run in private Skynet unit tests with wsd-related tests.
-  }, tags: 'wsd');
+  });
 }


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Make some last updates to prep the rename codemod for the sourcegraph batch
## Changes
  <!-- What this PR changes to fix the problem. -->
- Update the codemod to:
  - no longer make changes to import namespaces
  - update `data_grid_premium.dart` entrypoint which is different on `unify_ui`
  - update / add fixme comments to make sure everything that needs to be manually QAed has a comment saying so
  - add `LinkButton` constants to list to be updated
- Update tests
#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Frameworks Design team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-ui-platform Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
      - [ ] Run updated tests locally since they aren't run in CI
      - [ ] CI passes
      - [ ] Run the codemod on another repo (there are a few edge cases that the codemod won't cover that we'll just have to update on a case-by-case basis)
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Frameworks Design member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/over_react_codemod/blob/master/CONTRIBUTING.md#manual-testing-criteria
