### PR TITLE
Allow consumption of web_skin_dart 3.0.0

### DIFF
--- a/test/test_fixtures/wsd_project/pubspec.yaml
+++ b/test/test_fixtures/wsd_project/pubspec.yaml
@@ -7,4 +7,4 @@ dependencies:
     hosted:
       name: web_skin_dart
       url: https://pub.workiva.org
-    version: ^2.56.0
+    version: '>=2.56.0 <4.0.0'


### PR DESCRIPTION
This PR widens the allowable version range of web_skin_dart so that all Dart repos at Workiva 
can consume version 3.0.0 without updating all repositories in lock step.

This major version removes the "v1" UI components that were deprecated over 4 years ago. 

**Since over_react_codemod 
[no longer has any usages of these deprecated components / entrypoints](https://workiva.sourcegraphcloud.com/search?q=context%3Adart-prod+web_skin_dart%5C%2F%28ui_compo%7Cdnd%7Cshared%7Ctoolbars%7Cforms%7Clayout%29&patternType=regexp&case=yes&sm=0&df=%5B%22repo%22%2C%22github.com%2FWorkiva%2Fover_react_codemod%22%2C%22repo%3A%5Egithub%5C%5C.com%2FWorkiva%2Fover_react_codemod%24%22%5D) 
it is safe to allow consumption of the web_skin_dart release that removed them (3.0.0).**

**These changes can be merged without approval from a FED team member.**

---

For more information about these changes, reach out to the FED team in [#support-ui-platform](https://workiva.enterprise.slack.com/archives/CEFTMBPAA) with any specific questions or concerns.

[_Created by Sourcegraph batch change `Workiva/web_skin_dart-3.0_raise-upper`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/web_skin_dart-3.0_raise-upper)