### PR TITLE
No-op: verify CI on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.38.0
 - Add mui_system_props_migration codemod to migrate from system props to sx
+<!-- no-op: CI check -->
 
 ## 2.37.1
 - Use gha-dart-oss


### PR DESCRIPTION
## Summary

- Trivial no-op comment added to CHANGELOG.md to verify that CI is green on master.

## Test plan

- [ ] All CI checks pass on master

🤖 Generated with [Claude Code](https://claude.com/claude-code)