### PR TITLE
Raise the web_skin_dart dependency min to v3.0.0

### DIFF
--- a/test/test_fixtures/wsd_project/pubspec.yaml
+++ b/test/test_fixtures/wsd_project/pubspec.yaml
@@ -7,4 +7,4 @@ dependencies:
     hosted:
       name: web_skin_dart
       url: https://pub.workiva.org
-    version: '>=2.56.0 <4.0.0'
+    version: ^3.0.0


### PR DESCRIPTION
This PR raises the min version of web_skin_dart to 3.0.0. Passing CI
should be sufficient for QA, so feel free to review and merge this once CI completes.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/web_skin_dart_raise_min_v3_0_0`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/web_skin_dart_raise_min_v3_0_0)