### PR TITLE
Raise the meta dependency min to v1.16.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   glob: ^2.0.1
   json_annotation: ^4.8.0
   logging: ^1.0.1
-  meta: '>=1.7.0 <2.0.0'
+  meta: ^1.16.0
   package_config: ^2.1.0
   path: ^1.8.0
   pub_semver: ^2.0.0

--- a/test/test_fixtures/required_props/test_package/pubspec.yaml
+++ b/test/test_fixtures/required_props/test_package/pubspec.yaml
@@ -2,5 +2,5 @@ name: test_package
 environment:
   sdk: '>=2.11.0 <3.0.0'
 dependencies:
-  meta: ^1.3.0
+  meta: ^1.16.0
   over_react: ^5.0.0


### PR DESCRIPTION
This PR raises the min version of meta to 1.16.0. Passing CI
should be sufficient for QA, so feel free to review and merge this once CI completes.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/meta_raise_min_v1_16_0_really`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/meta_raise_min_v1_16_0_really)