### PR TITLE
Raise the uuid dependency min to v4.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,7 +39,7 @@ dev_dependencies:
   json_serializable: ^6.5.3
   test: ^1.17.10
   test_descriptor: ^2.0.0
-  uuid: '>=3.0.5 <5.0.0'
+  uuid: ^4.0.0
   workiva_analysis_options: ^1.2.2
 
 executables:


### PR DESCRIPTION
This PR raises the min version of uuid to 4.0.0. Passing CI
should be sufficient for QA, so feel free to review and merge this once CI completes.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/uuid_raise_min_v4_0_0`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/uuid_raise_min_v4_0_0)