### PR TITLE
TEST: Running tests on React 18

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,3 +55,17 @@ executables:
   intl_message_migration:
   sort_intl:
   unify_package_rename:
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,13 +59,13 @@ executables:
 dependency_overrides:
   react:
     git:
-      url: https://github.com/Workiva/react-dart.git
+      url: git@github.com:Workiva/react-dart.git
       ref: react-18-2-0-testing
   react_testing_library:
     git:
-      url: https://github.com/Workiva/react_testing_library.git
+      url: git@github.com:Workiva/react_testing_library.git
       ref: r18
   dart_dev_workiva:
     git:
-      url: https://github.com/Workiva/dart_dev_workiva.git
+      url: git@github.com:Workiva/dart_dev_workiva.git
       ref: override-react-js-files-for-r18

--- a/test/test_fixtures/over_react_null_safe_project/pubspec.yaml
+++ b/test/test_fixtures/over_react_null_safe_project/pubspec.yaml
@@ -3,3 +3,17 @@ environment:
   sdk: '>=2.19.0 <3.0.0'
 dependencies:
   over_react: ^5.0.0
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18

--- a/test/test_fixtures/over_react_project/pubspec.yaml
+++ b/test/test_fixtures/over_react_project/pubspec.yaml
@@ -3,3 +3,17 @@ environment:
   sdk: '>=2.11.0 <3.0.0'
 dependencies:
   over_react: ^5.0.0
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18

--- a/test/test_fixtures/required_props/test_consuming_package/pubspec.yaml
+++ b/test/test_fixtures/required_props/test_consuming_package/pubspec.yaml
@@ -5,3 +5,17 @@ dependencies:
   over_react: ^5.0.0
   test_package:
     path: ../test_package
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18

--- a/test/test_fixtures/required_props/test_package/pubspec.yaml
+++ b/test/test_fixtures/required_props/test_package/pubspec.yaml
@@ -4,3 +4,17 @@ environment:
 dependencies:
   meta: ^1.16.0
   over_react: ^5.0.0
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18

--- a/test/test_fixtures/rmui_project/pubspec.yaml
+++ b/test/test_fixtures/rmui_project/pubspec.yaml
@@ -8,3 +8,17 @@ dependencies:
       name: react_material_ui
       url: https://pub.workiva.org
     version: ^1.214.2
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18

--- a/test/test_fixtures/wsd_project/pubspec.yaml
+++ b/test/test_fixtures/wsd_project/pubspec.yaml
@@ -8,3 +8,17 @@ dependencies:
       name: web_skin_dart
       url: https://pub.workiva.org
     version: ^3.0.0
+
+dependency_overrides:
+  react:
+    git:
+      url: https://github.com/Workiva/react-dart.git
+      ref: react-18-2-0-testing
+  react_testing_library:
+    git:
+      url: https://github.com/Workiva/react_testing_library.git
+      ref: r18
+  dart_dev_workiva:
+    git:
+      url: https://github.com/Workiva/dart_dev_workiva.git
+      ref: override-react-js-files-for-r18


### PR DESCRIPTION
DO NOT MERGE. No action needed. This PR adds dependency overrides to https://github.com/Workiva/react-dart/pull/416
in order to test all consumers before rolling out React 18 in all repos.
For more info, see [our Wiki page with the rollout plan](https://wiki.atl.workiva.net/spaces/FEF/pages/405122049/React+18+Upgrade) and reach out to `#support-ui-platform` on Slack with any questions.

[_Created by Sourcegraph batch change `Workiva/react_18_test`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/react_18_test)