### PR TITLE
RM-302045 Release over_react_codemod 2.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.37.0
+- React 18 rollout codemod: `react_18_upgrade` to update React JS file paths from the React 17 to React 18 versions.
+- Raise other dependency minimums: `uuid`, `web_skin_dart`
+
+## 2.36.0
+- Raise min Dart sdk to 2.19.0
+- Raise other dependency minimums: `meta`
+
 ## 2.35.0
 - Updates to `unify_package_rename` codemod in preparation for migration
   - No longer update import namespaces

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: over_react_codemod
-version: 2.36.0
+version: 2.37.0
 homepage: https://github.com/Workiva/over_react_codemod
 
 description: >


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Raise the uuid dependency max to v5.0.0](https://github.com/Workiva/over_react_codemod/pull/313)
	* [Raise the uuid dependency min to v4.0.0](https://github.com/Workiva/over_react_codemod/pull/314)
	* [Allow consumption of web_skin_dart 3.0.0](https://github.com/Workiva/over_react_codemod/pull/315)
	* [Raise the web_skin_dart dependency min to v3.0.0](https://github.com/Workiva/over_react_codemod/pull/316)
	* [FED-3903 React 18 Upgrade Codemod](https://github.com/Workiva/over_react_codemod/pull/319)


Requested by: @sydneyjodon-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/over_react_codemod/compare/2.36.0...Workiva:release_over_react_codemod_2.37.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/over_react_codemod/compare/2.36.0...2.37.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6153708125028352/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6153708125028352/?repo_name=Workiva%2Fover_react_codemod&pull_number=320)