### PR TITLE
FEDX-6626 : Run dart format and re-enable format check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
     uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.12
     with:
       sdk: 3.12.2
-      format-check: false
       additional-checks: |
         no_entrypoint_imports
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 - Upgrade to Dart 3 SDK (`>=3.12.0 <4.0.0`)
 - Remove `null_safety_required_props` codemod and related fixtures (null-safety migration tooling no longer needed under Dart 3)
+- Run `dart format` and re-enable format check in CI
 
 ## 2.38.0
 - Add mui_system_props_migration codemod to migrate from system props to sx

--- a/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
+++ b/lib/src/boilerplate_suggestors/boilerplate_utilities.dart
@@ -19,8 +19,8 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:logging/logging.dart';
 import 'package:over_react_codemod/src/util.dart';
 
-typedef YieldPatch = void Function(String replacement, int startingOffset,
-    [int? endingOffset]);
+typedef YieldPatch =
+    void Function(String replacement, int startingOffset, [int? endingOffset]);
 
 const semverReportNotAvailable =
     'Semver report not available; this class is assumed to be public and thus will not be updated.';
@@ -36,8 +36,10 @@ final logger = Logger('over_react_codemod.boilerplate_upgrade.semver_helper');
 /// If [shouldTreatAllComponentsAsPrivate] is true, the returned [SemverHelper]
 /// assumes all classes passed to [getPublicExportLocations] are private
 /// (see: [SemverHelper.alwaysPrivate] constructor).
-SemverHelper getSemverHelper(String path,
-    {bool shouldTreatAllComponentsAsPrivate = false}) {
+SemverHelper getSemverHelper(
+  String path, {
+  bool shouldTreatAllComponentsAsPrivate = false,
+}) {
   if (shouldTreatAllComponentsAsPrivate) {
     return SemverHelper.alwaysPrivate();
   } else {
@@ -75,11 +77,7 @@ SemverHelper getSemverHelper(String path,
 }
 
 /// Returns whether or not [node] is publicly exported.
-bool isPublic(
-  ClassDeclaration node,
-  SemverHelper semverHelper,
-  String path,
-) {
+bool isPublic(ClassDeclaration node, SemverHelper semverHelper, String path) {
   return semverHelper.getPublicExportLocations(node, path).isNotEmpty;
 }
 
@@ -94,23 +92,18 @@ class SemverHelper {
 
   /// Used to ensure [getPublicExportLocations] always returns an empty list,
   /// treating all components as private.
-  SemverHelper.alwaysPrivate()
-      : _exportList = null,
-        _isAlwaysPrivate = true;
+  SemverHelper.alwaysPrivate() : _exportList = null, _isAlwaysPrivate = true;
 
   /// Used to ensure [getPublicExportLocations] always returns a non-empty list,
   /// treating all components as public.
   SemverHelper.alwaysPublic(this.warning)
-      : _exportList = null,
-        _isAlwaysPrivate = false;
+    : _exportList = null,
+      _isAlwaysPrivate = false;
 
   /// Returns a list of locations where [node] is publicly exported.
   ///
   /// If [node] is not publicly exported, returns an empty list.
-  List<String> getPublicExportLocations(
-    ClassDeclaration node,
-    String path,
-  ) {
+  List<String> getPublicExportLocations(ClassDeclaration node, String path) {
     final className = stripPrivateGeneratedPrefix(node.name.lexeme);
 
     if (!path.startsWith('lib/')) {

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -67,10 +67,7 @@ const List<String> overReactPropsStateNonMixinAnnotationNames = [
 ];
 
 /// Annotation names for over_react's props and state mixins.
-const List<String> overReactMixinAnnotationNames = [
-  'PropsMixin',
-  'StateMixin',
-];
+const List<String> overReactMixinAnnotationNames = ['PropsMixin', 'StateMixin'];
 
 /// A list of the names of the core component classes that can be upgraded to a "v2" version.
 const List<String> upgradableV1ComponentClassNames = [
@@ -101,16 +98,14 @@ const String stateMetaType = 'StateMeta';
 const String temporaryCompanionClassComment =
     'This will be removed once the transition to Dart 2 is complete.';
 
-RegExp getDependencyRegExp(String packageName) => RegExp(
-      packageName + r''':\s*(["']?)(.+)\1\s*$''',
-      multiLine: true,
-    );
+RegExp getDependencyRegExp(String packageName) =>
+    RegExp(packageName + r''':\s*(["']?)(.+)\1\s*$''', multiLine: true);
 
 RegExp getHostedDependencyRegExp(String packageName) => RegExp(
-      packageName +
-          r''':\n\s+hosted:\n\s+name:.*\n\s+url:.*\n\s+version:\s*(["']?)(.+)\1\s*$''',
-      multiLine: true,
-    );
+  packageName +
+      r''':\n\s+hosted:\n\s+name:.*\n\s+url:.*\n\s+version:\s*(["']?)(.+)\1\s*$''',
+  multiLine: true,
+);
 
 /// Regex to find a react dependency.
 final RegExp reactDependencyRegExp = getDependencyRegExp('react');
@@ -119,10 +114,7 @@ final RegExp reactDependencyRegExp = getDependencyRegExp('react');
 final RegExp overReactDependencyRegExp = getDependencyRegExp('over_react');
 
 /// Regex to find the dependency pubspec.yaml key.
-final RegExp dependencyRegExp = RegExp(
-  r'^dependencies:\s*$',
-  multiLine: true,
-);
+final RegExp dependencyRegExp = RegExp(r'^dependencies:\s*$', multiLine: true);
 
 /// Regex to find the dependency pubspec.yaml key.
 final RegExp devDependencyRegExp = RegExp(

--- a/lib/src/creator_utils.dart
+++ b/lib/src/creator_utils.dart
@@ -8,13 +8,15 @@ class DartTempProjectCreator {
   late List<PubspecCreator> pubspecCreators;
   late String mainDartContents;
 
-  DartTempProjectCreator(
-      {PubspecCreator? pubspecCreator,
-      List<PubspecCreator>? pubspecCreators,
-      String? mainDartContents}) {
+  DartTempProjectCreator({
+    PubspecCreator? pubspecCreator,
+    List<PubspecCreator>? pubspecCreators,
+    String? mainDartContents,
+  }) {
     if (pubspecCreator != null && pubspecCreators != null) {
       throw ArgumentError(
-          'Cannot specify both pubspecCreator and pubspecCreators');
+        'Cannot specify both pubspecCreator and pubspecCreators',
+      );
     }
 
     this.pubspecCreators =
@@ -24,8 +26,9 @@ class DartTempProjectCreator {
     for (var pubspecCreator in pubspecCreators!) {
       pubspecCreator.create(dir.path);
     }
-    File(p.join(dir.path, 'main.dart'))
-        .writeAsStringSync(this.mainDartContents);
+    File(
+      p.join(dir.path, 'main.dart'),
+    ).writeAsStringSync(this.mainDartContents);
   }
 }
 
@@ -37,13 +40,14 @@ class PubspecCreator {
   final List<DependencyCreator> dependencies;
   final String path;
 
-  PubspecCreator(
-      {this.name = 'fake_package',
-      this.version = '0.0.0',
-      this.isPrivate = true,
-      this.sdkVersion = '">=2.4.0 <3.0.0"',
-      this.dependencies = const [],
-      this.path = ''});
+  PubspecCreator({
+    this.name = 'fake_package',
+    this.version = '0.0.0',
+    this.isPrivate = true,
+    this.sdkVersion = '">=2.4.0 <3.0.0"',
+    this.dependencies = const [],
+    this.path = '',
+  });
 
   void create(String rootDir) {
     final parentDir = p.join(rootDir, path);
@@ -59,10 +63,12 @@ class PubspecCreator {
     dependencies.addAll(new_dependencies);
   }
 
-  void addDependency(String name,
-      {String version = 'any',
-      bool asDev = false,
-      bool Function()? shouldAdd}) {
+  void addDependency(
+    String name, {
+    String version = 'any',
+    bool asDev = false,
+    bool Function()? shouldAdd,
+  }) {
     if (shouldAdd?.call() ?? true) {
       dependencies.add(DependencyCreator(name, version: version, asDev: asDev));
     }
@@ -81,17 +87,17 @@ class PubspecCreator {
         '  sdk: $sdkVersion\n' +
         (dependencies.isNotEmpty
             ? '\ndependencies: \n' +
-                dependencies
-                    .where((dep) => !(dep.asDev || dep.asOverride))
-                    .join('\n')
+                  dependencies
+                      .where((dep) => !(dep.asDev || dep.asOverride))
+                      .join('\n')
             : '') +
         (dependencies.any((dep) => dep.asDev)
             ? '\ndev_dependencies: \n' +
-                dependencies.where((dep) => dep.asDev).join('\n')
+                  dependencies.where((dep) => dep.asDev).join('\n')
             : '') +
         (dependencies.any((dep) => dep.asOverride)
             ? '\ndependency_overrides: \n' +
-                dependencies.where((dep) => dep.asOverride).join('\n')
+                  dependencies.where((dep) => dep.asOverride).join('\n')
             : '') +
         '\n';
   }
@@ -117,12 +123,14 @@ class DependencyCreator {
   }) : version = _versionWithQuotes(version) {
     if (pathOverride.isNotEmpty && gitOverride.isNotEmpty) {
       throw ArgumentError(
-          'Cannot provide both git and path overrides on single dep.');
+        'Cannot provide both git and path overrides on single dep.',
+      );
     }
   }
 
   factory DependencyCreator.fromOverrideConfig(
-      DependencyOverrideConfig config) {
+    DependencyOverrideConfig config,
+  ) {
     switch (config.type) {
       case ConfigType.simple:
         return DependencyCreator(
@@ -195,11 +203,12 @@ class DartProjectCreatorTestConfig {
     this.mainDartContents,
     List<PubspecCreator>? pubspecCreators,
     this.shouldRunCodemod = false,
-  })  : _testName = testName,
-        expectedExitCode = expectedExitCode ?? (shouldRunCodemod ? 1 : 0) {
+  }) : _testName = testName,
+       expectedExitCode = expectedExitCode ?? (shouldRunCodemod ? 1 : 0) {
     if (pubspecCreators != null && dependencies != null) {
       throw ArgumentError(
-          'Cannot specify both pubspecCreators and dependencies');
+        'Cannot specify both pubspecCreators and dependencies',
+      );
     }
     this.pubspecCreators =
         pubspecCreators ?? [PubspecCreator(dependencies: dependencies ?? [])];
@@ -212,19 +221,23 @@ class DartProjectCreatorTestConfig {
     if (pubspecCreators.isEmpty) {
       name += 'no pubspecs';
     } else {
-      name += pubspecCreators.map((creator) {
-        // Make it so that test names aren't multiline, trim/consolidate whitespace.
-        final humanReadableDependencies = creator.dependencies
-            .map((dep) => dep
-                .toString()
-                .trim()
-                .replaceAll('\n', '\\n')
-                .replaceAll(RegExp(r' +'), ' '))
-            .toList();
-        return 'pubspec'
-            ' at ${creator.path.isEmpty ? 'root' : 'path ${creator.path}/pubspec.yaml'}'
-            ' with dependencies: ${humanReadableDependencies}';
-      }).join(', ');
+      name += pubspecCreators
+          .map((creator) {
+            // Make it so that test names aren't multiline, trim/consolidate whitespace.
+            final humanReadableDependencies = creator.dependencies
+                .map(
+                  (dep) => dep
+                      .toString()
+                      .trim()
+                      .replaceAll('\n', '\\n')
+                      .replaceAll(RegExp(r' +'), ' '),
+                )
+                .toList();
+            return 'pubspec'
+                ' at ${creator.path.isEmpty ? 'root' : 'path ${creator.path}/pubspec.yaml'}'
+                ' with dependencies: ${humanReadableDependencies}';
+          })
+          .join(', ');
     }
     return name;
   }

--- a/lib/src/dart2_9_suggestors/dart2_9_utilities.dart
+++ b/lib/src/dart2_9_suggestors/dart2_9_utilities.dart
@@ -66,8 +66,9 @@ SimpleIdentifier? getGeneratedFactory(TopLevelVariableDeclaration node) {
       final generatedName = r'_$' + name;
       if (initializer is SimpleIdentifier && initializer.name == generatedName)
         return initializer;
-      return allDescendantsOfType<SimpleIdentifier>(initializer)
-          .firstWhereOrNull((identifier) => identifier.name == generatedName);
+      return allDescendantsOfType<SimpleIdentifier>(
+        initializer,
+      ).firstWhereOrNull((identifier) => identifier.name == generatedName);
     }
   }
 
@@ -80,8 +81,9 @@ bool isClassOrConnectedComponentFactory(TopLevelVariableDeclaration node) =>
 
 /// Returns whether or not [node] is in the legacy boilerplate syntax.
 bool isLegacyFactoryDecl(TopLevelVariableDeclaration node) {
-  final annotation = node.metadata
-      .firstWhereOrNull((m) => m.toSource().startsWith('@Factory'));
+  final annotation = node.metadata.firstWhereOrNull(
+    (m) => m.toSource().startsWith('@Factory'),
+  );
   return isClassOrConnectedComponentFactory(node) && annotation != null;
 }
 
@@ -110,14 +112,18 @@ bool isLegacyFactoryDecl(TopLevelVariableDeclaration node) {
 ///
 ///   `// ignore: invalid_assignment` => `// ignore: invalid_assignment`
 void removeIgnoreComment(
-    Token? comment, String ignoreToRemove, YieldPatch yieldPatch) {
+  Token? comment,
+  String ignoreToRemove,
+  YieldPatch yieldPatch,
+) {
   ArgumentError.checkNotNull(ignoreToRemove, 'ignoreToRemove');
   if (comment == null) return;
 
   final lexeme = comment.lexeme.replaceAll(' ', '').toLowerCase();
   if (lexeme.startsWith('//ignore:')) {
-    final ignoreList =
-        lexeme.replaceFirst(RegExp('\/\/ignore\:'), '').split(',');
+    final ignoreList = lexeme
+        .replaceFirst(RegExp('\/\/ignore\:'), '')
+        .split(',');
     if (ignoreList.contains(ignoreToRemove) && ignoreList.length == 1) {
       yieldPatch('', comment.previous?.end ?? comment.offset, comment.end);
     } else if (ignoreList.contains(ignoreToRemove)) {

--- a/lib/src/dart2_9_suggestors/factory_and_config_ignore_comment_remover.dart
+++ b/lib/src/dart2_9_suggestors/factory_and_config_ignore_comment_remover.dart
@@ -56,7 +56,10 @@ class FactoryAndConfigIgnoreCommentRemover extends RecursiveAstVisitor
       }
 
       removeIgnoreComment(
-          node.beginToken.precedingComments, ignoreToRemove, yieldPatch);
+        node.beginToken.precedingComments,
+        ignoreToRemove,
+        yieldPatch,
+      );
     }
   }
 
@@ -64,15 +67,16 @@ class FactoryAndConfigIgnoreCommentRemover extends RecursiveAstVisitor
   bool shouldSkip(FileContext context) => hasParseErrors(context.sourceText);
 
   Iterable<Token> _findPossibleIgnoreComments(
-      SimpleIdentifier generatedFactoryNode) sync* {
+    SimpleIdentifier generatedFactoryNode,
+  ) sync* {
     final lineNumber = context.sourceFile.getLine(generatedFactoryNode.offset);
     for (var comment in allComments(generatedFactoryNode.root.beginToken)) {
       final commentLineNumber = context.sourceFile.getLine(comment.offset);
       final commentAppliesToNode =
           // EOL comments
           commentLineNumber == lineNumber ||
-              // Comments on the previous line
-              commentLineNumber == lineNumber - 1;
+          // Comments on the previous line
+          commentLineNumber == lineNumber - 1;
       if (commentAppliesToNode) {
         yield comment;
       }

--- a/lib/src/dart2_9_suggestors/generated_factory_migrator.dart
+++ b/lib/src/dart2_9_suggestors/generated_factory_migrator.dart
@@ -38,8 +38,11 @@ class GeneratedFactoryMigrator extends RecursiveAstVisitor
         return;
       }
 
-      yieldPatch('$castFunctionName(', generatedFactory!.offset,
-          generatedFactory.offset);
+      yieldPatch(
+        '$castFunctionName(',
+        generatedFactory!.offset,
+        generatedFactory.offset,
+      );
       yieldPatch(')', generatedFactory.end, generatedFactory.end);
     }
   }

--- a/lib/src/dart2_suggestors/orcm_ignore_remover.dart
+++ b/lib/src/dart2_suggestors/orcm_ignore_remover.dart
@@ -19,10 +19,6 @@ final _orcmIgnore = RegExp(r'[\n]?[ ]*//[ ]*orcm_ignore[ ]*');
 /// Suggestor that removes every instance of a `// orcm_ignore` comment.
 Stream<Patch> orcmIgnoreRemover(FileContext context) async* {
   for (final match in _orcmIgnore.allMatches(context.sourceText)) {
-    yield Patch(
-      '',
-      match.start,
-      match.end,
-    );
+    yield Patch('', match.start, match.end);
   }
 }

--- a/lib/src/dart2_suggestors/pubspec_over_react_upgrader.dart
+++ b/lib/src/dart2_suggestors/pubspec_over_react_upgrader.dart
@@ -30,17 +30,18 @@ class PubspecOverReactUpgrader extends PubspecUpgrader {
   /// Version constraint that ensures a version of over_react compatible with
   /// the Dart 2 builder and also opens the range up to over_react 2.x which is
   /// the first release that drops support for Dart 1.
-  static final VersionRange dart2Constraint =
-      parseVersionRange('>=1.30.2 <3.0.0');
+  static final VersionRange dart2Constraint = parseVersionRange(
+    '>=1.30.2 <3.0.0',
+  );
 
   PubspecOverReactUpgrader(
     VersionRange targetConstraint, {
     bool shouldAddDependencies = true,
   }) : super(
-          'over_react',
-          targetConstraint,
-          shouldAddDependencies: shouldAddDependencies,
-        );
+         'over_react',
+         targetConstraint,
+         shouldAddDependencies: shouldAddDependencies,
+       );
 
   /// Constructor used to ignore checks and ensure that the codemod always
   /// tries to update the constraint.
@@ -53,8 +54,8 @@ class PubspecOverReactUpgrader extends PubspecUpgrader {
     VersionRange targetConstraint, {
     bool shouldAddDependencies = true,
   }) : super.alwaysUpdate(
-          'over_react',
-          targetConstraint,
-          shouldAddDependencies: shouldAddDependencies,
-        );
+         'over_react',
+         targetConstraint,
+         shouldAddDependencies: shouldAddDependencies,
+       );
 }

--- a/lib/src/dependency_validator_suggestors/ignore_updaters/v1_updater.dart
+++ b/lib/src/dependency_validator_suggestors/ignore_updaters/v1_updater.dart
@@ -50,23 +50,29 @@ class V1DependencyValidatorUpdater {
       final ignoreArgMatches = ignoreArgPattern.allMatches(allArgs);
 
       if (ignoreArgMatches.length > 1) {
-        final lineStart = context.sourceFile
-            .getOffset(context.sourceFile.getLine(match.start));
-        patches.add(Patch(
+        final lineStart = context.sourceFile.getOffset(
+          context.sourceFile.getLine(match.start),
+        );
+        patches.add(
+          Patch(
             '//FIXME: unexpected outcome; there should only be one ignore argument\n',
             lineStart,
-            lineStart));
+            lineStart,
+          ),
+        );
         return;
       } else if (ignoreArgMatches.length == 1) {
         var ignoreArgMatch = ignoreArgMatches.first.group(1);
 
         if (ignoreArgMatch == null) {
           throw StateError(
-              'Expected a regex matching group when parsing $allArgs');
+            'Expected a regex matching group when parsing $allArgs',
+          );
         }
 
-        final dependenciesListOffset =
-            ignoreArgMatches.first.group(0)!.indexOf(ignoreArgMatch);
+        final dependenciesListOffset = ignoreArgMatches.first
+            .group(0)!
+            .indexOf(ignoreArgMatch);
 
         final ignoredPackages = ignoreArgMatch.split(',');
         if (ignoredPackages.contains(dependency)) {
@@ -82,19 +88,26 @@ class V1DependencyValidatorUpdater {
         // commandArgsStart is where the any arguments will start being added to the command
         // ignoreArgMatches.first.start is where (within the command string) the ignore argument starts
         // dependenciesListOffset is to account for the arg flag (-i or --ignore)
-        final startingOffset = commandArgsStart +
+        final startingOffset =
+            commandArgsStart +
             ignoreArgMatches.first.start +
             dependenciesListOffset;
-        patches.add(Patch(ignoreArgMatch, startingOffset,
-            commandArgsStart + ignoreArgMatches.first.end));
+        patches.add(
+          Patch(
+            ignoreArgMatch,
+            startingOffset,
+            commandArgsStart + ignoreArgMatches.first.end,
+          ),
+        );
         return;
       } else {
         // This will inject the ignore arg right after the command itself, rather
         // at the end of existing args, because our regex is greedy and doesn't really
         // know when the command args end. Therefore the safest thing when there is no
         // existing ignore arg is to use the command string as the anchor.
-        patches
-            .add(Patch(' -i $dependency', commandArgsStart, commandArgsStart));
+        patches.add(
+          Patch(' -i $dependency', commandArgsStart, commandArgsStart),
+        );
       }
     });
 

--- a/lib/src/dependency_validator_suggestors/ignore_updaters/v2_updater.dart
+++ b/lib/src/dependency_validator_suggestors/ignore_updaters/v2_updater.dart
@@ -51,8 +51,10 @@ class V2DependencyValidatorUpdater {
     if (currentDependencyValidatorConfig.isNotEmpty) {
       // This case adds to an existing ignore list
       if (currentDependencyValidatorConfig.keys.contains(ignoreKey)) {
-        final ignoreListNode =
-            pubspec.parseAt([dependencyValidatorKey, ignoreKey]);
+        final ignoreListNode = pubspec.parseAt([
+          dependencyValidatorKey,
+          ignoreKey,
+        ]);
         final ignoreList = ignoreListNode.value as YamlList;
 
         if (ignoreList.contains(dependency)) return;
@@ -61,10 +63,7 @@ class V2DependencyValidatorUpdater {
 
         // This case adds to any config that does not have an ignore list
       } else {
-        pubspec.update(
-          [dependencyValidatorKey, ignoreKey],
-          [dependency],
-        );
+        pubspec.update([dependencyValidatorKey, ignoreKey], [dependency]);
         yield Patch(pubspec.toString(), 0);
       }
       // If there is no existing "dependency_validator" tag, `YamlEdit` cannot add one, so
@@ -75,8 +74,9 @@ class V2DependencyValidatorUpdater {
       if (context.sourceFile.length == 0) prependNewLine = false;
 
       yield Patch(
-          '${prependNewLine ? '\n' : ''}$dependencyValidatorKey:\n  $ignoreKey:\n    - $dependency\n',
-          context.sourceFile.length);
+        '${prependNewLine ? '\n' : ''}$dependencyValidatorKey:\n  $ignoreKey:\n    - $dependency\n',
+        context.sourceFile.length,
+      );
     }
   }
 }

--- a/lib/src/executables/dart2_9_upgrade.dart
+++ b/lib/src/executables/dart2_9_upgrade.dart
@@ -41,24 +41,33 @@ const _changesRequiredOutput = """
 
 void main(List<String> args) async {
   final parser = ArgParser()
-    ..addFlag('help',
-        abbr: 'h', negatable: false, help: 'Prints this help output')
-    ..addFlag('verbose',
-        abbr: 'v',
-        negatable: false,
-        help: 'Outputs all logging to stdout/stderr.')
+    ..addFlag(
+      'help',
+      abbr: 'h',
+      negatable: false,
+      help: 'Prints this help output',
+    )
+    ..addFlag(
+      'verbose',
+      abbr: 'v',
+      negatable: false,
+      help: 'Outputs all logging to stdout/stderr.',
+    )
     ..addFlag(
       'yes-to-all',
       negatable: false,
-      help: 'Forces all patches accepted without prompting the user. '
+      help:
+          'Forces all patches accepted without prompting the user. '
           'Useful for scripts.',
     )
     ..addSeparator('Boilerplate Upgrade Options:')
-    ..addFlag(_checkForTransitioning,
-        negatable: false,
-        help:
-            'Checks to see if this repo already has some components using the latest boilerplate and sets'
-            'the codemod to fail on changes.');
+    ..addFlag(
+      _checkForTransitioning,
+      negatable: false,
+      help:
+          'Checks to see if this repo already has some components using the latest boilerplate and sets'
+          'the codemod to fail on changes.',
+    );
 
   final parsedArgs = parser.parse(args);
   final checkForTransitioning = parsedArgs[_checkForTransitioning] ?? false;
@@ -97,28 +106,35 @@ void main(List<String> args) async {
 
     if (!latestBoilerplateVisitor.detectedLatestBoilerplate) {
       logger.info(
-          'Did not detect the latest boilerplate. This repo is not transitioning. Exiting codemod.');
+        'Did not detect the latest boilerplate. This repo is not transitioning. Exiting codemod.',
+      );
       exitCode = 0;
       return;
     } else {
       logger.info(
-          'Detected the latest boilerplate. Continuing codemod and setting --fail-on-changes.');
+        'Detected the latest boilerplate. Continuing codemod and setting --fail-on-changes.',
+      );
       args.add('--fail-on-changes');
     }
   }
 
-  final overReactVersionConstraint =
-      VersionConstraint.parse(overReactVersionRange);
+  final overReactVersionConstraint = VersionConstraint.parse(
+    overReactVersionRange,
+  );
 
   // If we're checking for transitioning and got to the point (i.e. there was
   // new boilerplate), ignore the pubspec.
   if (!checkForTransitioning) {
     exitCode = await runInteractiveCodemod(
       pubspecYamlPaths(),
-      aggregate([
-        PubspecOverReactUpgrader(overReactVersionConstraint as VersionRange,
-            shouldAddDependencies: false),
-      ].map((s) => ignoreable(s))),
+      aggregate(
+        [
+          PubspecOverReactUpgrader(
+            overReactVersionConstraint as VersionRange,
+            shouldAddDependencies: false,
+          ),
+        ].map((s) => ignoreable(s)),
+      ),
       // Only pass valid low level codemod flags
       args: args.where((a) => !a.contains(_checkForTransitioning)),
       defaultYes: true,
@@ -144,14 +160,18 @@ void main(List<String> args) async {
 
   if (checkForTransitioning && exitCode == 1) {
     logger.severe(
-        'This repo is transitioning and has both the new factory syntax and the old.');
+      'This repo is transitioning and has both the new factory syntax and the old.',
+    );
   }
 }
 
 extension on RecursiveAstVisitor {
   /// Iterates over all the files provided and inspects them.
-  void inspectAllPaths(Iterable<String> files,
-      {bool Function()? shortCircuitTest, required Logger logger}) {
+  void inspectAllPaths(
+    Iterable<String> files, {
+    bool Function()? shortCircuitTest,
+    required Logger logger,
+  }) {
     for (final filePath in files) {
       if (shortCircuitTest?.call() ?? false) continue;
 
@@ -182,7 +202,8 @@ extension on RecursiveAstVisitor {
 
       if (shortCircuitTest?.call() ?? false) {
         logger.info(
-            'Inspection complete and will now short circuit after inspecting ${file.path}');
+          'Inspection complete and will now short circuit after inspecting ${file.path}',
+        );
       }
     }
   }

--- a/lib/src/executables/dependency_validator_ignore.dart
+++ b/lib/src/executables/dependency_validator_ignore.dart
@@ -32,23 +32,32 @@ const _dependency = 'dependency';
 /// config.
 void main(List<String> args) async {
   final parser = ArgParser()
-    ..addFlag('help',
-        abbr: 'h', negatable: false, help: 'Prints this help output')
-    ..addFlag('verbose',
-        abbr: 'v',
-        negatable: false,
-        help: 'Outputs all logging to stdout/stderr.')
+    ..addFlag(
+      'help',
+      abbr: 'h',
+      negatable: false,
+      help: 'Prints this help output',
+    )
+    ..addFlag(
+      'verbose',
+      abbr: 'v',
+      negatable: false,
+      help: 'Outputs all logging to stdout/stderr.',
+    )
     ..addFlag(
       'yes-to-all',
       negatable: false,
-      help: 'Forces all patches accepted without prompting the user. '
+      help:
+          'Forces all patches accepted without prompting the user. '
           'Useful for scripts.',
     )
     ..addSeparator('Dependency Validator Updater Options')
-    ..addOption(_dependency,
-        abbr: 'd',
-        mandatory: true,
-        help: 'The dependency that should be ignored.');
+    ..addOption(
+      _dependency,
+      abbr: 'd',
+      mandatory: true,
+      help: 'The dependency that should be ignored.',
+    );
 
   final parsedArgs = parser.parse(args);
 
@@ -83,7 +92,9 @@ void main(List<String> args) async {
     final pubspecFile = File(pubspec);
     final VersionRange? dependencyValidatorVersion =
         getNonHostedDependencyVersion(
-            pubspecFile.readAsStringSync(), 'dependency_validator');
+          pubspecFile.readAsStringSync(),
+          'dependency_validator',
+        );
     final majorVersion = dependencyValidatorVersion?.min?.major;
 
     // This means that either there is no dependency on `dependency_validator`
@@ -100,7 +111,8 @@ void main(List<String> args) async {
     if (exitCode == 1) continue;
 
     logger.info(
-        'Detected dependency_validator version $dependencyValidatorVersion');
+      'Detected dependency_validator version $dependencyValidatorVersion',
+    );
 
     // It is necessary to check the major version and handle each one
     // differently because each major has a different method to identify
@@ -118,8 +130,9 @@ void main(List<String> args) async {
           ],
           V1DependencyValidatorUpdater(dependencyToUpdate),
           // Only pass valid low level codemod flags
-          args: args
-              .where((arg) => !arg.contains(_dependency) && !arg.contains('d')),
+          args: args.where(
+            (arg) => !arg.contains(_dependency) && !arg.contains('d'),
+          ),
         );
         break;
       case 2:
@@ -127,8 +140,9 @@ void main(List<String> args) async {
           [pubspecFile.path],
           V2DependencyValidatorUpdater(dependencyToUpdate),
           // Only pass valid low level codemod flags
-          args: args
-              .where((arg) => !arg.contains(_dependency) && !arg.contains('d')),
+          args: args.where(
+            (arg) => !arg.contains(_dependency) && !arg.contains('d'),
+          ),
         );
         break;
       case 3:
@@ -145,15 +159,18 @@ void main(List<String> args) async {
         }
 
         exitCode = await runInteractiveCodemod(
-          configFiles, V3DependencyValidatorUpdater(dependencyToUpdate),
+          configFiles,
+          V3DependencyValidatorUpdater(dependencyToUpdate),
           // Only pass valid low level codemod flags
-          args: args
-              .where((arg) => !arg.contains(_dependency) && !arg.contains('d')),
+          args: args.where(
+            (arg) => !arg.contains(_dependency) && !arg.contains('d'),
+          ),
         );
         break;
       default:
         throw UnsupportedError(
-            'Unexpected version of dependency_validator detected: $majorVersion');
+          'Unexpected version of dependency_validator detected: $majorVersion',
+        );
     }
   }
 
@@ -165,9 +182,13 @@ void main(List<String> args) async {
 /// NOTE: This logic is not very flexible and doesn't work for hosted dependencies.
 @visibleForTesting
 VersionRange? getNonHostedDependencyVersion(
-    String pubspecContent, String dependency) {
-  final dependencyValidatorRegex =
-      RegExp('^ {2,}$dependency: *(.+)\$', multiLine: true);
+  String pubspecContent,
+  String dependency,
+) {
+  final dependencyValidatorRegex = RegExp(
+    '^ {2,}$dependency: *(.+)\$',
+    multiLine: true,
+  );
   final dependencyMatch = dependencyValidatorRegex.firstMatch(pubspecContent);
   if (dependencyMatch == null) return null;
 

--- a/lib/src/executables/intl_message_migration.dart
+++ b/lib/src/executables/intl_message_migration.dart
@@ -72,13 +72,15 @@ final parser = ArgParser()
   ..addFlag(
     _yesToAllFlag,
     negatable: false,
-    help: 'Forces all patches accepted without prompting the user. '
+    help:
+        'Forces all patches accepted without prompting the user. '
         'Useful for scripts.',
   )
   ..addFlag(
     _failOnChangesFlag,
     negatable: false,
-    help: 'Returns a non-zero exit code if there are changes to be made. '
+    help:
+        'Returns a non-zero exit code if there are changes to be made. '
         'Will not make any changes (i.e. this is a dry-run).',
   )
   ..addFlag(
@@ -93,12 +95,14 @@ final parser = ArgParser()
     help:
         "Try to remove any messages in the generated _intl.dart file that aren't called.",
   )
-  ..addFlag(_noMigrate,
-      negatable: false,
-      defaultsTo: false,
-      help:
-          'Does not run any migrators, overriding any --migrate flags. Can still be used with --prune-unused, and '
-          'will force the messages file to be sorted and rewritten')
+  ..addFlag(
+    _noMigrate,
+    negatable: false,
+    defaultsTo: false,
+    help:
+        'Does not run any migrators, overriding any --migrate flags. Can still be used with --prune-unused, and '
+        'will force the messages file to be sorted and rewritten',
+  )
   ..addFlag(
     _migrateConstants,
     negatable: true,
@@ -163,14 +167,15 @@ void main(List<String> args) async {
   // those, and make sure they're absolute.
   var basicDartPaths = parsedArgs.rest.isEmpty ? ['lib'] : parsedArgs.rest;
   var dartPaths = [
-    for (var path in basicDartPaths) p.canonicalize(p.absolute(path))
+    for (var path in basicDartPaths) p.canonicalize(p.absolute(path)),
   ];
 
   // Work around parts being unresolved if you resolve them before their libraries.
   // TODO - reference analyzer issue for this once it's created
   final packageRoots = dartPaths.map(findPackageRootFor).toSet().toList();
-  packageRoots.sort((packageA, packageB) =>
-      p.split(packageB).length - p.split(packageA).length);
+  packageRoots.sort(
+    (packageA, packageB) => p.split(packageB).length - p.split(packageA).length,
+  );
 
   // TODO: Use packageConfig and utilities for reading that rather than manually parsing pubspec..
   Map<String, String> packageNameLookup = {
@@ -181,7 +186,7 @@ void main(List<String> args) async {
           .firstWhere((line) => line.startsWith('name'))
           .split(':')
           .last
-          .trim()
+          .trim(),
   };
 
   final processedPackages = Set<String>();
@@ -200,28 +205,39 @@ void main(List<String> args) async {
 
   for (String package in packageRoots) {
     await migratePackage(
-        package, packageNameLookup, processedPackages, codemodArgs, dartPaths);
+      package,
+      packageNameLookup,
+      processedPackages,
+      codemodArgs,
+      dartPaths,
+    );
   }
 
   if (exitCode != 0) {
     printInBlue(
-        'To resolve these changes, please execute the codemod locally by running :');
+      'To resolve these changes, please execute the codemod locally by running :',
+    );
     printInBlue('dart pub global activate --overwrite over_react_codemod');
     printInBlue(
-        'dart pub global run over_react_codemod:intl_message_migration');
+      'dart pub global run over_react_codemod:intl_message_migration',
+    );
   }
 }
 
 void printDeprecationNotice() {
   printInRed('***** Deprecation Notice *****');
   printInBlue(
-      '# over_react_codemod:intl_message_migration is deprecated and will no longer receive updates.');
+    '# over_react_codemod:intl_message_migration is deprecated and will no longer receive updates.',
+  );
   stderr.writeln('# Instead, use the dart_dev or intl_tools commands:');
   stderr.writeln('# dart_dev intl <subcommands>');
-  stderr.writeln('# For example:  '
-      'dart_dev intl {check|migrate|sort}');
   stderr.writeln(
-      '# Refer to the documentation https://wiki.atl.workiva.net/display/FEF/Intl+Quick+Reference+Guide of dart_dev / dart_dev_workiva for more information on using intl_codemod with dart_dev.');
+    '# For example:  '
+    'dart_dev intl {check|migrate|sort}',
+  );
+  stderr.writeln(
+    '# Refer to the documentation https://wiki.atl.workiva.net/display/FEF/Intl+Quick+Reference+Guide of dart_dev / dart_dev_workiva for more information on using intl_codemod with dart_dev.',
+  );
 }
 
 void printInBlue(String text) {
@@ -234,7 +250,8 @@ void printInRed(String text) {
 
 void printUsage() {
   stderr.writeln(
-      'Migrates literal strings that seem user-visible in the package by wrapping them in Intl.message calls.');
+    'Migrates literal strings that seem user-visible in the package by wrapping them in Intl.message calls.',
+  );
 
   stderr.writeln('Usage:');
   stderr.writeln('    intl_message_migration [arguments]');
@@ -276,11 +293,12 @@ Future<int> runCodemodSequences(
 ///
 /// We expect [paths] to be absolute.
 Future<void> migratePackage(
-    String package,
-    Map<String, String> packageNameLookup,
-    Set<String> processedPackages,
-    List<String> codemodArgs,
-    List<String> paths) async {
+  String package,
+  Map<String, String> packageNameLookup,
+  Set<String> processedPackages,
+  List<String> codemodArgs,
+  List<String> paths,
+) async {
   _log.info('Starting migration for $package');
 
   final packageRoot = p.basename(package);
@@ -288,8 +306,10 @@ Future<void> migratePackage(
   _log.info('Starting migration for $packageName');
   List<String> packageDartPaths;
   try {
-    packageDartPaths =
-        dartFilesToMigrateForPackage(package, processedPackages).toList();
+    packageDartPaths = dartFilesToMigrateForPackage(
+      package,
+      processedPackages,
+    ).toList();
   } on FileSystemException {
     _log.info('${package} does not have a lib directory, moving on...');
     return;
@@ -298,11 +318,18 @@ Future<void> migratePackage(
   packageDartPaths = limitPaths(packageDartPaths, allowed: paths);
   sortPartsLast(packageDartPaths);
 
-  final IntlMessages messages = IntlMessages(packageName,
-      directory: fs.currentDirectory, packagePath: package);
+  final IntlMessages messages = IntlMessages(
+    packageName,
+    directory: fs.currentDirectory,
+    packagePath: package,
+  );
 
-  exitCode =
-      await runMigrators(packageDartPaths, codemodArgs, messages, packageName);
+  exitCode = await runMigrators(
+    packageDartPaths,
+    codemodArgs,
+    messages,
+    packageName,
+  );
 
   processedPackages.add(package);
 
@@ -310,11 +337,17 @@ Future<void> migratePackage(
   messages.format();
 }
 
-Future<int> runMigrators(List<String> packageDartPaths,
-    List<String> codemodArgs, IntlMessages messages, String packageName) async {
+Future<int> runMigrators(
+  List<String> packageDartPaths,
+  List<String> codemodArgs,
+  IntlMessages messages,
+  String packageName,
+) async {
   final intlPropMigrator = IntlMigrator(messages.className, messages);
-  final constantStringMigrator =
-      ConstantStringMigrator(messages.className, messages);
+  final constantStringMigrator = ConstantStringMigrator(
+    messages.className,
+    messages,
+  );
   final displayNameMigrator = ConfigsMigrator(messages.className, messages);
   final importMigrator = (FileContext context) =>
       intlImporter(context, packageName, messages.className);
@@ -330,11 +363,14 @@ Future<int> runMigrators(List<String> packageDartPaths,
   ];
   List<List<Migrator>> thingsToRun = [
     if (!parsedArgs[_noMigrate]) ...migrators,
-    if (parsedArgs[_pruneUnused]) [usedMethodsChecker]
+    if (parsedArgs[_pruneUnused]) [usedMethodsChecker],
   ];
 
-  var result =
-      await runCodemodSequences(packageDartPaths, thingsToRun, codemodArgs);
+  var result = await runCodemodSequences(
+    packageDartPaths,
+    thingsToRun,
+    codemodArgs,
+  );
   return result;
 }
 
@@ -343,17 +379,18 @@ void sortPartsLast(List<String> dartPaths) {
 
   final isPartCache = <String, bool>{};
   bool isPart(String path) => isPartCache.putIfAbsent(path, () {
-        // parseString is much faster than using an AnalysisContextCollection
-        //  to get unresolved AST, at least in repos with many context roots.
-        final unit = parseString(
-                content: LocalFileSystem().file(path).readAsStringSync())
-            .unit;
-        return unit.directives.whereType<PartOfDirective>().isNotEmpty;
-      });
+    // parseString is much faster than using an AnalysisContextCollection
+    //  to get unresolved AST, at least in repos with many context roots.
+    final unit = parseString(
+      content: LocalFileSystem().file(path).readAsStringSync(),
+    ).unit;
+    return unit.directives.whereType<PartOfDirective>().isNotEmpty;
+  });
 
   if (dartPaths.isNotEmpty && dartPaths.every(isPart)) {
     logShout(
-        'Only part files were specified. The containing library must be included for any part file, as it is needed for analysis context');
+      'Only part files were specified. The containing library must be included for any part file, as it is needed for analysis context',
+    );
     exit(1);
   }
   dartPaths.sort((a, b) {
@@ -376,7 +413,8 @@ void sortDeepestFirst(Set<String> packageRoots) {
 
 Future<void> pubGetForAllPackageRoots(Iterable<String> files) async {
   _log.info(
-      'Running `pub get` if needed so that all Dart files can be resolved...');
+    'Running `pub get` if needed so that all Dart files can be resolved...',
+  );
   final packageRoots = files.map(findPackageRootFor).toSet();
   for (final packageRoot in packageRoots) {
     await runPubGetIfNeeded(packageRoot);
@@ -398,7 +436,9 @@ Iterable<String> dartFilesToMigrate() => Glob('**.dart', recursive: true)
     .map((e) => e.path);
 
 Iterable<String> dartFilesToMigrateForPackage(
-        String package, Set<String> processedPackages) =>
+  String package,
+  Set<String> processedPackages,
+) =>
     // Glob is peculiar about how it wants absolute Windows paths, so just query the
     // file system directly. It wants "posix-style", but no leading slash. So
     // C:/users/user/..., which is ugly to produce.
@@ -420,16 +460,18 @@ Iterable<String> dartFilesToMigrateForPackage(
         .toList();
 
 Iterable<String> experienceConfigDartFiles() => [
-      for (var f in Glob('**.dart', recursive: true).listSync())
-        if (f is File && f.path.contains('_experience_config.dart')) f.path
-    ];
+  for (var f in Glob('**.dart', recursive: true).listSync())
+    if (f is File && f.path.contains('_experience_config.dart')) f.path,
+];
 
 // Limit the paths we handle to those that were included in [paths]
-List<String> limitPaths(List<String> allPaths,
-        {required List<String> allowed}) =>
-    [
-      for (var path in allPaths)
-        if (allowed
-            .any((included) => included == path || p.isWithin(included, path)))
-          path
-    ];
+List<String> limitPaths(
+  List<String> allPaths, {
+  required List<String> allowed,
+}) => [
+  for (var path in allPaths)
+    if (allowed.any(
+      (included) => included == path || p.isWithin(included, path),
+    ))
+      path,
+];

--- a/lib/src/executables/mui_migration.dart
+++ b/lib/src/executables/mui_migration.dart
@@ -65,13 +65,15 @@ void main(List<String> args) async {
     ..addFlag(
       _yesToAllFlag,
       negatable: false,
-      help: 'Forces all patches accepted without prompting the user. '
+      help:
+          'Forces all patches accepted without prompting the user. '
           'Useful for scripts.',
     )
     ..addFlag(
       _failOnChangesFlag,
       negatable: false,
-      help: 'Returns a non-zero exit code if there are changes to be made. '
+      help:
+          'Returns a non-zero exit code if there are changes to be made. '
           'Will not make any changes (i.e. this is a dry-run).',
     )
     ..addFlag(
@@ -83,13 +85,15 @@ void main(List<String> args) async {
     ..addOption(
       _rmuiVersionOption,
       defaultsTo: '1.1.1',
-      help: 'The react_material_ui version to use when adding it as'
+      help:
+          'The react_material_ui version to use when adding it as'
           ' a dependency via a "^" version constraint.',
     )
     ..addMultiOption(
       _componentOption,
       allowed: componentMigratorsByName.keys,
-      help: 'Choose which component migrators should be run. '
+      help:
+          'Choose which component migrators should be run. '
           'If no components are specified, all component migrators will be run.',
     );
 
@@ -97,7 +101,8 @@ void main(List<String> args) async {
 
   if (parsedArgs['help'] as bool) {
     stderr.writeln(
-        'Migrates web_skin_dart component usages to react_material_ui.');
+      'Migrates web_skin_dart component usages to react_material_ui.',
+    );
     stderr.writeln();
     stderr.writeln('Usage:');
     stderr.writeln('    mui_migration [arguments]');
@@ -191,7 +196,10 @@ void main(List<String> args) async {
     // output of previous migrators.
     [aggregate(migratorsToRun)],
     [
-      importerSuggestorBuilder(importUri: rmuiImportUri, importNamespace: muiNs)
+      importerSuggestorBuilder(
+        importUri: rmuiImportUri,
+        importNamespace: muiNs,
+      ),
     ],
     [unusedImportRemoverSuggestorBuilder('web_skin_dart')],
   ]);
@@ -201,10 +209,15 @@ void main(List<String> args) async {
   final rmuiVersionRange = parseVersionRange('^$rmuiVersion');
   exitCode = await runInteractiveCodemod(
     pubspecYamlPaths(),
-    aggregate([
-      PubspecUpgrader('react_material_ui', rmuiVersionRange,
-          hostedUrl: 'https://pub.workiva.org'),
-    ].map((s) => ignoreable(s))),
+    aggregate(
+      [
+        PubspecUpgrader(
+          'react_material_ui',
+          rmuiVersionRange,
+          hostedUrl: 'https://pub.workiva.org',
+        ),
+      ].map((s) => ignoreable(s)),
+    ),
     defaultYes: true,
     args: codemodArgs,
     additionalHelpOutput: parser.usage,
@@ -217,11 +230,11 @@ void sortPartsLast(List<String> dartPaths) {
 
   final isPartCache = <String, bool>{};
   bool isPart(String path) => isPartCache.putIfAbsent(path, () {
-        // parseString is much faster than using an AnalysisContextCollection
-        //  to get unresolved AST, at least in repos with many context roots.
-        final unit = parseString(content: File(path).readAsStringSync()).unit;
-        return unit.directives.whereType<PartOfDirective>().isNotEmpty;
-      });
+    // parseString is much faster than using an AnalysisContextCollection
+    //  to get unresolved AST, at least in repos with many context roots.
+    final unit = parseString(content: File(path).readAsStringSync()).unit;
+    return unit.directives.whereType<PartOfDirective>().isNotEmpty;
+  });
 
   dartPaths.sort((a, b) {
     final isAPart = isPart(a);
@@ -235,7 +248,8 @@ void sortPartsLast(List<String> dartPaths) {
 
 Future<void> pubGetForAllPackageRoots(Iterable<String> files) async {
   _log.info(
-      'Running `pub get` if needed so that all Dart files can be resolved...');
+    'Running `pub get` if needed so that all Dart files can be resolved...',
+  );
   final packageRoots = files.map(findPackageRootFor).toSet();
   for (final packageRoot in packageRoots) {
     await runPubGetIfNeeded(packageRoot);

--- a/lib/src/executables/mui_system_props_migration.dart
+++ b/lib/src/executables/mui_system_props_migration.dart
@@ -20,14 +20,13 @@ import 'package:over_react_codemod/src/mui_suggestors/system_props_to_sx_migrato
 import 'package:over_react_codemod/src/util.dart';
 
 void main(List<String> args) async {
-  const description = 'Migrates deprecated MUI system props to the `sx` prop,'
+  const description =
+      'Migrates deprecated MUI system props to the `sx` prop,'
       '\nensuring that existing `sx` prop values are preserved and merged correctly.';
 
   exitCode = await runInteractiveCodemod(
     allDartPathsExceptHidden(),
-    aggregate([
-      SystemPropsToSxMigrator(),
-    ].map((s) => ignoreable(s))),
+    aggregate([SystemPropsToSxMigrator()].map((s) => ignoreable(s))),
     defaultYes: true,
     args: args,
     additionalHelpOutput: description,

--- a/lib/src/executables/react_18_upgrade.dart
+++ b/lib/src/executables/react_18_upgrade.dart
@@ -36,19 +36,25 @@ void main(List<String> args) async {
   if (parsedArgs.arguments.contains('--help')) {
     // Print command description; flags and other output will get printed via runInteractiveCodemodSequence.
     print(
-        'Updates React JS paths in HTML and Dart files from the React 17 versions to the React 18 versions.\n');
+      'Updates React JS paths in HTML and Dart files from the React 17 versions to the React 18 versions.\n',
+    );
   }
 
   exitCode = await runInteractiveCodemodSequence(
     allHtmlPathsIncludingTemplates(),
     [
       // Update react.js bundle files to React 18 versions in html files
-      ...react17to18ReactJsScriptNames.keys.map((key) => HtmlScriptUpdater(
-          key, react17to18ReactJsScriptNames[key]!,
-          updateAttributes: false)),
+      ...react17to18ReactJsScriptNames.keys.map(
+        (key) => HtmlScriptUpdater(
+          key,
+          react17to18ReactJsScriptNames[key]!,
+          updateAttributes: false,
+        ),
+      ),
       // Remove React 17 react_dom bundle files in html files
-      ...react17ReactDomJsOnlyScriptNames
-          .map((name) => HtmlScriptUpdater.remove(name)),
+      ...react17ReactDomJsOnlyScriptNames.map(
+        (name) => HtmlScriptUpdater.remove(name),
+      ),
     ],
     defaultYes: true,
     args: parsedArgs.rest,
@@ -62,12 +68,17 @@ void main(List<String> args) async {
     allDartPathsExceptHidden(),
     [
       // Update react.js bundle files to React 18 versions in Dart files
-      ...react17to18ReactJsScriptNames.keys.map((key) => DartScriptUpdater(
-          key, react17to18ReactJsScriptNames[key]!,
-          updateAttributes: false)),
+      ...react17to18ReactJsScriptNames.keys.map(
+        (key) => DartScriptUpdater(
+          key,
+          react17to18ReactJsScriptNames[key]!,
+          updateAttributes: false,
+        ),
+      ),
       // Remove React 17 react_dom bundle files in Dart files
-      ...react17ReactDomJsOnlyScriptNames
-          .map((name) => DartScriptUpdater.remove(name)),
+      ...react17ReactDomJsOnlyScriptNames.map(
+        (name) => DartScriptUpdater.remove(name),
+      ),
     ],
     defaultYes: true,
     args: parsedArgs.rest,

--- a/lib/src/executables/rmui_bundle_update.dart
+++ b/lib/src/executables/rmui_bundle_update.dart
@@ -36,10 +36,16 @@ void main(List<String> args) async {
 
   exitCode = await runInteractiveCodemod(
     pubspecYamlPaths(),
-    aggregate([
-      PubspecUpgrader('react_material_ui', parseVersionRange('^1.89.1'),
-          hostedUrl: 'https://pub.workiva.org', shouldAddDependencies: false),
-    ].map((s) => ignoreable(s))),
+    aggregate(
+      [
+        PubspecUpgrader(
+          'react_material_ui',
+          parseVersionRange('^1.89.1'),
+          hostedUrl: 'https://pub.workiva.org',
+          shouldAddDependencies: false,
+        ),
+      ].map((s) => ignoreable(s)),
+    ),
     defaultYes: true,
     args: parsedArgs.rest,
     additionalHelpOutput: parser.usage,

--- a/lib/src/executables/rmui_preparation.dart
+++ b/lib/src/executables/rmui_preparation.dart
@@ -37,10 +37,15 @@ void main(List<String> args) async {
 
   exitCode = await runInteractiveCodemod(
     pubspecYamlPaths(),
-    aggregate([
-      PubspecUpgrader('react_material_ui', parseVersionRange('^1.1.1'),
-          hostedUrl: 'https://pub.workiva.org'),
-    ].map((s) => ignoreable(s))),
+    aggregate(
+      [
+        PubspecUpgrader(
+          'react_material_ui',
+          parseVersionRange('^1.1.1'),
+          hostedUrl: 'https://pub.workiva.org',
+        ),
+      ].map((s) => ignoreable(s)),
+    ),
     defaultYes: true,
     args: parsedArgs.rest,
     additionalHelpOutput: parser.usage,

--- a/lib/src/executables/unify_package_rename.dart
+++ b/lib/src/executables/unify_package_rename.dart
@@ -44,9 +44,7 @@ void main(List<String> args) async {
   final parsedArgs = parser.parse(args);
 
   /// Runs a list of codemods one after the other and returns exit code 0 if any fail.
-  Future<int> runCodemods(
-    Iterable<CodemodInfo> codemods,
-  ) async {
+  Future<int> runCodemods(Iterable<CodemodInfo> codemods) async {
     for (final sequence in codemods) {
       final exitCode = await runInteractiveCodemodSequence(
         sequence.paths,
@@ -64,15 +62,21 @@ void main(List<String> args) async {
 
   exitCode = await runCodemods([
     // Update RMUI bundle script in all HTML files (and templates) to Unify bundle.
-    CodemodInfo(paths: allHtmlPathsIncludingTemplates(), sequence: [
-      HtmlScriptUpdater(rmuiBundleDevUpdated, unifyBundleDev),
-      HtmlScriptUpdater(rmuiBundleProdUpdated, unifyBundleProd),
-    ]),
+    CodemodInfo(
+      paths: allHtmlPathsIncludingTemplates(),
+      sequence: [
+        HtmlScriptUpdater(rmuiBundleDevUpdated, unifyBundleDev),
+        HtmlScriptUpdater(rmuiBundleProdUpdated, unifyBundleProd),
+      ],
+    ),
     // Update RMUI bundle script in all Dart files to Unify bundle.
-    CodemodInfo(paths: allDartPathsExceptHidden(), sequence: [
-      DartScriptUpdater(rmuiBundleDevUpdated, unifyBundleDev),
-      DartScriptUpdater(rmuiBundleProdUpdated, unifyBundleProd),
-    ]),
+    CodemodInfo(
+      paths: allDartPathsExceptHidden(),
+      sequence: [
+        DartScriptUpdater(rmuiBundleDevUpdated, unifyBundleDev),
+        DartScriptUpdater(rmuiBundleProdUpdated, unifyBundleProd),
+      ],
+    ),
   ]);
 
   if (exitCode != 0) return;
@@ -87,17 +91,23 @@ void main(List<String> args) async {
     // Make main rename updates.
     CodemodInfo(paths: dartPaths, sequence: [UnifyRenameSuggestor()]),
     // Update rmui imports to unify.
-    CodemodInfo(paths: dartPaths, sequence: [
-      importRenamerSuggestorBuilder(
-        oldPackageName: 'react_material_ui',
-        newPackageName: 'unify_ui',
-      )
-    ]),
+    CodemodInfo(
+      paths: dartPaths,
+      sequence: [
+        importRenamerSuggestorBuilder(
+          oldPackageName: 'react_material_ui',
+          newPackageName: 'unify_ui',
+        ),
+      ],
+    ),
     // Remove any left over unused imports.
-    CodemodInfo(paths: dartPaths, sequence: [
-      unusedImportRemoverSuggestorBuilder('react_material_ui'),
-      unusedImportRemoverSuggestorBuilder('unify_ui'),
-    ]),
+    CodemodInfo(
+      paths: dartPaths,
+      sequence: [
+        unusedImportRemoverSuggestorBuilder('react_material_ui'),
+        unusedImportRemoverSuggestorBuilder('unify_ui'),
+      ],
+    ),
   ]);
   if (exitCode != 0) return;
 }

--- a/lib/src/ignoreable.dart
+++ b/lib/src/ignoreable.dart
@@ -30,9 +30,9 @@ Suggestor ignoreable(Suggestor suggestor) {
         .map((match) => context.sourceFile.getLine(match.start));
 
     yield* suggestor(context)
-        // Skip patches that start on a line (or on a line immediately after a
-        // line) with an `// orcm_ignore` comment.
-        .where((patch) {
+    // Skip patches that start on a line (or on a line immediately after a
+    // line) with an `// orcm_ignore` comment.
+    .where((patch) {
       final startLine = context.sourceFile.getLine(patch.startOffset);
       return !ignoreLines.contains(startLine) &&
           !ignoreLines.contains(startLine - 1);

--- a/lib/src/intl_suggestors/intl_importer.dart
+++ b/lib/src/intl_suggestors/intl_importer.dart
@@ -21,7 +21,10 @@ import 'package:collection/collection.dart';
 import 'package:path/path.dart' as path;
 
 Stream<Patch> intlImporter(
-    FileContext context, String projectName, String className) async* {
+  FileContext context,
+  String projectName,
+  String className,
+) async* {
   final libraryResult = await context.getResolvedLibrary();
   if (libraryResult == null) {
     // Most likely a part and not a library.
@@ -30,9 +33,11 @@ Stream<Patch> intlImporter(
 
   // Parts that have not been generated can show up as `exists = false` but also `isPart = false`,
   // so using the unitResults is a little trickier than using the libraryElement to get it.
-  final mainLibraryUnitResult = libraryResult.units.singleWhere((unitResult) =>
-      unitResult.unit.declaredElement ==
-      libraryResult.element.definingCompilationUnit);
+  final mainLibraryUnitResult = libraryResult.units.singleWhere(
+    (unitResult) =>
+        unitResult.unit.declaredElement ==
+        libraryResult.element.definingCompilationUnit,
+  );
 
   final needsIntlImport = libraryResult.units
       .expand((unitResult) => unitResult.errors)
@@ -44,10 +49,15 @@ Stream<Patch> intlImporter(
   final intlFilePath = '/src/intl/${projectName}_intl.dart';
   final intlUri = 'package:${projectName}' + intlFilePath;
   final intlDirectory = path.join(context.root, intlFilePath);
-  final relativePathToIntlDir =
-      path.relative(intlDirectory, from: Directory.current.path);
+  final relativePathToIntlDir = path.relative(
+    intlDirectory,
+    from: Directory.current.path,
+  );
   final insertInfo = _insertionLocationForPackageImport(
-      intlUri, mainLibraryUnitResult.unit, mainLibraryUnitResult.lineInfo);
+    intlUri,
+    mainLibraryUnitResult.unit,
+    mainLibraryUnitResult.lineInfo,
+  );
 
   final importStatement = insertInfo.usePackageImports
       ? packageImport(intlUri, insertInfo)
@@ -62,7 +72,9 @@ String packageImport(String intlUri, _InsertionLocation insertInfo) =>
     insertInfo.trailingNewlines;
 
 String relativeImport(
-        String relativeImportPath, _InsertionLocation insertInfo) =>
+  String relativeImportPath,
+  _InsertionLocation insertInfo,
+) =>
     insertInfo.leadingNewlines +
     "import '$relativeImportPath';" +
     insertInfo.trailingNewlines;
@@ -90,16 +102,21 @@ class _InsertionLocation {
 /// otherwise inserting it in a new section relative to other imports
 /// or other directives.
 _InsertionLocation _insertionLocationForPackageImport(
-    String importUri, CompilationUnit unit, LineInfo lineInfo) {
+  String importUri,
+  CompilationUnit unit,
+  LineInfo lineInfo,
+) {
   final imports = unit.directives.whereType<ImportDirective>();
   final firstImport = imports.firstOrNull;
 
-  final dartImports =
-      imports.where((i) => i.uri.stringValue?.startsWith('dart:') ?? false);
+  final dartImports = imports.where(
+    (i) => i.uri.stringValue?.startsWith('dart:') ?? false,
+  );
   final lastDartImport = dartImports.lastOrNull;
 
-  final packageImports =
-      imports.where((i) => i.uri.stringValue?.startsWith('package:') ?? false);
+  final packageImports = imports.where(
+    (i) => i.uri.stringValue?.startsWith('package:') ?? false,
+  );
   final firstPackageImportSortedAfterNewImport = packageImports
       .where((i) => i.uri.stringValue!.compareTo(importUri) > 0)
       .firstOrNull;
@@ -107,8 +124,9 @@ _InsertionLocation _insertionLocationForPackageImport(
       .where((i) => i.uri.stringValue!.compareTo(importUri) < 0)
       .lastOrNull;
 
-  final firstNonImportDirective =
-      unit.directives.where((d) => d is! ImportDirective).firstOrNull;
+  final firstNonImportDirective = unit.directives
+      .where((d) => d is! ImportDirective)
+      .firstOrNull;
 
   final AstNode relativeNode;
   final bool insertAfter;
@@ -140,8 +158,11 @@ _InsertionLocation _insertionLocationForPackageImport(
   } else {
     // No directive to insert relative to; insert before the first member or
     // at the beginning of the file.
-    return _InsertionLocation(unit.declarations.firstOrNull?.offset ?? 0,
-        trailingNewlineCount: 2, usePackageImports: true);
+    return _InsertionLocation(
+      unit.declarations.firstOrNull?.offset ?? 0,
+      trailingNewlineCount: 2,
+      usePackageImports: true,
+    );
   }
 
   hasOnlyPackageImports = !imports.any((importDirective) {
@@ -154,8 +175,9 @@ _InsertionLocation _insertionLocationForPackageImport(
   });
 
   return _InsertionLocation(
-      insertAfter ? relativeNode.end : relativeNode.offset,
-      leadingNewlineCount: insertAfter ? (inOwnSection ? 2 : 1) : 0,
-      trailingNewlineCount: !insertAfter ? (inOwnSection ? 2 : 1) : 0,
-      usePackageImports: hasOnlyPackageImports);
+    insertAfter ? relativeNode.end : relativeNode.offset,
+    leadingNewlineCount: insertAfter ? (inOwnSection ? 2 : 1) : 0,
+    trailingNewlineCount: !insertAfter ? (inOwnSection ? 2 : 1) : 0,
+    usePackageImports: hasOnlyPackageImports,
+  );
 }

--- a/lib/src/intl_suggestors/intl_message_syntax.dart
+++ b/lib/src/intl_suggestors/intl_message_syntax.dart
@@ -24,12 +24,18 @@ class MessageSyntax {
   /// one from the string.
   ///
   /// ex: static String get fooBar => Intl.message('Foo Bar','name: FooBarIntl_fooBar',);
-  String getterDefinition(StringLiteral node, String namespace,
-      {String? name}) {
+  String getterDefinition(
+    StringLiteral node,
+    String namespace, {
+    String? name,
+  }) {
     String text = stringContent(node)!;
     final varName = nameForNode(node, initialName: name);
-    final message = intlFunctionBody(text, '${namespace}_$varName',
-        isMultiline: isMultiline(node));
+    final message = intlFunctionBody(
+      text,
+      '${namespace}_$varName',
+      isMultiline: isMultiline(node),
+    );
     return '  $intlFunctionPrefix get $varName => $message;';
   }
 
@@ -52,14 +58,20 @@ class MessageSyntax {
   ///                                           'name: FooBarIntl_Foo_bar',
   ///                                           );
   String functionDefinition(
-      StringInterpolation node, String namespace, String namePrefix) {
+    StringInterpolation node,
+    String namespace,
+    String namePrefix,
+  ) {
     final functionName = nameForNode(node);
     final functionParams = intlFunctionParameters(node);
     final parameterizedMessage = intlParameterizedMessage(node);
     final messageArgs = intlMessageArgs(node);
     final message = intlFunctionBody(
-        parameterizedMessage, '${namespace}_$functionName',
-        args: messageArgs, isMultiline: node.isMultiline);
+      parameterizedMessage,
+      '${namespace}_$functionName',
+      args: messageArgs,
+      isMultiline: node.isMultiline,
+    );
     return '  ${intlFunctionPrefix} $functionName$functionParams => $message;';
   }
 
@@ -87,9 +99,14 @@ class MessageSyntax {
   /// Converts 'Interpolated ${foo.bar} and $baz' into
   /// 'Interpolated $bar and $baz'
   String intlParameterizedMessage(StringInterpolation node) => node.elements
-      .map((e) => e is InterpolationExpression
-          ? intlInterpolation(e)
-          : escapeNewlines((e as InterpolationString).value, node.isMultiline))
+      .map(
+        (e) => e is InterpolationExpression
+            ? intlInterpolation(e)
+            : escapeNewlines(
+                (e as InterpolationString).value,
+                node.isMultiline,
+              ),
+      )
       .toList()
       .join('');
 
@@ -123,13 +140,18 @@ class MessageSyntax {
     return '(${args.join(', ')})';
   }
 
-  String nameForNode(StringLiteral body,
-      {String? initialName, bool startAtZero = false}) {
+  String nameForNode(
+    StringLiteral body, {
+    String? initialName,
+    bool startAtZero = false,
+  }) {
     var messageText = literalText(body);
     // The case where there is no text after this should be checked in
     // isValidStringInterpolationNode and so it should never happen here.
     return owner.nameForString(
-        initialName ?? toVariableName(messageText), messageText,
-        startAtZero: startAtZero);
+      initialName ?? toVariableName(messageText),
+      messageText,
+      startAtZero: startAtZero,
+    );
   }
 }

--- a/lib/src/intl_suggestors/intl_messages.dart
+++ b/lib/src/intl_suggestors/intl_messages.dart
@@ -33,23 +33,31 @@ class IntlMessages {
   bool get pruning => methodsUsed.isNotEmpty;
 
   // TODO: I think packagePath only applies if there's a sub-package.
-  IntlMessages(this.packageName,
-      {Directory? directory, String packagePath = '', File? output})
-      : outputFile = output ??
-            (directory ?? LocalFileSystem().currentDirectory).childFile(p.join(
-                packagePath,
-                'lib',
-                'src',
-                'intl',
-                '${packageName}_intl.dart')) {
+  IntlMessages(
+    this.packageName, {
+    Directory? directory,
+    String packagePath = '',
+    File? output,
+  }) : outputFile =
+           output ??
+           (directory ?? LocalFileSystem().currentDirectory).childFile(
+             p.join(
+               packagePath,
+               'lib',
+               'src',
+               'intl',
+               '${packageName}_intl.dart',
+             ),
+           ) {
     syntax = MessageSyntax(this);
     _readExisting();
   }
 
   /// Read the existing file and incorporate its methods.
   void _readExisting() {
-    String existing =
-        outputFile.existsSync() ? outputFile.readAsStringSync() : '';
+    String existing = outputFile.existsSync()
+        ? outputFile.readAsStringSync()
+        : '';
     var parsed = parseMethods(existing);
     if (parsed != null) {
       for (var method in parsed) {
@@ -72,8 +80,10 @@ class IntlMessages {
     // If we call this rather than addMethodNamed, then we're adding a new
     // method, record that.
     addedNewMethods |= true;
-    var parsed =
-        MessageParser.forMethod(source, className: className).methods.first;
+    var parsed = MessageParser.forMethod(
+      source,
+      className: className,
+    ).methods.first;
     var expectedName = nameForString(parsed.name, parsed.messageText);
     if (expectedName != parsed.name) {
       throw AssertionError('''
@@ -91,8 +101,11 @@ Attempting to add a different message with the same name:
 
   /// Find the existing name for [name]+number that has the same [messageText], or
   /// if there isn't one, return the first available.
-  String nameForString(String name, String messageText,
-      {bool startAtZero = false}) {
+  String nameForString(
+    String name,
+    String messageText, {
+    bool startAtZero = false,
+  }) {
     var index = 1;
     var newName = '$name${startAtZero ? 0 : ''}';
     while (isNameTaken(newName, messageText)) {
@@ -111,17 +124,19 @@ Attempting to add a different message with the same name:
   void delete() => outputFile.deleteSync();
 
   /// The contents of the generated file.
-  String get contents => (StringBuffer()
-        ..write(prologue)
-        ..write(_messageContents)
-        ..write('\n}'))
-      .toString();
+  String get contents =>
+      (StringBuffer()
+            ..write(prologue)
+            ..write(_messageContents)
+            ..write('\n}'))
+          .toString();
 
   // Just the messages, without the prologue or closing brace.
   String get _messageContents {
     var buffer = StringBuffer();
-    (methods.keys.toList()..sort())
-        .forEach((name) => buffer.write('\n${methods[name]?.source}\n'));
+    (methods.keys.toList()..sort()).forEach(
+      (name) => buffer.write('\n${methods[name]?.source}\n'),
+    );
     return '$buffer';
   }
 
@@ -152,8 +167,12 @@ Attempting to add a different message with the same name:
   /// Format the output file using dart_dev, and print an error it it fails
   /// (possibly because dart_dev is not set up for this repo.)
   void format() async {
-    var result =
-        Process.runSync('dart', ['run', 'dart_dev', 'format', outputFile.path]);
+    var result = Process.runSync('dart', [
+      'run',
+      'dart_dev',
+      'format',
+      outputFile.path,
+    ]);
     if (result.exitCode != 0) {
       print('Stderr from formatting:\n${result.stderr}');
       print('''

--- a/lib/src/intl_suggestors/intl_migrator.dart
+++ b/lib/src/intl_suggestors/intl_migrator.dart
@@ -30,20 +30,29 @@ class ContextMenuMigrator extends GeneralizingAstVisitor
     if (isValidStringLiteralNode(args.first)) {
       var literal = args.first as StringLiteral;
       final functionCall = _messages.syntax.getterCall(literal, _className);
-      final functionDef =
-          _messages.syntax.getterDefinition(literal, _className);
+      final functionDef = _messages.syntax.getterDefinition(
+        literal,
+        _className,
+      );
       yieldPatch(functionCall, literal.offset, literal.end);
       addMethodToClass(_messages, functionDef);
     }
     if (isValidStringInterpolationNode(args.first)) {
       var interpolation = args.first as StringInterpolation;
-      final functionCall =
-          _messages.syntax.functionCall(interpolation, _className, '');
-      final functionDef =
-          _messages.syntax.functionDefinition(interpolation, _className, '');
+      final functionCall = _messages.syntax.functionCall(
+        interpolation,
+        _className,
+        '',
+      );
+      final functionDef = _messages.syntax.functionDefinition(
+        interpolation,
+        _className,
+        '',
+      );
       // A lot of context menu calls are of the form 'Delete $type', which would be better done
       // as a fixed number of 'Delete Audit', 'Delete Form', etc. Add a comment to point that out.
-      final callWithFixMe = '''
+      final callWithFixMe =
+          '''
 // FIXME - INTL Untranslated interpolated value. Is this one of a known set of possibilities?
 $functionCall
 ''';
@@ -127,10 +136,16 @@ class ConstantStringMigrator extends GeneralizingAstVisitor
         // Constant strings might be private.
         var name = publicNameFor(node);
         names.add(name);
-        final functionCall =
-            _messages.syntax.getterCall(literal, _className, name: name);
-        final functionDef =
-            _messages.syntax.getterDefinition(literal, _className, name: name);
+        final functionCall = _messages.syntax.getterCall(
+          literal,
+          _className,
+          name: name,
+        );
+        final functionDef = _messages.syntax.getterDefinition(
+          literal,
+          _className,
+          name: name,
+        );
         yieldPatch('final String ${node.name} = $functionCall', start, end);
         addMethodToClass(_messages, functionDef);
       }
@@ -140,14 +155,16 @@ class ConstantStringMigrator extends GeneralizingAstVisitor
   String publicNameFor(VariableDeclaration node) {
     var basicName = node.name.lexeme;
     // Make sure it's not private.
-    var publicName =
-        basicName.startsWith('_') ? basicName.substring(1) : basicName;
+    var publicName = basicName.startsWith('_')
+        ? basicName.substring(1)
+        : basicName;
     if (isUnique(publicName)) {
       return publicName;
     } else {
       // Use a content-based name.
-      var contentBasedName =
-          toVariableName(stringContent(node.initializer! as StringLiteral)!);
+      var contentBasedName = toVariableName(
+        stringContent(node.initializer! as StringLiteral)!,
+      );
       return contentBasedName;
     }
   }
@@ -182,45 +199,50 @@ class IntlMigrator extends ComponentUsageMigrator {
     if (isStatementIgnored(usage.node)) return false;
     if (isFileIgnored(this.context.sourceText)) return false;
 
-    return usage.cascadedProps.any((prop) =>
-            isValidStringLiteralProp(prop) ||
-            isValidStringInterpolationProp(prop)) ||
-        usage.children.any((child) =>
-            isValidStringLiteralNode(child.node) ||
-            isValidStringInterpolationNode(child.node));
+    return usage.cascadedProps.any(
+          (prop) =>
+              isValidStringLiteralProp(prop) ||
+              isValidStringInterpolationProp(prop),
+        ) ||
+        usage.children.any(
+          (child) =>
+              isValidStringLiteralNode(child.node) ||
+              isValidStringInterpolationNode(child.node),
+        );
   }
 
   @override
   void migrateUsage(FluentComponentUsage usage) {
     super.migrateUsage(usage);
-    final namePrefix = usage.node
-            .thisOrAncestorOfType<ClassDeclaration>()
-            ?.name
-            .lexeme ??
+    final namePrefix =
+        usage.node.thisOrAncestorOfType<ClassDeclaration>()?.name.lexeme ??
         usage.node.thisOrAncestorOfType<VariableDeclaration>()?.name.lexeme ??
         'null';
 
     //Props
-    final stringLiteralProps =
-        usage.cascadedProps.where((prop) => isValidStringLiteralProp(prop));
-    final stringInterpolationProps = usage.cascadedProps
-        .where((prop) => isValidStringInterpolationProp(prop));
+    final stringLiteralProps = usage.cascadedProps.where(
+      (prop) => isValidStringLiteralProp(prop),
+    );
+    final stringInterpolationProps = usage.cascadedProps.where(
+      (prop) => isValidStringInterpolationProp(prop),
+    );
 
     stringLiteralProps.forEach(migratePropStringLiteral);
-    stringInterpolationProps
-        .forEach((prop) => migratePropStringInterpolation(prop, namePrefix));
+    stringInterpolationProps.forEach(
+      (prop) => migratePropStringInterpolation(prop, namePrefix),
+    );
 
     //Children
     final childNodes = usage.children.map((child) => child.node).toList();
     //Migrate String Literals
-    childNodes
-        .whereType<StringLiteral>()
-        .forEach((node) => migrateChildStringLiteral(node));
+    childNodes.whereType<StringLiteral>().forEach(
+      (node) => migrateChildStringLiteral(node),
+    );
 
     //Migrate String Interpolations
-    childNodes
-        .whereType<StringInterpolation>()
-        .forEach((node) => migrateChildStringInterpolation(node, namePrefix));
+    childNodes.whereType<StringInterpolation>().forEach(
+      (node) => migrateChildStringInterpolation(node, namePrefix),
+    );
   }
 
   @override
@@ -249,9 +271,7 @@ class IntlMigrator extends ComponentUsageMigrator {
     // }
   }
 
-  void migrateChildStringLiteral(
-    StringLiteral node,
-  ) {
+  void migrateChildStringLiteral(StringLiteral node) {
     if (isValidStringLiteralNode(node)) {
       final functionCall = _messages.syntax.getterCall(node, _className);
       final functionDef = _messages.syntax.getterDefinition(node, _className);
@@ -261,20 +281,26 @@ class IntlMigrator extends ComponentUsageMigrator {
   }
 
   void migrateChildStringInterpolation(
-      StringInterpolation node, String namePrefix) {
+    StringInterpolation node,
+    String namePrefix,
+  ) {
     if (isValidStringInterpolationNode(node)) {
-      final functionCall =
-          _messages.syntax.functionCall(node, _className, namePrefix);
-      final functionDef =
-          _messages.syntax.functionDefinition(node, _className, namePrefix);
+      final functionCall = _messages.syntax.functionCall(
+        node,
+        _className,
+        namePrefix,
+      );
+      final functionDef = _messages.syntax.functionDefinition(
+        node,
+        _className,
+        namePrefix,
+      );
       yieldPatchOverNode(functionCall, node);
       addMethodToClass(_messages, functionDef);
     }
   }
 
-  void migratePropStringLiteral(
-    PropAssignment prop,
-  ) {
+  void migratePropStringLiteral(PropAssignment prop) {
     if (isValidStringLiteralProp(prop)) {
       final rhs = prop.rightHandSide as StringLiteral;
       final functionCall = _messages.syntax.getterCall(rhs, _className);
@@ -284,16 +310,19 @@ class IntlMigrator extends ComponentUsageMigrator {
     }
   }
 
-  void migratePropStringInterpolation(
-    PropAssignment prop,
-    String namePrefix,
-  ) {
+  void migratePropStringInterpolation(PropAssignment prop, String namePrefix) {
     if (isValidStringInterpolationProp(prop)) {
       final rhs = prop.rightHandSide as StringInterpolation;
-      final functionCall =
-          _messages.syntax.functionCall(rhs, _className, namePrefix);
-      final functionDef =
-          _messages.syntax.functionDefinition(rhs, _className, namePrefix);
+      final functionCall = _messages.syntax.functionCall(
+        rhs,
+        _className,
+        namePrefix,
+      );
+      final functionDef = _messages.syntax.functionDefinition(
+        rhs,
+        _className,
+        namePrefix,
+      );
       yieldPropPatch(prop, newRhs: functionCall);
       addMethodToClass(_messages, functionDef);
     }

--- a/lib/src/intl_suggestors/message_parser.dart
+++ b/lib/src/intl_suggestors/message_parser.dart
@@ -32,8 +32,8 @@ class MessageParser {
   // If we're parsing a method in isolation, it can't be parsed (at least not if it's static),
   // so wrap it in a trivial class and parse that.
   MessageParser.forMethod(String methodSource, {String className = 'Foo'})
-      : this.source = 'class $className { $methodSource }',
-        path = 'generated class for method' {
+    : this.source = 'class $className { $methodSource }',
+      path = 'generated class for method' {
     _parse();
   }
 
@@ -53,14 +53,18 @@ class MessageParser {
     for (var decl in allDeclarations) {
       if (decl is! MethodDeclaration) {
         throw FormatException(
-            'Invalid member, not a method declaration: "$decl"');
+          'Invalid member, not a method declaration: "$decl"',
+        );
       }
     }
     var methodDeclarations = allDeclarations.cast<MethodDeclaration>();
     methods = [
       for (var declaration in methodDeclarations)
-        Method(declaration.name.lexeme, messageText(declaration),
-            '  ${corrected(declaration)}')
+        Method(
+          declaration.name.lexeme,
+          messageText(declaration),
+          '  ${corrected(declaration)}',
+        ),
     ];
   }
 
@@ -87,7 +91,9 @@ class MessageParser {
   /// This also takes the state of the current source if it's already been
   /// partially rewritten.
   String withCorrectFunctionTypes(
-      MethodDeclaration declaration, String currentSource) {
+    MethodDeclaration declaration,
+    String currentSource,
+  ) {
     // Split out the body and just do a simple string replace on the header. The
     // conditions for a false positive on this seem unlikely, so just do it and
     // cross our fingers. If it's in a function name it will be followed by a
@@ -96,16 +102,20 @@ class MessageParser {
     // presumably be followed by either a comma or a close-paren.
     var splitString = (declaration.body is BlockFunctionBody) ? '{' : '=>';
     var declarationParts = currentSource.split(splitString);
-    var newBeginning =
-        declarationParts.first.replaceAll('Function ', 'Object ');
+    var newBeginning = declarationParts.first.replaceAll(
+      'Function ',
+      'Object ',
+    );
     return '$newBeginning$splitString${declarationParts.last}';
   }
 
   /// Find the parameter `name:` from the invocation, or return null if there
   /// isn't one.
   NamedExpression? nameParameterFrom(MethodInvocation invocation) =>
-      invocation.argumentList.childEntities.firstWhereOrNull((element) =>
-              element is NamedExpression && element.name.label.name == 'name')
+      invocation.argumentList.childEntities.firstWhereOrNull(
+            (element) =>
+                element is NamedExpression && element.name.label.name == 'name',
+          )
           as NamedExpression?;
 
   /// Return the method body with the correct name.
@@ -118,7 +128,10 @@ class MessageParser {
     var basicString = '$declaration';
     if (actual == null) {
       return basicString.replaceRange(
-          basicString.length - 2, basicString.length, ', name: $expected);');
+        basicString.length - 2,
+        basicString.length,
+        ', name: $expected);',
+      );
     } else
       return expected == actual
           ? basicString
@@ -138,11 +151,13 @@ class MessageParser {
       var methods = children.whereType<MethodInvocation>().toList();
       if (methods.length > 1)
         throw ArgumentError(
-            'A message can only contain a single call, which must be to an Intl function');
+          'A message can only contain a single call, which must be to an Intl function',
+        );
       return methods.first;
     } else {
       throw ArgumentError(
-          'Cannot parse $node. It needs to be a function with a single expression which is an Intl method invocation');
+        'Cannot parse $node. It needs to be a function with a single expression which is an Intl method invocation',
+      );
     }
   }
 

--- a/lib/src/intl_suggestors/utils.dart
+++ b/lib/src/intl_suggestors/utils.dart
@@ -49,8 +49,9 @@ String? stringContent(AstNode node) {
   if (node is AdjacentStrings) {
     if (!node.strings.toList().every((x) => x is SimpleStringLiteral))
       return null;
-    return [for (var s in node.strings) (s as SimpleStringLiteral).value]
-        .join('');
+    return [
+      for (var s in node.strings) (s as SimpleStringLiteral).value,
+    ].join('');
   }
   return null;
 }
@@ -166,12 +167,18 @@ String toVariableName(String str) {
   if (str.startsWith("'") && str.endsWith("'")) {
     str = str.substring(1, str.length - 1);
   }
-  String strippedName =
-      str.replaceFirst(RegExp(r'^[0-9]*'), '').replaceAll("'", '').trim();
-  var fiveAtMost =
-      strippedName.split(' ').where((each) => each.isNotEmpty).toList();
-  fiveAtMost =
-      fiveAtMost.sublist(0, fiveAtMost.length < 5 ? fiveAtMost.length : 5);
+  String strippedName = str
+      .replaceFirst(RegExp(r'^[0-9]*'), '')
+      .replaceAll("'", '')
+      .trim();
+  var fiveAtMost = strippedName
+      .split(' ')
+      .where((each) => each.isNotEmpty)
+      .toList();
+  fiveAtMost = fiveAtMost.sublist(
+    0,
+    fiveAtMost.length < 5 ? fiveAtMost.length : 5,
+  );
   final alphaNumericName = toAlphaNumeric(fiveAtMost.join(' '));
   final name = toCamelCase(alphaNumericName);
 
@@ -191,9 +198,9 @@ String toCamelCase(String str) {
 
   /// BuildCamelCase
   var capitalizationResult = res.replaceAllMapped(
-      _toCamelCaseRegexp,
-      (m) =>
-          m.start == 0 ? m[0]?.toLowerCase() ?? '' : m[0]?.toUpperCase() ?? '');
+    _toCamelCaseRegexp,
+    (m) => m.start == 0 ? m[0]?.toLowerCase() ?? '' : m[0]?.toUpperCase() ?? '',
+  );
 
   /// Finally remove the spaces
   return capitalizationResult.replaceAll(' ', '');
@@ -206,31 +213,40 @@ bool excludeKnownBadCases(PropAssignment prop, String propKey) {
   var targetType = prop.target.staticType;
   if (targetType == null) return false; // We don't know.
   if (targetType.isOrIsSubtypeOfClassFromPackage(
-          'AbstractSelectOptionPropsMixin', 'web_skin_dart') &&
+        'AbstractSelectOptionPropsMixin',
+        'web_skin_dart',
+      ) &&
       propKey == 'value') {
     return true;
   }
   return false;
 }
 
-final RegExp _excludedStaticTypes =
-    RegExp('((List|Iterable)\<ReactElement\>|ReactElement)(\sFunction)?');
+final RegExp _excludedStaticTypes = RegExp(
+  '((List|Iterable)\<ReactElement\>|ReactElement)(\sFunction)?',
+);
 
 bool excludeUnlikelyExpressions<E extends Expression>(
-    PropAssignment prop, String propKey) {
+  PropAssignment prop,
+  String propKey,
+) {
   final staticType = prop.rightHandSide.staticType;
   if (staticType == null) return true;
   if (staticType.isDartCoreBool) return true;
   if (staticType.isDartCoreNull) return true;
   if (_excludedStaticTypes.hasMatch(
-      prop.rightHandSide.staticType?.getDisplayString(withNullability: false) ??
-          '')) return true;
+    prop.rightHandSide.staticType?.getDisplayString(withNullability: false) ??
+        '',
+  ))
+    return true;
   if (prop.rightHandSide.staticType?.getDisplayString(withNullability: false) ==
-      'Iterable<ReactElement>') return true;
+      'Iterable<ReactElement>')
+    return true;
   final source = prop.rightHandSide.toSource();
   if (source == propKey ||
       source == 'props.$propKey' ||
-      source == "props['$propKey']") return true;
+      source == "props['$propKey']")
+    return true;
   if (source == "''") return true;
   if (source == "'.'") return true;
   if (source == "'('") return true;
@@ -251,7 +267,8 @@ bool excludeUnlikelyExpressions<E extends Expression>(
 ///
 /// So basically camel case either starting lower case or upper case.
 final _camelRegexp = RegExp(
-    r"^([a-z\.]+[A-Z0-9\.][a-z0-9\.]+[A-Za-z0-9\.]*)|([A-Z\.][a-z0-9\.]*[A-Z0-9\.][a-z0-9\.]+[A-Za-z0-9\.]*)$");
+  r"^([a-z\.]+[A-Z0-9\.][a-z0-9\.]+[A-Za-z0-9\.]*)|([A-Z\.][a-z0-9\.]*[A-Z0-9\.][a-z0-9\.]+[A-Za-z0-9\.]*)$",
+);
 
 /// If a string value is in lowerCamelCase or UpperCamelCase or
 /// Period.Separated.Camels, it is most likely a key of some kind, not a
@@ -291,28 +308,42 @@ extension DartHtmlTypes$Element on Element /*?*/ {
 }
 
 extension ElementSubtypeUtils on Element /*?*/ {
-  bool isOrIsSubtypeOfTypeFromPackage(String typeName, String packageName,
-      [PackageType packageType = PackageType.package]) {
+  bool isOrIsSubtypeOfTypeFromPackage(
+    String typeName,
+    String packageName, [
+    PackageType packageType = PackageType.package,
+  ]) {
     final that = this;
     return that is InterfaceElement &&
         (that.isTypeFromPackage(typeName, packageName, packageType) ||
-            that.allSupertypes.any((type) => type.element
-                .isTypeFromPackage(typeName, packageName, packageType)));
+            that.allSupertypes.any(
+              (type) => type.element.isTypeFromPackage(
+                typeName,
+                packageName,
+                packageType,
+              ),
+            ));
   }
 
-  bool isTypeFromPackage(String typeName, String packageName,
-          [PackageType packageType = PackageType.package]) =>
-      name == typeName && isDeclaredInPackageOfType(packageName, packageType);
+  bool isTypeFromPackage(
+    String typeName,
+    String packageName, [
+    PackageType packageType = PackageType.package,
+  ]) => name == typeName && isDeclaredInPackageOfType(packageName, packageType);
 }
 
 extension ElementChecks on Element {
-  bool isDeclaredInPackageOfType(String packageName,
-          [PackageType packageType = PackageType.package]) =>
-      isUriWithinPackage(source?.uri ?? Uri(), packageName, packageType);
+  bool isDeclaredInPackageOfType(
+    String packageName, [
+    PackageType packageType = PackageType.package,
+  ]) => isUriWithinPackage(source?.uri ?? Uri(), packageName, packageType);
 }
 
-bool isUriWithinPackage(Uri uri, String packageName,
-    [PackageType packageType = PackageType.package]) {
+bool isUriWithinPackage(
+  Uri uri,
+  String packageName, [
+  PackageType packageType = PackageType.package,
+]) {
   switch (packageType) {
     case PackageType.dartCore:
       return uri.isScheme('dart') &&
@@ -325,10 +356,7 @@ bool isUriWithinPackage(Uri uri, String packageName,
   }
 }
 
-enum PackageType {
-  dartCore,
-  package,
-}
+enum PackageType { dartCore, package }
 
 /// Is there an ignore comment ahead of this token which we think should apply to it.
 ///

--- a/lib/src/mui_suggestors/components/mui_button_group_migrator.dart
+++ b/lib/src/mui_suggestors/components/mui_button_group_migrator.dart
@@ -43,9 +43,11 @@ class MuiButtonGroupMigrator extends ComponentUsageMigrator with MuiMigrator {
 
     final rhs = prop.rightHandSide;
     if (rhs is BooleanLiteral) {
-      yieldPropPatch(prop,
-          newName: 'orientation',
-          newRhs: rhs.value ? verticalOrientation : horizontalOrientation);
+      yieldPropPatch(
+        prop,
+        newName: 'orientation',
+        newRhs: rhs.value ? verticalOrientation : horizontalOrientation,
+      );
     } else {
       // Change
       //     ..isVertical = expression
@@ -53,7 +55,9 @@ class MuiButtonGroupMigrator extends ComponentUsageMigrator with MuiMigrator {
       //     ..orientation = expression ? mui.ButtonGroupOrientation.vertical : mui.ButtonGroupOrientation.horizontal
       yieldPropPatch(prop, newName: 'orientation');
       yieldInsertionPatch(
-          ' ? $verticalOrientation : $horizontalOrientation', rhs.end);
+        ' ? $verticalOrientation : $horizontalOrientation',
+        rhs.end,
+      );
     }
   }
 

--- a/lib/src/mui_suggestors/components/mui_button_migrator.dart
+++ b/lib/src/mui_suggestors/components/mui_button_migrator.dart
@@ -24,10 +24,7 @@ import 'mui_migrator.dart';
 const _linkButtonSkin = 'ButtonSkin.LINK';
 const _outlineLinkButtonSkin = 'ButtonSkin.OUTLINE_LINK';
 
-const _linkButtonSkins = {
-  _linkButtonSkin,
-  _outlineLinkButtonSkin,
-};
+const _linkButtonSkins = {_linkButtonSkin, _outlineLinkButtonSkin};
 
 class MuiButtonMigrator extends ComponentUsageMigrator
     with MuiMigrator, ButtonDisplayPropsMigrator {
@@ -38,8 +35,11 @@ class MuiButtonMigrator extends ComponentUsageMigrator
   static bool isLinkButtonSkin(Expression expr) =>
       _linkButtonSkins.any((linkSkin) => isWsdStaticConstant(expr, linkSkin));
 
-  static bool isLikelyAssignedToButtonAddonProp(FluentComponentUsage usage) =>
-      usage.node.ancestors.whereType<AssignmentExpression>().map((e) {
+  static bool isLikelyAssignedToButtonAddonProp(
+    FluentComponentUsage usage,
+  ) => usage.node.ancestors
+      .whereType<AssignmentExpression>()
+      .map((e) {
         // Get the resolved name of the property being assigned so we don't have
         // to handle as many unresolved AST cases.
         final writeElement = e.writeElement;
@@ -48,7 +48,8 @@ class MuiButtonMigrator extends ComponentUsageMigrator
             // Use variable.name since PropertyAccessorElement's name has a trailing `=`
             ? writeElement.variable.name
             : writeElement.name;
-      }).any(const {'buttonBefore', 'buttonAfter'}.contains);
+      })
+      .any(const {'buttonBefore', 'buttonAfter'}.contains);
 
   @override
   bool shouldMigrateUsage(FluentComponentUsage usage) =>
@@ -64,8 +65,9 @@ class MuiButtonMigrator extends ComponentUsageMigrator
   void migrateUsage(FluentComponentUsage usage) {
     super.migrateUsage(usage);
 
-    final newFactory =
-        hasLinkButtonSkin(usage) ? '$muiNs.LinkButton' : '$muiNs.Button';
+    final newFactory = hasLinkButtonSkin(usage)
+        ? '$muiNs.LinkButton'
+        : '$muiNs.Button';
     yieldPatchOverNode(newFactory, usage.factory!);
 
     // Needed so we can  only attempt to migrate certain props if they're
@@ -92,8 +94,11 @@ class MuiButtonMigrator extends ComponentUsageMigrator
       propsClassHasHitareaMixin =
           wsdComponentVersionForFactory(usage) != WsdComponentVersion.v1;
     } else if (usesWsdFactory(usage, 'FormResetInput')) {
-      yieldAddPropPatch(usage, "..type = ${_MuiButtonType.reset}",
-          placement: NewPropPlacement.end);
+      yieldAddPropPatch(
+        usage,
+        "..type = ${_MuiButtonType.reset}",
+        placement: NewPropPlacement.end,
+      );
 
       propsClassHasHitareaMixin =
           wsdComponentVersionForFactory(usage) != WsdComponentVersion.v1;
@@ -114,8 +119,10 @@ class MuiButtonMigrator extends ComponentUsageMigrator
 
       // Related to disabled state
       'isDisabled': (p) {
-        yieldPropFixmePatch(p,
-            'if this button has mouse handlers that should fire when disabled or needs to show a tooltip/overlay when disabled, add a wrapper element');
+        yieldPropFixmePatch(
+          p,
+          'if this button has mouse handlers that should fire when disabled or needs to show a tooltip/overlay when disabled, add a wrapper element',
+        );
         yieldPropPatch(p, newName: 'disabled');
       },
       if (propsClassHasHitareaMixin)
@@ -128,14 +135,16 @@ class MuiButtonMigrator extends ComponentUsageMigrator
 
       // Props that always need manual intervention.
       'isCallout': (p) => yieldPropFixmePatch(
-          p,
-          "this styling can be recreated using"
-          " `..sx = const {'textTransform': 'uppercase', 'fontWeight': 'bold'}`"),
+        p,
+        "this styling can be recreated using"
+        " `..sx = const {'textTransform': 'uppercase', 'fontWeight': 'bold'}`",
+      ),
       'pullRight': (p) => yieldPropFixmePatch(
-          p,
-          "this styling can be recreated using"
-          " `..sx = const {'float': 'right'}`"
-          " (or by adjusting the parent layout)"),
+        p,
+        "this styling can be recreated using"
+        " `..sx = const {'float': 'right'}`"
+        " (or by adjusting the parent layout)",
+      ),
     });
 
     // Only attempt to migrate these props if they're declared on the props class
@@ -152,16 +161,19 @@ class MuiButtonMigrator extends ComponentUsageMigrator
     // manually checked.
     if (context.sourceText.contains('DialogFooter')) {
       yieldUsageFixmePatch(
-          usage,
-          "check whether this button is nested inside a DialogFooter."
-          " If so, wrap it in a $muiNs.ButtonToolbar with `..sx = {'float': 'right'}`.");
+        usage,
+        "check whether this button is nested inside a DialogFooter."
+        " If so, wrap it in a $muiNs.ButtonToolbar with `..sx = {'float': 'right'}`.",
+      );
     }
-    if (context.sourceText
-        .contains(RegExp(r'\b(?:buttonBefore|buttonAfter)\b'))) {
+    if (context.sourceText.contains(
+      RegExp(r'\b(?:buttonBefore|buttonAfter)\b'),
+    )) {
       yieldUsageFixmePatch(
-          usage,
-          "check whether this button is assigned to a buttonBefore or buttonAfter prop."
-          " If so, revert the changes to this usage and add an `orcm_ignore` comment to it.");
+        usage,
+        "check whether this button is assigned to a buttonBefore or buttonAfter prop."
+        " If so, revert the changes to this usage and add an `orcm_ignore` comment to it.",
+      );
     }
   }
 
@@ -207,8 +219,10 @@ class MuiButtonMigrator extends ComponentUsageMigrator
   /// ```
   /// ..addProps(someValue)
   /// ```
-  String _cascadeFromMapPropValue(PropAssignment? assignment,
-      {required String destinationFactoryName}) {
+  String _cascadeFromMapPropValue(
+    PropAssignment? assignment, {
+    required String destinationFactoryName,
+  }) {
     if (assignment == null) return '';
 
     // If the RHS is a maps view using destinationFactoryName,
@@ -232,22 +246,28 @@ class MuiButtonMigrator extends ComponentUsageMigrator
     final tooltipContentProp = getFirstPropWithName(usage, 'tooltipContent');
     if (tooltipContentProp == null) return;
 
-    final tooltipContentSource =
-        context.sourceFor(tooltipContentProp.rightHandSide);
+    final tooltipContentSource = context.sourceFor(
+      tooltipContentProp.rightHandSide,
+    );
     yieldRemovePropPatch(tooltipContentProp);
 
-    final overlayTriggerPropsProp =
-        getFirstPropWithName(usage, 'overlayTriggerProps');
+    final overlayTriggerPropsProp = getFirstPropWithName(
+      usage,
+      'overlayTriggerProps',
+    );
     final overlayTriggerCascadeToAdd = _cascadeFromMapPropValue(
-        overlayTriggerPropsProp,
-        destinationFactoryName: 'OverlayTrigger');
+      overlayTriggerPropsProp,
+      destinationFactoryName: 'OverlayTrigger',
+    );
     if (overlayTriggerPropsProp != null) {
       yieldRemovePropPatch(overlayTriggerPropsProp);
     }
 
     final tooltipPropsProp = getFirstPropWithName(usage, 'tooltipProps');
-    final tooltipCascadeToAdd = _cascadeFromMapPropValue(tooltipPropsProp,
-        destinationFactoryName: 'Tooltip');
+    final tooltipCascadeToAdd = _cascadeFromMapPropValue(
+      tooltipPropsProp,
+      destinationFactoryName: 'Tooltip',
+    );
     if (tooltipPropsProp != null) {
       yieldRemovePropPatch(tooltipPropsProp);
     }
@@ -256,13 +276,14 @@ class MuiButtonMigrator extends ComponentUsageMigrator
         '${tooltipCascadeToAdd.isEmpty ? 'Tooltip()' : '(Tooltip()$tooltipCascadeToAdd)'}($tooltipContentSource)';
 
     yieldInsertionPatch(
-        '(OverlayTrigger()\n'
-        // Put this comment here instead of on OverlayTrigger since that might not format nicely
-        '  ${lineComment('$fixmePrefix - tooltip props - manually verify this new Tooltip and wrapper OverlayTrigger')}'
-        '..overlay2 = $overlaySource'
-        '$overlayTriggerCascadeToAdd'
-        ')(',
-        usage.node.offset);
+      '(OverlayTrigger()\n'
+      // Put this comment here instead of on OverlayTrigger since that might not format nicely
+      '  ${lineComment('$fixmePrefix - tooltip props - manually verify this new Tooltip and wrapper OverlayTrigger')}'
+      '..overlay2 = $overlaySource'
+      '$overlayTriggerCascadeToAdd'
+      ')(',
+      usage.node.offset,
+    );
     yieldInsertionPatch(',)', usage.node.end);
   }
 
@@ -277,9 +298,11 @@ class MuiButtonMigrator extends ComponentUsageMigrator
 
     // If it's a single child or `noText = true`, no moving is needed.
     if (usage.children.length == 1 ||
-        usage.cascadedProps.any((p) =>
-            p.name.name == 'noText' &&
-            p.rightHandSide.tryCast<BooleanLiteral>()?.value == true)) {
+        usage.cascadedProps.any(
+          (p) =>
+              p.name.name == 'noText' &&
+              p.rightHandSide.tryCast<BooleanLiteral>()?.value == true,
+        )) {
       return;
     }
 
@@ -287,9 +310,10 @@ class MuiButtonMigrator extends ComponentUsageMigrator
       final iconPropName = isFirst ? 'startIcon' : 'endIcon';
 
       void flagChild() => yieldChildFixmePatch(
-          child,
-          'Button child - manually verify that this child'
-          ' is not an icon that should be moved to `$iconPropName`');
+        child,
+        'Button child - manually verify that this child'
+        ' is not an icon that should be moved to `$iconPropName`',
+      );
 
       // Don't try to handle non-expression (collection element) children.
       if (child is! ExpressionComponentChild) {
@@ -320,7 +344,9 @@ class MuiButtonMigrator extends ComponentUsageMigrator
 
       if (usesWsdFactory(childAsUsage, 'Icon')) {
         yieldAddPropPatch(
-            usage, '..$iconPropName = ${context.sourceFor(child.node)}');
+          usage,
+          '..$iconPropName = ${context.sourceFor(child.node)}',
+        );
         yieldRemoveChildPatch(child.node);
       }
     }
@@ -337,8 +363,10 @@ class MuiButtonMigrator extends ComponentUsageMigrator
 const muiPrimaryColor = '$muiNs.ButtonColor.primary';
 
 mixin ButtonDisplayPropsMigrator on ComponentUsageMigrator {
-  void migrateButtonSkin(PropAssignment prop,
-      {bool handleLinkVariants = false}) {
+  void migrateButtonSkin(
+    PropAssignment prop, {
+    bool handleLinkVariants = false,
+  }) {
     final rhs = prop.rightHandSide;
 
     const muiOutlineVariant = '$muiNs.ButtonVariant.outlined';
@@ -355,10 +383,12 @@ mixin ButtonDisplayPropsMigrator on ComponentUsageMigrator {
     }
 
     if (isWsdStaticConstant(rhs, 'ButtonSkin.VANILLA')) {
-      yieldPropPatch(prop,
-          newName: 'color',
-          newRhs: '$muiNs.ButtonColor.inherit',
-          additionalCascadeSection: '..variant = $muiNs.ButtonVariant.text');
+      yieldPropPatch(
+        prop,
+        newName: 'color',
+        newRhs: '$muiNs.ButtonColor.inherit',
+        additionalCascadeSection: '..variant = $muiNs.ButtonVariant.text',
+      );
       return;
     }
 
@@ -374,11 +404,7 @@ mixin ButtonDisplayPropsMigrator on ComponentUsageMigrator {
       'ButtonSkin.WARNING': '$muiNs.ButtonColor.warning',
     });
     if (colorFromWsdSkin != null) {
-      yieldPropPatch(
-        prop,
-        newName: 'color',
-        newRhs: colorFromWsdSkin,
-      );
+      yieldPropPatch(prop, newName: 'color', newRhs: colorFromWsdSkin);
       return;
     }
 
@@ -398,10 +424,12 @@ mixin ButtonDisplayPropsMigrator on ComponentUsageMigrator {
       'ButtonSkin.OUTLINE_WARNING': '$muiNs.ButtonColor.warning',
     });
     if (colorFromWsdOutlineSkin != null) {
-      yieldPropPatch(prop,
-          newName: 'color',
-          newRhs: colorFromWsdOutlineSkin,
-          additionalCascadeSection: '..variant = $muiOutlineVariant');
+      yieldPropPatch(
+        prop,
+        newName: 'color',
+        newRhs: colorFromWsdOutlineSkin,
+        additionalCascadeSection: '..variant = $muiOutlineVariant',
+      );
       return;
     }
 

--- a/lib/src/mui_suggestors/components/mui_inline_alert_migrator.dart
+++ b/lib/src/mui_suggestors/components/mui_inline_alert_migrator.dart
@@ -40,8 +40,9 @@ class MuiInlineAlertMigrator extends ComponentUsageMigrator
       usesWsdFactory(usage, 'Alert') &&
       // If the alert has props related to the `toast` variant, don't try to
       // migrate it.
-      !usage.cascadedProps
-          .any((prop) => toastAlertProps.contains(prop.name.name));
+      !usage.cascadedProps.any(
+        (prop) => toastAlertProps.contains(prop.name.name),
+      );
 
   @override
   void migrateUsage(FluentComponentUsage usage) {
@@ -70,23 +71,24 @@ mixin AlertDisplayPropsMigrator on ComponentUsageMigrator {
     });
 
     if (severityFromWsdSkin != null) {
-      yieldPropPatch(
-        prop,
-        newName: 'severity',
-        newRhs: severityFromWsdSkin,
-      );
+      yieldPropPatch(prop, newName: 'severity', newRhs: severityFromWsdSkin);
       return;
     }
 
-    final usesInverseSkin =
-        isWsdStaticConstant(prop.rightHandSide, 'AlertSkin.INVERSE');
-    var migrateVariantToGray = usesInverseSkin ||
+    final usesInverseSkin = isWsdStaticConstant(
+      prop.rightHandSide,
+      'AlertSkin.INVERSE',
+    );
+    var migrateVariantToGray =
+        usesInverseSkin ||
         isWsdStaticConstant(prop.rightHandSide, 'AlertSkin.GRAY');
 
     if (migrateVariantToGray) {
       if (usesInverseSkin) {
-        yieldPropFixmePatch(prop,
-            'this prop was converted from the INVERSE skin and should be double checked');
+        yieldPropFixmePatch(
+          prop,
+          'this prop was converted from the INVERSE skin and should be double checked',
+        );
       }
 
       yieldPropPatch(
@@ -105,7 +107,9 @@ mixin AlertDisplayPropsMigrator on ComponentUsageMigrator {
 
     yieldRemovePropPatch(prop);
     yieldAddChildPatch(
-        usage, '$muiNs.AlertTitle()(${context.sourceFor(propValue)})');
+      usage,
+      '$muiNs.AlertTitle()(${context.sourceFor(propValue)})',
+    );
   }
 
   void migrateAlertSize(PropAssignment prop) {
@@ -118,10 +122,7 @@ mixin AlertDisplayPropsMigrator on ComponentUsageMigrator {
     });
 
     if (sizeFromWsdAlertSize != null) {
-      yieldPropPatch(
-        prop,
-        newRhs: sizeFromWsdAlertSize,
-      );
+      yieldPropPatch(prop, newRhs: sizeFromWsdAlertSize);
       return;
     }
 

--- a/lib/src/mui_suggestors/system_props.dart
+++ b/lib/src/mui_suggestors/system_props.dart
@@ -27,8 +27,10 @@ bool hasSxAndSomeSystemProps(InterfaceElement propsElement) {
     'letterSpacing',
   ];
 
-  return propsToCheck.every((propName) =>
-      propsElement.lookUpGetter(propName, propsElement.library) != null);
+  return propsToCheck.every(
+    (propName) =>
+        propsElement.lookUpGetter(propName, propsElement.library) != null,
+  );
 }
 
 /// The names of all the MUI system props.

--- a/lib/src/mui_suggestors/system_props_to_sx_migrator.dart
+++ b/lib/src/mui_suggestors/system_props_to_sx_migrator.dart
@@ -136,24 +136,30 @@ class SystemPropsToSxMigrator extends ComponentUsageMigrator {
           ? ''
           // Get full comment text, and trim trailing newline/whitespace
           : context.sourceFile
-              .getText(beforeComments.first.offset, beforeComments.last.end)
-              .trimRight();
+                .getText(beforeComments.first.offset, beforeComments.last.end)
+                .trimRight();
 
-      migratedSystemPropEntries.add([
-        if (commentSource.isNotEmpty) '\n $commentSource',
-        "'${prop.name.name}': ${context.sourceFor(prop.rightHandSide)}"
-      ].join('\n'));
+      migratedSystemPropEntries.add(
+        [
+          if (commentSource.isNotEmpty) '\n $commentSource',
+          "'${prop.name.name}': ${context.sourceFor(prop.rightHandSide)}",
+        ].join('\n'),
+      );
 
-      yieldPatch('', beforeComments.firstOrNull?.offset ?? prop.node.offset,
-          prop.node.end);
+      yieldPatch(
+        '',
+        beforeComments.firstOrNull?.offset ?? prop.node.offset,
+        prop.node.end,
+      );
     }
 
     final propForwardingSources = _detectPropForwardingSources(usage);
 
     final bool anySystemPropSetBeforeForwarding;
     if (propForwardingSources.isNotEmpty) {
-      final propForwardingOffsets =
-          propForwardingSources.map((s) => s.cascadedMethod.node.end).toList();
+      final propForwardingOffsets = propForwardingSources
+          .map((s) => s.cascadedMethod.node.end)
+          .toList();
       final systemPropOffsets = systemProps.map((p) => p.node.end).toList();
       anySystemPropSetBeforeForwarding =
           systemPropOffsets.min < propForwardingOffsets.max;
@@ -188,9 +194,10 @@ class SystemPropsToSxMigrator extends ComponentUsageMigrator {
         // Insert before, to preserve existing behavior where any spread sx trumped these styles.
         // Add a leading newline to ensure comments don't get stuck to the opening braces.
         yieldPatch(
-            '${getFixmesSource()}\n${migratedSystemPropEntries.join(',\n')},',
-            value.leftBracket.end,
-            value.leftBracket.end);
+          '${getFixmesSource()}\n${migratedSystemPropEntries.join(',\n')},',
+          value.leftBracket.end,
+          value.leftBracket.end,
+        );
         // Force a multiline in all cases by ensuring there's a trailing comma.
         final hadTrailingComma =
             value.rightBracket.previous?.type == TokenType.COMMA;
@@ -202,19 +209,22 @@ class SystemPropsToSxMigrator extends ComponentUsageMigrator {
         // Case 1b: spread existing sx value into a new map literal
 
         final type = value.staticType;
-        final nonNullable = type != null &&
+        final nonNullable =
+            type != null &&
             type is! DynamicType &&
             type.nullabilitySuffix == NullabilitySuffix.none;
         final spread = '...${nonNullable ? '' : '?'}';
         // Insert before spread, to preserve existing behavior where any forwarded sx trumped these styles.
         yieldPatch(
-            '{${getFixmesSource()}\n${migratedSystemPropEntries.join(', ')}, $spread',
-            value.offset,
-            value.offset);
-        final maybeTrailingComma = _shouldForceMultiline([
-          ...migratedSystemPropEntries,
-          '$spread${context.sourceFor(value)}',
-        ])
+          '{${getFixmesSource()}\n${migratedSystemPropEntries.join(', ')}, $spread',
+          value.offset,
+          value.offset,
+        );
+        final maybeTrailingComma =
+            _shouldForceMultiline([
+              ...migratedSystemPropEntries,
+              '$spread${context.sourceFor(value)}',
+            ])
             ? ','
             : '';
         yieldPatch('$maybeTrailingComma}', value.end, value.end);
@@ -245,8 +255,9 @@ class SystemPropsToSxMigrator extends ComponentUsageMigrator {
         bool canSafelyGetForwardedSx;
         final props = propForwardingSources.singleOrNull?.sourceProps;
         if (props != null && (props is Identifier || props is PropertyAccess)) {
-          final propsElement =
-              props.staticType?.typeOrBound.tryCast<InterfaceType>()?.element;
+          final propsElement = props.staticType?.typeOrBound
+              .tryCast<InterfaceType>()
+              ?.element;
           canSafelyGetForwardedSx =
               propsElement?.lookUpGetter('sx', propsElement.library) != null;
         } else {
@@ -258,7 +269,8 @@ class SystemPropsToSxMigrator extends ComponentUsageMigrator {
         } else {
           forwardedSxSpread = null;
           fixmes.add(
-              'spread in any sx prop forwarded to this component above, if needed (spread should go at the end of this map to preserve behavior)');
+            'spread in any sx prop forwarded to this component above, if needed (spread should go at the end of this map to preserve behavior)',
+          );
         }
       } else {
         forwardedSxSpread = null;
@@ -276,13 +288,14 @@ class SystemPropsToSxMigrator extends ComponentUsageMigrator {
       // whichever is later.
       final insertionLocation = [
         ...propForwardingSources.map((s) => s.cascadedMethod.node.end),
-        ...systemProps.map((p) => p.node.end)
+        ...systemProps.map((p) => p.node.end),
       ].max;
 
       yieldPatch(
-          '${getFixmesSource()}..sx = {${elements.join(', ')}$maybeTrailingComma}',
-          insertionLocation,
-          insertionLocation);
+        '${getFixmesSource()}..sx = {${elements.join(', ')}$maybeTrailingComma}',
+        insertionLocation,
+        insertionLocation,
+      );
     }
   }
 
@@ -324,7 +337,8 @@ class _PropSpreadSource {
 
 /// Returns the sources of props being added or spread to [usage].
 List<_PropSpreadSource> _detectPropForwardingSources(
-    FluentComponentUsage usage) {
+  FluentComponentUsage usage,
+) {
   return usage.cascadedMethodInvocations
       .map((c) {
         final methodName = c.methodName.name;

--- a/lib/src/react16_suggestors/comment_remover.dart
+++ b/lib/src/react16_suggestors/comment_remover.dart
@@ -33,13 +33,17 @@ class CommentRemover extends GeneralizingAstVisitor with AstVisitingSuggestor {
     int? endingOffset;
 
     for (var comment in allComments(node.root.beginToken)) {
-      final commentText =
-          context.sourceFile.getText(comment.offset, comment.end);
+      final commentText = context.sourceFile.getText(
+        comment.offset,
+        comment.end,
+      );
 
       if (commentText.contains(startString) && startingOffset == null) {
         // Make the starting offset the end of the previous line.
-        startingOffset = context.sourceFile
-                .getOffset(context.sourceFile.getLine(comment.offset)) -
+        startingOffset =
+            context.sourceFile.getOffset(
+              context.sourceFile.getLine(comment.offset),
+            ) -
             1;
       }
 

--- a/lib/src/react16_suggestors/constants.dart
+++ b/lib/src/react16_suggestors/constants.dart
@@ -25,7 +25,8 @@ const styleMapExplanation =
 const styleMapExample =
     "// Incorrect value for 'width': '40'. Correct values: 40, '40px', '4em'.";
 
-const styleMapComment = '''
+const styleMapComment =
+    '''
       $styleMapExplanation
       $styleMapExample
     ''';

--- a/lib/src/react16_suggestors/dependency_override_updater.dart
+++ b/lib/src/react16_suggestors/dependency_override_updater.dart
@@ -22,10 +22,7 @@ import '../constants.dart';
 import '../creator_utils.dart';
 
 /// A reference to all the known override types.
-enum ConfigType {
-  simple,
-  git,
-}
+enum ConfigType { simple, git }
 
 /// A config representing an override to a git ref.
 ///
@@ -42,7 +39,7 @@ class GitOverrideConfig extends DependencyOverrideConfig {
   final String url;
 
   GitOverrideConfig({required String name, required this.url, this.ref})
-      : super(name, ConfigType.git);
+    : super(name, ConfigType.git);
 }
 
 /// A config representing an override to a simple version.
@@ -56,7 +53,7 @@ class SimpleOverrideConfig extends DependencyOverrideConfig {
   final String version;
 
   SimpleOverrideConfig({required String name, required this.version})
-      : super(name, ConfigType.simple);
+    : super(name, ConfigType.simple);
 }
 
 /// The base class for all dependency override configs.
@@ -78,8 +75,9 @@ class DependencyOverrideUpdater {
   });
 
   Stream<Patch> call(FileContext context) async* {
-    final dependencyOverrideSectionKey =
-        dependencyOverrideRegExp.firstMatch(context.sourceText);
+    final dependencyOverrideSectionKey = dependencyOverrideRegExp.firstMatch(
+      context.sourceText,
+    );
     final dependencyOverrideSectionStart =
         dependencyOverrideSectionKey?.start ?? -1;
     final dependenciesSectionStart =
@@ -88,7 +86,8 @@ class DependencyOverrideUpdater {
         devDependencyRegExp.firstMatch(context.sourceText)?.start ?? -1;
 
     bool _isDependencyMatchWithinDependencyOverridesSection(
-        RegExpMatch dependencyMatch) {
+      RegExpMatch dependencyMatch,
+    ) {
       if (dependencyOverrideSectionStart == -1) return false;
       if (dependencyMatch.start < dependencyOverrideSectionStart) return false;
       if (dependencyMatch.start > dependencyOverrideSectionStart) {
@@ -126,10 +125,12 @@ class DependencyOverrideUpdater {
 
     // Each override has its own object to keep track of what the dependency
     // override is and what it needs to be overridden with.
-    var reactDependencyOverride =
-        DependencyCreator.fromOverrideConfig(reactOverrideConfig);
-    var overReactDependencyOverride =
-        DependencyCreator.fromOverrideConfig(overReactOverrideConfig);
+    var reactDependencyOverride = DependencyCreator.fromOverrideConfig(
+      reactOverrideConfig,
+    );
+    var overReactDependencyOverride = DependencyCreator.fromOverrideConfig(
+      overReactOverrideConfig,
+    );
 
     final dependenciesToUpdate = [
       reactDependencyOverride,
@@ -145,7 +146,8 @@ class DependencyOverrideUpdater {
         throw Exception('Could not parse pubspec.yaml.$e\n$stackTrace');
       } else {
         throw Exception(
-            'Unexpected error loading pubspec.yaml.$e\n$stackTrace');
+          'Unexpected error loading pubspec.yaml.$e\n$stackTrace',
+        );
       }
     }
 
@@ -155,17 +157,26 @@ class DependencyOverrideUpdater {
 
       // This dependency override already exists with the exact version... get outta here.
       if (fileAlreadyContainsMatchingOverrideForDependency(
-          dependency: dependencyOverride, yamlContent: parsedYamlMap)) continue;
+        dependency: dependencyOverride,
+        yamlContent: parsedYamlMap,
+      ))
+        continue;
 
       if (fileAlreadyContainsOverrideForDependency(
-          dependency: dependencyOverride, yamlContent: parsedYamlMap)) {
+        dependency: dependencyOverride,
+        yamlContent: parsedYamlMap,
+      )) {
         // The regex that can be used to find the location of the override.
         final dependencyRegex = getDependencyRegEx(
-            dependency: dependencyName, yamlContent: parsedYamlMap);
+          dependency: dependencyName,
+          yamlContent: parsedYamlMap,
+        );
         final dependencyMatch = dependencyRegex
             .allMatches(context.sourceText)
-            .singleWhereOrNull((match) =>
-                _isDependencyMatchWithinDependencyOverridesSection(match));
+            .singleWhereOrNull(
+              (match) =>
+                  _isDependencyMatchWithinDependencyOverridesSection(match),
+            );
 
         if (dependencyMatch != null) {
           // startPoint is needed because a new line would be added to the
@@ -196,11 +207,7 @@ class DependencyOverrideUpdater {
         insertionOffset = context.sourceFile.getOffset(insertionLine);
 
         if (!shouldAddDependencyOverrideKey) {
-          yield Patch(
-            '$overrideString',
-            insertionOffset,
-            insertionOffset,
-          );
+          yield Patch('$overrideString', insertionOffset, insertionOffset);
         } else {
           yield Patch(
             '\n'
@@ -217,8 +224,10 @@ class DependencyOverrideUpdater {
   }
 }
 
-bool fileAlreadyContainsOverrideForDependency(
-    {required DependencyCreator dependency, required YamlMap? yamlContent}) {
+bool fileAlreadyContainsOverrideForDependency({
+  required DependencyCreator dependency,
+  required YamlMap? yamlContent,
+}) {
   if (yamlContent == null) return false;
 
   if (yamlContent['dependency_overrides'] != null) {
@@ -230,17 +239,24 @@ bool fileAlreadyContainsOverrideForDependency(
   return false;
 }
 
-bool fileAlreadyContainsMatchingOverrideForDependency(
-    {required DependencyCreator dependency, required YamlMap? yamlContent}) {
+bool fileAlreadyContainsMatchingOverrideForDependency({
+  required DependencyCreator dependency,
+  required YamlMap? yamlContent,
+}) {
   if (!fileAlreadyContainsOverrideForDependency(
-      dependency: dependency, yamlContent: yamlContent)) return false;
+    dependency: dependency,
+    yamlContent: yamlContent,
+  ))
+    return false;
   return yamlContent!['dependency_overrides'][dependency.name] ==
       dependency.version;
 }
 
 // Method that builds the RegEx that will match the dependency in the pubspec.
-RegExp getDependencyRegEx(
-    {required String dependency, required YamlMap? yamlContent}) {
+RegExp getDependencyRegEx({
+  required String dependency,
+  required YamlMap? yamlContent,
+}) {
   if (yamlContent == null) throw Exception('Invalid yaml content');
 
   if (yamlContent['dependency_overrides'] != null) {
@@ -249,8 +265,10 @@ RegExp getDependencyRegEx(
 
       if (dependencyValue is String) {
         // The override is simply specifying a new version.
-        return RegExp(r'''^\s*''' + dependency + r''':\s*(["']?)(.+)\1\s*$''',
-            multiLine: true);
+        return RegExp(
+          r'''^\s*''' + dependency + r''':\s*(["']?)(.+)\1\s*$''',
+          multiLine: true,
+        );
         // If the override uses git
       } else if (yamlContent['dependency_overrides'][dependency]['git'] !=
           null) {
@@ -259,21 +277,25 @@ RegExp getDependencyRegEx(
         if (yamlContent['dependency_overrides'][dependency]['git']['ref'] !=
             null) {
           return RegExp(
-              r'''^\s*(''' +
-                  dependency +
-                  r'''):\s*git:\s*url:\s*(.+)\s*ref:\s*(.+)$''',
-              multiLine: true);
+            r'''^\s*(''' +
+                dependency +
+                r'''):\s*git:\s*url:\s*(.+)\s*ref:\s*(.+)$''',
+            multiLine: true,
+          );
         } else {
           return RegExp(
-              r'''^\s*(''' + dependency + r'''):\s+git:\s+url:\s*(.+)$''',
-              multiLine: true);
+            r'''^\s*(''' + dependency + r'''):\s+git:\s+url:\s*(.+)$''',
+            multiLine: true,
+          );
         }
 
         // If the override uses path.
       } else if (yamlContent['dependency_overrides'][dependency]['path'] !=
           null) {
-        return RegExp(r'''^\s*(''' + dependency + r'''):\s+path:\s+(.+)$''',
-            multiLine: true);
+        return RegExp(
+          r'''^\s*(''' + dependency + r'''):\s+path:\s+(.+)$''',
+          multiLine: true,
+        );
       }
     }
   }

--- a/lib/src/react16_suggestors/pubspec_react_upgrader.dart
+++ b/lib/src/react16_suggestors/pubspec_react_upgrader.dart
@@ -26,8 +26,8 @@ class PubspecReactUpdater extends PubspecUpgrader {
     VersionRange targetConstraint, {
     bool shouldAddDependencies = true,
   }) : super(
-          'react',
-          targetConstraint,
-          shouldAddDependencies: shouldAddDependencies,
-        );
+         'react',
+         targetConstraint,
+         shouldAddDependencies: shouldAddDependencies,
+       );
 }

--- a/lib/src/react16_suggestors/react16_utilities.dart
+++ b/lib/src/react16_suggestors/react16_utilities.dart
@@ -56,21 +56,25 @@ bool hasComment(AstNode node, SourceFile sourceFile, String comment) {
 /// Whether the [node] has a documentation comment that has
 /// any lines that match lines found within the provided [comment].
 bool hasMultilineDocComment(
-    AnnotatedNode node, SourceFile sourceFile, String comment) {
-  final nodeComments = nodeCommentSpan(node, sourceFile)
-      .text
-      .replaceAll('///', '')
-      .split('\n')
-      .map((line) => line.replaceAll('\n', '').trim())
-      .toList()
-    ..removeWhere((line) => line.isEmpty);
-  final commentLines = comment
-      .replaceAll('///', '')
-      .trimLeft()
-      .split('\n')
-      .map((line) => line.replaceAll('\n', '').trim())
-      .toList()
-    ..removeWhere((line) => line.isEmpty);
+  AnnotatedNode node,
+  SourceFile sourceFile,
+  String comment,
+) {
+  final nodeComments =
+      nodeCommentSpan(node, sourceFile).text
+          .replaceAll('///', '')
+          .split('\n')
+          .map((line) => line.replaceAll('\n', '').trim())
+          .toList()
+        ..removeWhere((line) => line.isEmpty);
+  final commentLines =
+      comment
+          .replaceAll('///', '')
+          .trimLeft()
+          .split('\n')
+          .map((line) => line.replaceAll('\n', '').trim())
+          .toList()
+        ..removeWhere((line) => line.isEmpty);
 
   bool match = false;
 
@@ -88,7 +92,8 @@ bool hasMultilineDocComment(
 /// Returns the `SourceSpan` value of any comments on the provided [node] within the [sourceFile].
 SourceSpan nodeCommentSpan(AnnotatedNode node, SourceFile sourceFile) {
   return sourceFile.span(
-      node.beginToken.offset,
-      node.metadata.beginToken?.offset ??
-          node.firstTokenAfterCommentAndMetadata.offset);
+    node.beginToken.offset,
+    node.metadata.beginToken?.offset ??
+        node.firstTokenAfterCommentAndMetadata.offset,
+  );
 }

--- a/lib/src/react16_suggestors/react_dom_render_migrator.dart
+++ b/lib/src/react16_suggestors/react_dom_render_migrator.dart
@@ -47,14 +47,20 @@ class ReactDomRenderMigrator extends GeneralizingAstVisitor
         .whereType<LibraryDirective>()
         .toList();
 
-    final overReactImport = imports.lastWhereOrNull((dir) =>
-        dir.uri.stringValue == 'package:over_react/over_react.dart' ||
-        // These tests strings are split by web_skin_dart to work around issues with dependency_validator.
-        dir.uri.stringValue == 'package:' 'web_skin_dart/ui_core.dart');
+    final overReactImport = imports.lastWhereOrNull(
+      (dir) =>
+          dir.uri.stringValue == 'package:over_react/over_react.dart' ||
+          // These tests strings are split by web_skin_dart to work around issues with dependency_validator.
+          dir.uri.stringValue ==
+              'package:'
+                  'web_skin_dart/ui_core.dart',
+    );
 
-    final reactDomImport = imports.lastWhereOrNull((dir) =>
-        (dir.uri.stringValue == 'package:react/react_dom.dart' ||
-            dir.uri.stringValue == 'package:over_react/react_dom.dart'));
+    final reactDomImport = imports.lastWhereOrNull(
+      (dir) =>
+          (dir.uri.stringValue == 'package:react/react_dom.dart' ||
+          dir.uri.stringValue == 'package:over_react/react_dom.dart'),
+    );
 
     String? reactDomImportNamespace;
     bool isWrappedWithErrorBoundary = false;
@@ -65,9 +71,11 @@ class ReactDomRenderMigrator extends GeneralizingAstVisitor
       reactDomImportNamespace = reactDomImport.prefix?.name;
     }
 
-    final testAncestor = node.thisOrAncestorMatching((ancestor) =>
-        ancestor is MethodInvocation &&
-        const {'test', 'group'}.contains(ancestor.methodName.name));
+    final testAncestor = node.thisOrAncestorMatching(
+      (ancestor) =>
+          ancestor is MethodInvocation &&
+          const {'test', 'group'}.contains(ancestor.methodName.name),
+    );
     final inTest = testAncestor != null;
 
     if (node.methodName.name != 'render' ||
@@ -94,7 +102,10 @@ class ReactDomRenderMigrator extends GeneralizingAstVisitor
       }
       if (!isPartOf) {
         yieldPatch(
-            'import \'package:over_react/over_react.dart\';\n', offset, offset);
+          'import \'package:over_react/over_react.dart\';\n',
+          offset,
+          offset,
+        );
       }
     }
 
@@ -116,11 +127,7 @@ class ReactDomRenderMigrator extends GeneralizingAstVisitor
         renderFirstArg.offset,
         renderFirstArg.offset,
       );
-      yieldPatch(
-        ')',
-        renderFirstArg.end,
-        renderFirstArg.end,
-      );
+      yieldPatch(')', renderFirstArg.end, renderFirstArg.end);
     } else if (isWrappedWithErrorBoundary && overReactImport == null) {
       addOverReactPatch(reactDomImport?.offset);
     }
@@ -140,11 +147,7 @@ class ReactDomRenderMigrator extends GeneralizingAstVisitor
       // Edit assignment
       if (parent is VariableDeclaration) {
         // Instances of this class are always children of the class [VariableDeclarationList]
-        yieldPatch(
-          ';',
-          parent.equals!.offset,
-          parent.equals!.end,
-        );
+        yieldPatch(';', parent.equals!.offset, parent.equals!.end);
 
         // Add this on the render call and not before the parent so that dupe
         // comments aren't added on subsequent runs.
@@ -158,11 +161,7 @@ class ReactDomRenderMigrator extends GeneralizingAstVisitor
 
         refVariableName = parent.name.lexeme;
       } else if (parent is AssignmentExpression) {
-        yieldPatch(
-          '',
-          parent.offset,
-          parent.rightHandSide.offset,
-        );
+        yieldPatch('', parent.offset, parent.rightHandSide.offset);
 
         // Add this on the render call and not before the parent so that dupe
         // comments aren't added on subsequent runs.
@@ -184,11 +183,7 @@ class ReactDomRenderMigrator extends GeneralizingAstVisitor
         final builderExpression = usage.node.function;
 
         if (builderExpression is! ParenthesizedExpression) {
-          yieldPatch(
-            '(',
-            builderExpression.offset,
-            builderExpression.offset,
-          );
+          yieldPatch('(', builderExpression.offset, builderExpression.offset);
         }
 
         yieldPatch(
@@ -198,11 +193,7 @@ class ReactDomRenderMigrator extends GeneralizingAstVisitor
         );
 
         if (builderExpression is! ParenthesizedExpression) {
-          yieldPatch(
-            ')',
-            builderExpression.end,
-            builderExpression.end,
-          );
+          yieldPatch(')', builderExpression.end, builderExpression.end);
         }
       }
     } else if (parent is ArgumentList &&

--- a/lib/src/react16_suggestors/react_style_maps_updater.dart
+++ b/lib/src/react16_suggestors/react_style_maps_updater.dart
@@ -26,8 +26,9 @@ import 'package:over_react_codemod/src/react16_suggestors/react16_utilities.dart
 /// cases should be a num instead of a string.
 class ReactStyleMapsUpdater extends GeneralizingAstVisitor
     with AstVisitingSuggestor {
-  static final _cssValueSuffixPattern =
-      RegExp(r'\b(?:rem|em|ex|vh|vw|vmin|vmax|%|px|cm|mm|in|pt|pc|ch)$');
+  static final _cssValueSuffixPattern = RegExp(
+    r'\b(?:rem|em|ex|vh|vw|vmin|vmax|%|px|cm|mm|in|pt|pc|ch)$',
+  );
 
   @override
   visitCascadeExpression(CascadeExpression node) {
@@ -110,12 +111,12 @@ class ReactStyleMapsUpdater extends GeneralizingAstVisitor
             if (cssPropertyValue is ConditionalExpression) {
               ternaryExpressions = [
                 cssPropertyValue.thenExpression,
-                cssPropertyValue.elseExpression
+                cssPropertyValue.elseExpression,
               ];
             } else if (cssPropertyValue is BinaryExpression) {
               ternaryExpressions = [
                 cssPropertyValue.leftOperand,
-                cssPropertyValue.rightOperand
+                cssPropertyValue.rightOperand,
               ];
             } else {
               throw UnimplementedError('Unhandled type for cssPropertyValue');
@@ -129,7 +130,10 @@ class ReactStyleMapsUpdater extends GeneralizingAstVisitor
               } else if (isANumber(cleanedPropertySubString) &&
                   !isANumber(property.toSource())) {
                 yieldPatch(
-                    cleanedPropertySubString, property.offset, property.end);
+                  cleanedPropertySubString,
+                  property.offset,
+                  property.end,
+                );
               }
             }
           } else if (cssPropertyValue is SimpleStringLiteral ||
@@ -191,14 +195,15 @@ class ReactStyleMapsUpdater extends GeneralizingAstVisitor
           isOther) {
         yieldPatch(
           getString(
-              isAVariable: isAVariable,
-              hasPotentiallyInvalidValue:
-                  potentiallyInvalidProperties.isNotEmpty,
-              isAFunction: isAFunction,
-              affectedValues: potentiallyInvalidProperties,
-              addExtraLine: context.sourceFile.getLine(cascade.offset) ==
-                  context.sourceFile.getLine(cascade.parent!.offset),
-              isOther: isOther),
+            isAVariable: isAVariable,
+            hasPotentiallyInvalidValue: potentiallyInvalidProperties.isNotEmpty,
+            isAFunction: isAFunction,
+            affectedValues: potentiallyInvalidProperties,
+            addExtraLine:
+                context.sourceFile.getLine(cascade.offset) ==
+                context.sourceFile.getLine(cascade.parent!.offset),
+            isOther: isOther,
+          ),
           cascade.offset,
           cascade.offset,
         );
@@ -217,21 +222,25 @@ String getString({
   bool isForCustomProps = false,
   bool isOther = false,
 }) {
-  String checkboxWithAffectedValues = '// [ ] Check this box upon manual '
+  String checkboxWithAffectedValues =
+      '// [ ] Check this box upon manual '
       'validation that this style map uses a valid value for the following '
       'keys: ${affectedValues.join(', ')}.';
 
-  String variableCheckbox = '// [ ] Check this box upon manual validation '
+  String variableCheckbox =
+      '// [ ] Check this box upon manual validation '
       'that this style map is receiving a value that is valid for the keys '
       'that are simple string variables.';
 
-  String variableCheckboxWithAffectedValues = '// [ ] Check this box upon '
+  String variableCheckboxWithAffectedValues =
+      '// [ ] Check this box upon '
       'manual validation that this style map is receiving a value that is '
       'valid for the following keys: ${affectedValues.join(', ')}.';
 
   String willBeRemovedSuffix = '//$willBeRemovedCommentSuffix';
 
-  String functionCheckbox = '// [ ] Check this box upon manual validation '
+  String functionCheckbox =
+      '// [ ] Check this box upon manual validation '
       'that the method called to set the style prop does not return any '
       'simple, unitless strings instead of nums.';
 

--- a/lib/src/rmui_bundle_update_suggestors/constants.dart
+++ b/lib/src/rmui_bundle_update_suggestors/constants.dart
@@ -53,9 +53,10 @@ class Link {
 
   /// A pattern for finding a link tag with a matching path.
   RegExp get pattern => RegExp(
-      r'(?<preceding_whitespace>[^\S\r\n]*)<link[^>]*href="(?<path_prefix>[^"]*)' +
-          pathSubpattern +
-          r'"[^>]*>(?<trailing_new_line>\n?)');
+    r'(?<preceding_whitespace>[^\S\r\n]*)<link[^>]*href="(?<path_prefix>[^"]*)' +
+        pathSubpattern +
+        r'"[^>]*>(?<trailing_new_line>\n?)',
+  );
 
   @override
   String toString() =>

--- a/lib/src/rmui_bundle_update_suggestors/dart_script_updater.dart
+++ b/lib/src/rmui_bundle_update_suggestors/dart_script_updater.dart
@@ -33,15 +33,17 @@ class DartScriptUpdater extends RecursiveAstVisitor<void>
   final bool updateAttributes;
   final bool removeTag;
 
-  DartScriptUpdater(this.existingScriptPath, this.newScriptPath,
-      {this.updateAttributes = true})
-      : removeTag = false;
+  DartScriptUpdater(
+    this.existingScriptPath,
+    this.newScriptPath, {
+    this.updateAttributes = true,
+  }) : removeTag = false;
 
   /// Use this constructor to remove the whole tag instead of updating it.
   DartScriptUpdater.remove(this.existingScriptPath)
-      : removeTag = true,
-        updateAttributes = false,
-        newScriptPath = 'will be ignored';
+    : removeTag = true,
+      updateAttributes = false,
+      newScriptPath = 'will be ignored';
 
   @override
   void visitSimpleStringLiteral(SimpleStringLiteral node) {
@@ -49,22 +51,22 @@ class DartScriptUpdater extends RecursiveAstVisitor<void>
     final stringValue = node.literal.lexeme;
 
     final relevantScriptTags = [
-      ...Script(pathSubpattern: existingScriptPath)
-          .pattern
-          .allMatches(stringValue),
+      ...Script(
+        pathSubpattern: existingScriptPath,
+      ).pattern.allMatches(stringValue),
       ...?(!removeTag
-          ? Script(pathSubpattern: newScriptPath)
-              .pattern
-              .allMatches(stringValue)
-          : null)
+          ? Script(
+              pathSubpattern: newScriptPath,
+            ).pattern.allMatches(stringValue)
+          : null),
     ];
     final relevantLinkTags = [
-      ...Link(pathSubpattern: existingScriptPath)
-          .pattern
-          .allMatches(stringValue),
+      ...Link(
+        pathSubpattern: existingScriptPath,
+      ).pattern.allMatches(stringValue),
       ...?(!removeTag
           ? Link(pathSubpattern: newScriptPath).pattern.allMatches(stringValue)
-          : null)
+          : null),
     ];
 
     // Do not update if neither the existingScriptPath nor newScriptPath are in the file.
@@ -99,8 +101,9 @@ class DartScriptUpdater extends RecursiveAstVisitor<void>
       for (final scriptTagMatch in relevantScriptTags) {
         final scriptTag = scriptTagMatch.group(0);
         if (scriptTag == null) continue;
-        final typeAttributes =
-            getAttributePattern('type').allMatches(scriptTag);
+        final typeAttributes = getAttributePattern(
+          'type',
+        ).allMatches(scriptTag);
         if (typeAttributes.isNotEmpty) {
           final attribute = typeAttributes.first;
           final value = attribute.group(1);
@@ -129,8 +132,9 @@ class DartScriptUpdater extends RecursiveAstVisitor<void>
       for (final linkTagMatch in relevantLinkTags) {
         final linkTag = linkTagMatch.group(0);
         if (linkTag == null) continue;
-        final crossOriginAttributes =
-            getAttributePattern('crossorigin').allMatches(linkTag);
+        final crossOriginAttributes = getAttributePattern(
+          'crossorigin',
+        ).allMatches(linkTag);
         if (crossOriginAttributes.isNotEmpty) {
           final attribute = crossOriginAttributes.first;
           final value = attribute.group(1);

--- a/lib/src/rmui_bundle_update_suggestors/html_script_updater.dart
+++ b/lib/src/rmui_bundle_update_suggestors/html_script_updater.dart
@@ -29,36 +29,38 @@ class HtmlScriptUpdater {
   final bool updateAttributes;
   final bool removeTag;
 
-  HtmlScriptUpdater(this.existingScriptPath, this.newScriptPath,
-      {this.updateAttributes = true})
-      : removeTag = false;
+  HtmlScriptUpdater(
+    this.existingScriptPath,
+    this.newScriptPath, {
+    this.updateAttributes = true,
+  }) : removeTag = false;
 
   /// Use this constructor to remove the whole tag instead of updating it.
   HtmlScriptUpdater.remove(this.existingScriptPath)
-      : removeTag = true,
-        updateAttributes = false,
-        newScriptPath = 'will be ignored';
+    : removeTag = true,
+      updateAttributes = false,
+      newScriptPath = 'will be ignored';
 
   Stream<Patch> call(FileContext context) async* {
     final relevantScriptTags = [
-      ...Script(pathSubpattern: existingScriptPath)
-          .pattern
-          .allMatches(context.sourceText),
+      ...Script(
+        pathSubpattern: existingScriptPath,
+      ).pattern.allMatches(context.sourceText),
       ...?(!removeTag
-          ? Script(pathSubpattern: newScriptPath)
-              .pattern
-              .allMatches(context.sourceText)
-          : null)
+          ? Script(
+              pathSubpattern: newScriptPath,
+            ).pattern.allMatches(context.sourceText)
+          : null),
     ];
     final relevantLinkTags = [
-      ...Link(pathSubpattern: existingScriptPath)
-          .pattern
-          .allMatches(context.sourceText),
+      ...Link(
+        pathSubpattern: existingScriptPath,
+      ).pattern.allMatches(context.sourceText),
       ...?(!removeTag
-          ? Link(pathSubpattern: newScriptPath)
-              .pattern
-              .allMatches(context.sourceText)
-          : null)
+          ? Link(
+              pathSubpattern: newScriptPath,
+            ).pattern.allMatches(context.sourceText)
+          : null),
     ];
 
     // Do not update if neither the existingScriptPath nor newScriptPath are in the file.
@@ -68,11 +70,7 @@ class HtmlScriptUpdater {
 
     if (removeTag) {
       for (final tag in [...relevantScriptTags, ...relevantLinkTags]) {
-        patches.add(Patch(
-          '',
-          tag.start,
-          tag.end,
-        ));
+        patches.add(Patch('', tag.start, tag.end));
       }
     } else {
       if (updateAttributes) {
@@ -80,8 +78,9 @@ class HtmlScriptUpdater {
         for (final scriptTagMatch in relevantScriptTags) {
           final scriptTag = scriptTagMatch.group(0);
           if (scriptTag == null) continue;
-          final typeAttributes =
-              getAttributePattern('type').allMatches(scriptTag);
+          final typeAttributes = getAttributePattern(
+            'type',
+          ).allMatches(scriptTag);
           if (typeAttributes.isNotEmpty) {
             final attribute = typeAttributes.first;
             final value = attribute.group(1);
@@ -89,21 +88,26 @@ class HtmlScriptUpdater {
               continue;
             } else {
               // If the value of the type attribute is not "module", overwrite it.
-              patches.add(Patch(
-                typeModuleAttribute,
-                scriptTagMatch.start + attribute.start,
-                scriptTagMatch.start + attribute.end,
-              ));
+              patches.add(
+                Patch(
+                  typeModuleAttribute,
+                  scriptTagMatch.start + attribute.start,
+                  scriptTagMatch.start + attribute.end,
+                ),
+              );
             }
           } else {
             // If the type attribute does not exist, add it.
-            final srcAttribute =
-                getAttributePattern('src').allMatches(scriptTag);
-            patches.add(Patch(
-              ' ${typeModuleAttribute}',
-              scriptTagMatch.start + srcAttribute.first.end,
-              scriptTagMatch.start + srcAttribute.first.end,
-            ));
+            final srcAttribute = getAttributePattern(
+              'src',
+            ).allMatches(scriptTag);
+            patches.add(
+              Patch(
+                ' ${typeModuleAttribute}',
+                scriptTagMatch.start + srcAttribute.first.end,
+                scriptTagMatch.start + srcAttribute.first.end,
+              ),
+            );
           }
         }
 
@@ -111,8 +115,9 @@ class HtmlScriptUpdater {
         for (final linkTagToMatch in relevantLinkTags) {
           final linkTag = linkTagToMatch.group(0);
           if (linkTag == null) continue;
-          final crossOriginAttributes =
-              getAttributePattern('crossorigin').allMatches(linkTag);
+          final crossOriginAttributes = getAttributePattern(
+            'crossorigin',
+          ).allMatches(linkTag);
           if (crossOriginAttributes.isNotEmpty) {
             final attribute = crossOriginAttributes.first;
             final value = attribute.group(1);
@@ -120,21 +125,26 @@ class HtmlScriptUpdater {
               continue;
             } else {
               // If the value of the crossorigin attribute is not "", overwrite it.
-              patches.add(Patch(
-                crossOriginAttribute,
-                linkTagToMatch.start + attribute.start,
-                linkTagToMatch.start + attribute.end,
-              ));
+              patches.add(
+                Patch(
+                  crossOriginAttribute,
+                  linkTagToMatch.start + attribute.start,
+                  linkTagToMatch.start + attribute.end,
+                ),
+              );
             }
           } else {
             // If the crossorigin attribute does not exist, add it.
-            final hrefAttribute =
-                getAttributePattern('href').allMatches(linkTag);
-            patches.add(Patch(
-              ' ${crossOriginAttribute}',
-              linkTagToMatch.start + hrefAttribute.first.end,
-              linkTagToMatch.start + hrefAttribute.first.end,
-            ));
+            final hrefAttribute = getAttributePattern(
+              'href',
+            ).allMatches(linkTag);
+            patches.add(
+              Patch(
+                ' ${crossOriginAttribute}',
+                linkTagToMatch.start + hrefAttribute.first.end,
+                linkTagToMatch.start + hrefAttribute.first.end,
+              ),
+            );
           }
         }
       }
@@ -142,11 +152,7 @@ class HtmlScriptUpdater {
       // Update existing path to new path.
       final scriptMatches = existingScriptPath.allMatches(context.sourceText);
       scriptMatches.forEach((match) async {
-        patches.add(Patch(
-          newScriptPath,
-          match.start,
-          match.end,
-        ));
+        patches.add(Patch(newScriptPath, match.start, match.end));
       });
     }
 

--- a/lib/src/rmui_preparation_suggestors/constants.dart
+++ b/lib/src/rmui_preparation_suggestors/constants.dart
@@ -17,16 +17,19 @@ const wkTheme = 'wkTheme';
 
 /// The script for the dev RMUI bundle.
 final rmuiBundleDev = ScriptToAdd(
-    path: 'packages/react_material_ui/react-material-ui-development.umd.js');
+  path: 'packages/react_material_ui/react-material-ui-development.umd.js',
+);
 
 /// The script for the prod RMUI bundle.
-final rmuiBundleProd =
-    ScriptToAdd(path: 'packages/react_material_ui/react-material-ui.umd.js');
+final rmuiBundleProd = ScriptToAdd(
+  path: 'packages/react_material_ui/react-material-ui.umd.js',
+);
 
 /// The script pattern for finding react-dart JS scripts.
 const reactJsScript = Script(
-    pathSubpattern: r'packages/react/react\w*.js',
-    includeTrailingNewLine: false);
+  pathSubpattern: r'packages/react/react\w*.js',
+  includeTrailingNewLine: false,
+);
 
 /// A script that can be searched for via a script tag [pattern] for a
 /// specific path ([pathSubpattern]).
@@ -34,8 +37,10 @@ class Script {
   final String pathSubpattern;
   final bool includeTrailingNewLine;
 
-  const Script(
-      {required this.pathSubpattern, this.includeTrailingNewLine = true});
+  const Script({
+    required this.pathSubpattern,
+    this.includeTrailingNewLine = true,
+  });
 
   /// A pattern for finding a script tag with a matching path,
   /// including preceding whitespace and any path prefix.
@@ -45,10 +50,11 @@ class Script {
   /// - [ScriptMatch.precedingWhitespaceGroup]
   /// - [ScriptMatch.pathPrefixGroup]
   RegExp get pattern => RegExp(
-      r'(?<preceding_whitespace>[^\S\r\n]*)<script.*src="(?<path_prefix>.*)' +
-          pathSubpattern +
-          r'".*</script>' +
-          (includeTrailingNewLine ? r'(?<trailing_new_line>\n?)' : ''));
+    r'(?<preceding_whitespace>[^\S\r\n]*)<script.*src="(?<path_prefix>.*)' +
+        pathSubpattern +
+        r'".*</script>' +
+        (includeTrailingNewLine ? r'(?<trailing_new_line>\n?)' : ''),
+  );
 
   @override
   String toString() =>
@@ -62,7 +68,7 @@ class ScriptToAdd extends Script {
   final String path;
 
   ScriptToAdd({required this.path})
-      : super(pathSubpattern: RegExp.escape(path));
+    : super(pathSubpattern: RegExp.escape(path));
 
   String scriptTag({required String pathPrefix}) =>
       '<script src="$pathPrefix$path"></script>';

--- a/lib/src/rmui_preparation_suggestors/dart_script_adder.dart
+++ b/lib/src/rmui_preparation_suggestors/dart_script_adder.dart
@@ -67,9 +67,11 @@ class DartScriptAdder extends RecursiveAstVisitor<void>
       }
     } else if (parent is ListLiteral) {
       // Do not add the script to the list if it is already there.
-      if (parent.elements.any((element) =>
-          element is SimpleStringLiteral &&
-          scriptToAdd.pattern.hasMatch(element.literal.lexeme))) {
+      if (parent.elements.any(
+        (element) =>
+            element is SimpleStringLiteral &&
+            scriptToAdd.pattern.hasMatch(element.literal.lexeme),
+      )) {
         return;
       }
 
@@ -80,9 +82,11 @@ class DartScriptAdder extends RecursiveAstVisitor<void>
       if (scriptMatch != null && isExactMatch) {
         // To avoid adding the [scriptToAdd] twice, verify that [node] is the
         // last matching react script in the list.
-        final lastMatchElement = parent.elements.lastWhere((element) =>
-            element is SimpleStringLiteral &&
-            reactJsScript.pattern.firstMatch(element.value) != null);
+        final lastMatchElement = parent.elements.lastWhere(
+          (element) =>
+              element is SimpleStringLiteral &&
+              reactJsScript.pattern.firstMatch(element.value) != null,
+        );
         if (node.offset != lastMatchElement.offset) return;
 
         // Only add [scriptToAdd] if it has the same prod/dev status as the

--- a/lib/src/rmui_preparation_suggestors/theme_provider_adder.dart
+++ b/lib/src/rmui_preparation_suggestors/theme_provider_adder.dart
@@ -55,13 +55,17 @@ class ThemeProviderAdder extends GeneralizingAstVisitor
         .toList()
         .isNotEmpty;
 
-    final themeProviderImport = imports.lastWhereOrNull((dir) =>
-        dir.uri.stringValue ==
-        'package:react_material_ui/styles/theme_provider.dart');
+    final themeProviderImport = imports.lastWhereOrNull(
+      (dir) =>
+          dir.uri.stringValue ==
+          'package:react_material_ui/styles/theme_provider.dart',
+    );
 
-    final reactDomImport = imports.lastWhereOrNull((dir) =>
-        (dir.uri.stringValue == 'package:react/react_dom.dart' ||
-            dir.uri.stringValue == 'package:over_react/react_dom.dart'));
+    final reactDomImport = imports.lastWhereOrNull(
+      (dir) =>
+          (dir.uri.stringValue == 'package:react/react_dom.dart' ||
+          dir.uri.stringValue == 'package:over_react/react_dom.dart'),
+    );
 
     // Don't update if no `react_dom.dart` import is found in the file or if
     // the namespace of the render call does not match the namespace of the
@@ -79,7 +83,8 @@ class ThemeProviderAdder extends GeneralizingAstVisitor
     if (!isPartOf && themeProviderImport == null) {
       if (reactDomImport == null) {
         throw StateError(
-            '`reactDomImport` should never be null here unless `isPartOf == true`');
+          '`reactDomImport` should never be null here unless `isPartOf == true`',
+        );
       }
       yieldPatch(
         '\nimport \'package:react_material_ui/styles/theme_provider.dart\';',

--- a/lib/src/unify_package_rename_suggestors/constants.dart
+++ b/lib/src/unify_package_rename_suggestors/constants.dart
@@ -55,7 +55,7 @@ final rmuiImportsToUpdate = [
     'package:unify_ui/components/usage_must_be_approved_by_unify_team_for_legal_reasons/data_grid_premium.dart',
     rmuiUri:
         'package:react_material_ui/components/usage_must_be_approved_by_unify_team_for_legal_reasons_rmui/data_grid_premium.dart',
-  )
+  ),
 ];
 
 /// A map of RMUI component names to their new names in unify_ui.

--- a/lib/src/unify_package_rename_suggestors/import_renamer.dart
+++ b/lib/src/unify_package_rename_suggestors/import_renamer.dart
@@ -33,38 +33,48 @@ Suggestor importRenamerSuggestorBuilder({
     // Parts that have not been generated can show up as `exists = false` but also `isPart = false`,
     // so using the unitResults is a little trickier than using the libraryElement to get it.
     final mainLibraryUnitResult = libraryResult.units.singleWhere(
-        (unitResult) =>
-            unitResult.unit.declaredElement ==
-            libraryResult.element.definingCompilationUnit);
+      (unitResult) =>
+          unitResult.unit.declaredElement ==
+          libraryResult.element.definingCompilationUnit,
+    );
 
     // Look for imports with old package name.
     final importsToUpdate = mainLibraryUnitResult.unit.directives
         .whereType<ImportDirective>()
-        .where((import) =>
-            import.uri.stringValue?.startsWith('package:$oldPackageName/') ??
-            false);
+        .where(
+          (import) =>
+              import.uri.stringValue?.startsWith('package:$oldPackageName/') ??
+              false,
+        );
 
     final newImportsInfo = <UnifyImportInfo>[];
     for (final import in importsToUpdate) {
       final importUri = import.uri.stringValue;
       final namespace = import.prefix?.name;
       var newImportUri = importUri?.replaceFirst(
-          'package:$oldPackageName/', 'package:$newPackageName/');
+        'package:$oldPackageName/',
+        'package:$newPackageName/',
+      );
 
       // Check for special cases where the unify_ui import path does not match the previous RMUI path.
-      final specialCaseRmuiImport =
-          rmuiImportsToUpdate.where((i) => importUri == i.rmuiUri);
+      final specialCaseRmuiImport = rmuiImportsToUpdate.where(
+        (i) => importUri == i.rmuiUri,
+      );
       if (specialCaseRmuiImport.isNotEmpty) {
         newImportUri = specialCaseRmuiImport.single.uri;
       }
 
       if (newImportUri != null) {
         // Collect info on new imports to add.
-        newImportsInfo.add(UnifyImportInfo(newImportUri,
+        newImportsInfo.add(
+          UnifyImportInfo(
+            newImportUri,
             namespace: namespace,
             showHideInfo: import.combinators.isEmpty
                 ? null
-                : import.combinators.map((c) => c.toSource()).join(' ')));
+                : import.combinators.map((c) => c.toSource()).join(' '),
+          ),
+        );
       }
 
       final prevTokenEnd = import.beginToken.previous?.end;
@@ -82,14 +92,18 @@ Suggestor importRenamerSuggestorBuilder({
 
     // Add imports in their alphabetical positions.
     for (final importInfo in newImportsInfo) {
-      final insertInfo = insertionLocationForPackageImport(importInfo.uri,
-          mainLibraryUnitResult.unit, mainLibraryUnitResult.lineInfo);
+      final insertInfo = insertionLocationForPackageImport(
+        importInfo.uri,
+        mainLibraryUnitResult.unit,
+        mainLibraryUnitResult.lineInfo,
+      );
       yield Patch(
-          insertInfo.leadingNewlines +
-              "import '${importInfo.uri}'${importInfo.namespace != null ? ' as ${importInfo.namespace}' : ''}${importInfo.showHideInfo != null ? ' ${importInfo.showHideInfo}' : ''};" +
-              insertInfo.trailingNewlines,
-          insertInfo.offset,
-          insertInfo.offset);
+        insertInfo.leadingNewlines +
+            "import '${importInfo.uri}'${importInfo.namespace != null ? ' as ${importInfo.namespace}' : ''}${importInfo.showHideInfo != null ? ' ${importInfo.showHideInfo}' : ''};" +
+            insertInfo.trailingNewlines,
+        insertInfo.offset,
+        insertInfo.offset,
+      );
     }
   };
 }

--- a/lib/src/unify_package_rename_suggestors/unify_rename_suggestor.dart
+++ b/lib/src/unify_package_rename_suggestors/unify_rename_suggestor.dart
@@ -48,7 +48,8 @@ class UnifyRenameSuggestor extends GeneralizingAstVisitor with ClassSuggestor {
       return;
     }
 
-    final identifier = node.tryCast<SimpleIdentifier>() ??
+    final identifier =
+        node.tryCast<SimpleIdentifier>() ??
         node.tryCast<PrefixedIdentifier>()?.identifier;
     final uri = identifier?.staticElement?.source?.uri;
     final prefix = node.tryCast<PrefixedIdentifier>()?.prefix;
@@ -72,7 +73,10 @@ class UnifyRenameSuggestor extends GeneralizingAstVisitor with ClassSuggestor {
       {
         // Update WSD constant properties objects to use the WSD versions if applicable.
         yieldWsdRenamePatchIfApplicable(
-            Expression node, String? objectName, String? propertyName) {
+          Expression node,
+          String? objectName,
+          String? propertyName,
+        ) {
           const wsdConstantNames = [
             'AlertSize',
             'AlertColor',
@@ -97,22 +101,29 @@ class UnifyRenameSuggestor extends GeneralizingAstVisitor with ClassSuggestor {
         // Check for namespaced `mui.ButtonColor.wsd...` usage.
         if (node is PrefixedIdentifier && parent is PropertyAccess) {
           yieldWsdRenamePatchIfApplicable(
-              parent, identifier?.name, parent.propertyName.name);
+            parent,
+            identifier?.name,
+            parent.propertyName.name,
+          );
         }
       }
 
       // Add comments for components that need manual verification.
       if (identifier?.name == 'Badge' || identifier?.name == 'LinearProgress') {
         yieldInsertionPatch(
-            lineComment(
-                'FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, manually QA this component and remove this FIXME; otherwise, migrate this component back to Web Skin Dart.'),
-            node.offset);
+          lineComment(
+            'FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, manually QA this component and remove this FIXME; otherwise, migrate this component back to Web Skin Dart.',
+          ),
+          node.offset,
+        );
       } else if (identifier?.name == 'Alert' ||
           identifier?.name == 'AlertPropsMixin') {
         yieldInsertionPatch(
-            lineComment(
-                'FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, update this to `${identifier?.name}` from `unify_ui/components/alert.dart`, manually QA this component, and remove this FIXME; otherwise, remove this FIXME.'),
-            node.offset);
+          lineComment(
+            'FIXME(unify_package_rename) Check what theme provider is wrapping this component: if it is a UnifyThemeProvider, update this to `${identifier?.name}` from `unify_ui/components/alert.dart`, manually QA this component, and remove this FIXME; otherwise, remove this FIXME.',
+          ),
+          node.offset,
+        );
       }
     }
   }
@@ -124,20 +135,25 @@ class UnifyRenameSuggestor extends GeneralizingAstVisitor with ClassSuggestor {
     final result = await context.getResolvedUnit();
     if (result == null) {
       throw Exception(
-          'Could not get resolved result for "${context.relativePath}"');
+        'Could not get resolved result for "${context.relativePath}"',
+      );
     }
     needsWsdImport = false;
     result.unit.visitChildren(this);
 
     if (needsWsdImport) {
       final insertInfo = insertionLocationForPackageImport(
-          unifyWsdUri, result.unit, result.lineInfo);
+        unifyWsdUri,
+        result.unit,
+        result.lineInfo,
+      );
       yieldPatch(
-          insertInfo.leadingNewlines +
-              "import '$unifyWsdUri';" +
-              insertInfo.trailingNewlines,
-          insertInfo.offset,
-          insertInfo.offset);
+        insertInfo.leadingNewlines +
+            "import '$unifyWsdUri';" +
+            insertInfo.trailingNewlines,
+        insertInfo.offset,
+        insertInfo.offset,
+      );
     }
   }
 

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -38,8 +38,13 @@ import 'package:source_span/source_span.dart';
 
 import 'constants.dart';
 
-typedef CompanionBuilder = String Function(String className,
-    {String? annotations, String? commentPrefix, String? docComment});
+typedef CompanionBuilder =
+    String Function(
+      String className, {
+      String? annotations,
+      String? commentPrefix,
+      String? docComment,
+    });
 
 /// Returns an iterable of all the comments from [beginToken] to the end of the
 /// file.
@@ -66,8 +71,10 @@ Iterable<Token> allComments(Token beginToken) sync* {
 }
 
 bool _isCommentToken(Token token) {
-  return const {TokenType.SINGLE_LINE_COMMENT, TokenType.MULTI_LINE_COMMENT}
-      .contains(token.type);
+  return const {
+    TokenType.SINGLE_LINE_COMMENT,
+    TokenType.MULTI_LINE_COMMENT,
+  }.contains(token.type);
 }
 
 /// Returns all the comments before a given [node], including doc comments.
@@ -207,7 +214,9 @@ final _usesOverReactRegex = RegExp(
 /// This can be used to update dependency ranges without lowering a current
 /// constraint unintentionally.
 VersionRange generateNewVersionRange(
-    VersionRange currentRange, VersionRange targetRange) {
+  VersionRange currentRange,
+  VersionRange targetRange,
+) {
   return VersionRange(
     min: currentRange.min! > targetRange.min!
         ? currentRange.min
@@ -243,8 +252,8 @@ String friendlyVersionConstraint(VersionConstraint constraint) {
 /// should be wrapped in quotations.
 bool mightNeedYamlEscaping(String scalarValue) =>
     // Values starting with `>` need escaping.
-// Whitelist a non-exhaustive list of allowable characters,
-// flagging that the value should be escaped when we're not sure.
+    // Whitelist a non-exhaustive list of allowable characters,
+    // flagging that the value should be escaped when we're not sure.
     !RegExp(r'^[^>][-+.<>=^ \w]*$').hasMatch(scalarValue);
 
 /// Parses a `--comment-prefix=<value>` command-line option from [args] if
@@ -283,28 +292,41 @@ String? parseAndRemoveCommentPrefixArg(List<String> args) {
 /// Locates the [commentToRemove] and - if found - removes it from the
 /// [node] using the [yieldPatch] provided.
 void removeCommentFromNode(
-    AstNode node, String commentToRemove, YieldPatch yieldPatch) {
+  AstNode node,
+  String commentToRemove,
+  YieldPatch yieldPatch,
+) {
   final nodeCommentLines = allComments(node.beginToken);
-  final commentLinesToRemove =
-      commentToRemove.split('\n').map((line) => line.trim()).toList();
+  final commentLinesToRemove = commentToRemove
+      .split('\n')
+      .map((line) => line.trim())
+      .toList();
   final firstLineOfCommentToRemove = commentLinesToRemove.first;
   final firstMatchingCommentLineToken = nodeCommentLines.firstWhereOrNull(
-      (token) => token.toString().trim() == firstLineOfCommentToRemove);
+    (token) => token.toString().trim() == firstLineOfCommentToRemove,
+  );
 
   if (firstMatchingCommentLineToken != null) {
     if (commentLinesToRemove.length == 1) {
       // Remove single line comment
-      yieldPatch('', firstMatchingCommentLineToken.offset,
-          firstMatchingCommentLineToken.end);
+      yieldPatch(
+        '',
+        firstMatchingCommentLineToken.offset,
+        firstMatchingCommentLineToken.end,
+      );
     } else {
       final lastLineOfCommentToRemove =
           commentLinesToRemove[commentLinesToRemove.length - 2];
       final lastMatchingCommentLineToken = nodeCommentLines.lastWhereOrNull(
-          (token) => token.toString().trim() == lastLineOfCommentToRemove);
+        (token) => token.toString().trim() == lastLineOfCommentToRemove,
+      );
       if (lastMatchingCommentLineToken != null) {
         // Remove multi line comment
-        yieldPatch('', firstMatchingCommentLineToken.offset,
-            lastMatchingCommentLineToken.end);
+        yieldPatch(
+          '',
+          firstMatchingCommentLineToken.offset,
+          lastMatchingCommentLineToken.end,
+        );
       }
     }
   }
@@ -406,15 +428,16 @@ Iterable<String> pubspecYamlPaths() => Directory.current
 Iterable<String> allHtmlPaths() =>
     filePathsFromGlob(Glob('**.html', recursive: true));
 
-Iterable<String> allHtmlPathsIncludingTemplates() => allHtmlPaths()
-    .followedBy(filePathsFromGlob(Glob('**.html.tpl', recursive: true)));
+Iterable<String> allHtmlPathsIncludingTemplates() => allHtmlPaths().followedBy(
+  filePathsFromGlob(Glob('**.html.tpl', recursive: true)),
+);
 
 Iterable<String> allDartPathsExceptHidden() =>
     filePathsFromGlob(Glob('**.dart', recursive: true));
 
-Iterable<String> allDartPathsExceptHiddenAndGenerated() =>
-    filePathsFromGlob(Glob('**.dart', recursive: true))
-        .where((path) => !path.endsWith('.g.dart'));
+Iterable<String> allDartPathsExceptHiddenAndGenerated() => filePathsFromGlob(
+  Glob('**.dart', recursive: true),
+).where((path) => !path.endsWith('.g.dart'));
 
 /// Returns whether or not [sourceText] contains invalid code.
 ///
@@ -460,7 +483,7 @@ extension IsA on DartType {
     InterfaceType self = this as InterfaceType;
 
     var supertypes = [
-      for (var type in self.element.allSupertypes) type.element.name
+      for (var type in self.element.allSupertypes) type.element.name,
     ];
     return supertypes.contains(typeName);
   }
@@ -488,7 +511,10 @@ VersionRange parseVersionRange(String text) {
   final constraint = VersionConstraint.parse(text);
   if (constraint is! VersionRange) {
     throw ArgumentError.value(
-        text, 'text', 'not a VersionRange; was a ${constraint.runtimeType}');
+      text,
+      'text',
+      'not a VersionRange; was a ${constraint.runtimeType}',
+    );
   }
   return constraint;
 }
@@ -516,17 +542,22 @@ extension IterableGroupBy<E> on Iterable<E> {
       collection.groupBy(this, key);
 }
 
-String prettyPrintErrors(Iterable<AnalysisError> errors,
-    {LineInfo? lineInfo, bool includeFilename = true}) {
-  return errors.map((e) {
-    final severity = e.errorCode.errorSeverity.name.toLowerCase();
-    final errorCode = e.errorCode.name.toLowerCase();
-    final location =
-        lineInfo?.getLocation(e.offset).toString() ?? 'offset ${e.offset}';
-    final filename = e.source.shortName;
+String prettyPrintErrors(
+  Iterable<AnalysisError> errors, {
+  LineInfo? lineInfo,
+  bool includeFilename = true,
+}) {
+  return errors
+      .map((e) {
+        final severity = e.errorCode.errorSeverity.name.toLowerCase();
+        final errorCode = e.errorCode.name.toLowerCase();
+        final location =
+            lineInfo?.getLocation(e.offset).toString() ?? 'offset ${e.offset}';
+        final filename = e.source.shortName;
 
-    return " - [$severity] ${e.message} ($errorCode at${includeFilename ? ' $filename' : ''} $location)";
-  }).join('\n');
+        return " - [$severity] ${e.message} ($errorCode at${includeFilename ? ' $filename' : ''} $location)";
+      })
+      .join('\n');
 }
 
 extension SpanForEntity on SourceFile {

--- a/lib/src/util/args.dart
+++ b/lib/src/util/args.dart
@@ -37,7 +37,9 @@ import 'package:args/args.dart';
 /// print(updatedArgs); // ['--baz=baz', 'positionalArg']
 /// ```
 List<String> removeOptionArgs(
-    List<String> args, Iterable<String> optionArgNames) {
+  List<String> args,
+  Iterable<String> optionArgNames,
+) {
   return optionArgNames.fold(args, (updatedArgs, argName) {
     return _removeOptionOrFlagArgs(updatedArgs, argName, isOption: true);
   });
@@ -69,8 +71,11 @@ List<String> removeFlagArgs(List<String> args, Iterable<String> flagArgNames) {
   });
 }
 
-List<String> _removeOptionOrFlagArgs(List<String> args, String argName,
-    {required bool isOption}) {
+List<String> _removeOptionOrFlagArgs(
+  List<String> args,
+  String argName, {
+  required bool isOption,
+}) {
   final updatedArgs = [...args];
 
   final argPattern = isOption
@@ -108,13 +113,15 @@ void addCodemodArgs(ArgParser argParser) => argParser
   ..addFlag(
     'yes-to-all',
     negatable: false,
-    help: 'Forces all patches accepted without prompting the user. '
+    help:
+        'Forces all patches accepted without prompting the user. '
         'Useful for scripts.',
   )
   ..addFlag(
     'fail-on-changes',
     negatable: false,
-    help: 'Returns a non-zero exit code if there are changes to be made. '
+    help:
+        'Returns a non-zero exit code if there are changes to be made. '
         'Will not make any changes (i.e. this is a dry-run).',
   )
   ..addFlag(

--- a/lib/src/util/class_suggestor.dart
+++ b/lib/src/util/class_suggestor.dart
@@ -30,8 +30,10 @@ mixin ClassSuggestor {
   /// The context helper for the file currently being visited.
   FileContext get context {
     if (_context != null) return _context!;
-    throw StateError('context accessed outside of a visiting context. '
-        'Ensure that your suggestor only accesses `this.context` inside an AST visitor method.');
+    throw StateError(
+      'context accessed outside of a visiting context. '
+      'Ensure that your suggestor only accesses `this.context` inside an AST visitor method.',
+    );
   }
 
   FileContext? _context;
@@ -57,22 +59,22 @@ mixin ClassSuggestor {
           .groupBy((patch) => patch.isInsertionPatch ? patch.startOffset : null)
           .entries
           .expand((entry) {
-        final isInsertionPatchGroup = entry.key != null;
-        if (!isInsertionPatchGroup) return entry.value;
+            final isInsertionPatchGroup = entry.key != null;
+            if (!isInsertionPatchGroup) return entry.value;
 
-        return entry.value.toList()
-          ..sort((a, b) {
-            if (a.updatedText == '(' && b.updatedText == '(') return 0;
-            if (a.updatedText == '(') return -1000;
-            if (b.updatedText == '(') return 1000;
+            return entry.value.toList()..sort((a, b) {
+              if (a.updatedText == '(' && b.updatedText == '(') return 0;
+              if (a.updatedText == '(') return -1000;
+              if (b.updatedText == '(') return 1000;
 
-            if (a.updatedText == ')' && b.updatedText == ')') return 0;
-            if (a.updatedText == ')') return 1000;
-            if (b.updatedText == ')') return -1000;
+              if (a.updatedText == ')' && b.updatedText == ')') return 0;
+              if (a.updatedText == ')') return 1000;
+              if (b.updatedText == ')') return -1000;
 
-            return entry.value.indexOf(a).compareTo(entry.value.indexOf(b));
-          });
-      }).toList();
+              return entry.value.indexOf(a).compareTo(entry.value.indexOf(b));
+            });
+          })
+          .toList();
     }
 
     yield* Stream.fromIterable(patches);

--- a/lib/src/util/command.dart
+++ b/lib/src/util/command.dart
@@ -14,24 +14,41 @@
 
 import 'dart:io';
 
-Future<String> runCommandAndThrowIfFailed(String command, List<String> args,
-    {String? workingDirectory, bool returnErr = false}) async {
-  final result =
-      await Process.run(command, args, workingDirectory: workingDirectory);
+Future<String> runCommandAndThrowIfFailed(
+  String command,
+  List<String> args, {
+  String? workingDirectory,
+  bool returnErr = false,
+}) async {
+  final result = await Process.run(
+    command,
+    args,
+    workingDirectory: workingDirectory,
+  );
 
   if (result.exitCode != 0) {
     throw ProcessException(
-        command, args, '${result.stdout}${result.stderr}', result.exitCode);
+      command,
+      args,
+      '${result.stdout}${result.stderr}',
+      result.exitCode,
+    );
   }
 
   return ((returnErr ? result.stderr : result.stdout) as String).trim();
 }
 
 Future<void> runCommandAndThrowIfFailedInheritIo(
-    String command, List<String> args,
-    {String? workingDirectory}) async {
-  final process = await Process.start(command, args,
-      workingDirectory: workingDirectory, mode: ProcessStartMode.inheritStdio);
+  String command,
+  List<String> args, {
+  String? workingDirectory,
+}) async {
+  final process = await Process.start(
+    command,
+    args,
+    workingDirectory: workingDirectory,
+    mode: ProcessStartMode.inheritStdio,
+  );
 
   final exitCode = await process.exitCode;
 

--- a/lib/src/util/command_runner.dart
+++ b/lib/src/util/command_runner.dart
@@ -52,9 +52,9 @@ extension CommandExtension on Command {
 
   /// Same as [invocationPrefix], but doesn't include the current command.
   String get parentInvocationPrefix => <String>[
-        ...parentCommands.map((p) => p.name),
-        runner!.executableName,
-      ].reversed.join(' ');
+    ...parentCommands.map((p) => p.name),
+    runner!.executableName,
+  ].reversed.join(' ');
 
   Iterable<Command> get parentCommands sync* {
     final parent = this.parent;

--- a/lib/src/util/component_usage.dart
+++ b/lib/src/util/component_usage.dart
@@ -105,8 +105,8 @@ class FluentComponentUsage {
 
     final builder = this.builder;
     if (builder is MethodInvocation) {
-      final methodElement =
-          builder.methodName.staticElement?.tryCast<MethodElement>();
+      final methodElement = builder.methodName.staticElement
+          ?.tryCast<MethodElement>();
       if (methodElement != null && methodElement.isStatic) {
         final className = methodElement.enclosingElement.name;
         if (className != null) {
@@ -184,9 +184,9 @@ class FluentComponentUsage {
   ///
   /// See also: other `cascaded`* methods in this class.
   Iterable<BuilderMethodInvocation> get cascadedMethodInvocations =>
-      cascadeSections
-          .whereType<MethodInvocation>()
-          .map((methodInvocation) => BuilderMethodInvocation(methodInvocation));
+      cascadeSections.whereType<MethodInvocation>().map(
+        (methodInvocation) => BuilderMethodInvocation(methodInvocation),
+      );
 
   /// All the cascades on this usage's builder, each wrapped in one of the
   /// [BuilderMemberAccess] subtypes.
@@ -205,10 +205,7 @@ class FluentComponentUsage {
         .map((section) => OtherBuilderMemberAccess(section))
         .toList();
 
-    return [
-      ...allHandledMembers,
-      ...allUnhandledMembers,
-    ]
+    return [...allHandledMembers, ...allUnhandledMembers]
       // Order them in the order they appear by sorting based on the offset.
       ..sort((a, b) => a.node.offset.compareTo(b.node.offset));
   }
@@ -454,8 +451,8 @@ class _PropertyAccessStateAssignment extends StateAssignment {
   final AssignmentExpression node;
 
   _PropertyAccessStateAssignment(this.node)
-      : assert(node.leftHandSide is PropertyAccess),
-        super._();
+    : assert(node.leftHandSide is PropertyAccess),
+      super._();
 
   /// The property access representing the left hand side of this assignment.
   @override
@@ -496,8 +493,8 @@ class _PropertyAccessPropAssignment extends PropAssignment {
   final AssignmentExpression node;
 
   _PropertyAccessPropAssignment(this.node)
-      : assert(node.leftHandSide is PropertyAccess),
-        super._();
+    : assert(node.leftHandSide is PropertyAccess),
+      super._();
 
   /// The property access representing the left hand side of this assignment.
   @override
@@ -643,9 +640,11 @@ FluentComponentUsage? getComponentUsage(InvocationExpression node) {
         if (builderName != null) {
           isComponent =
               RegExp(r'(?:^|\.)Dom\.[a-z0-9]+$').hasMatch(builderName) ||
-                  RegExp(r'factory|builder', caseSensitive: false)
-                      .hasMatch(builderName) ||
-                  RegExp(r'(?:^|\.)[A-Z][^\.]*$').hasMatch(builderName);
+              RegExp(
+                r'factory|builder',
+                caseSensitive: false,
+              ).hasMatch(builderName) ||
+              RegExp(r'(?:^|\.)[A-Z][^\.]*$').hasMatch(builderName);
         } else {
           isComponent = false;
         }
@@ -657,8 +656,10 @@ FluentComponentUsage? getComponentUsage(InvocationExpression node) {
           methodNameBlockList.contains(builder.name)) {
         isComponent = false;
       } else {
-        isComponent =
-            RegExp(r'builder', caseSensitive: false).hasMatch(builder.name);
+        isComponent = RegExp(
+          r'builder',
+          caseSensitive: false,
+        ).hasMatch(builder.name);
       }
     } else {
       isComponent = false;

--- a/lib/src/util/component_usage_migrator.dart
+++ b/lib/src/util/component_usage_migrator.dart
@@ -138,16 +138,19 @@ abstract class ComponentUsageMigrator with ClassSuggestor {
     final result = await context.getResolvedUnit();
     if (result == null) {
       throw Exception(
-          'Could not get resolved result for "${context.relativePath}"');
+        'Could not get resolved result for "${context.relativePath}"',
+      );
     }
     final allUsages = <FluentComponentUsage>[];
     result.unit.accept(ComponentUsageVisitor(allUsages.add));
 
     for (final usage in allUsages) {
       if (_isIgnored(usage, result.unit)) {
-        _log.finest(context.sourceFile
-            .spanFor(usage.factory ?? usage.builder)
-            .message('Skipping ignored usage'));
+        _log.finest(
+          context.sourceFile
+              .spanFor(usage.factory ?? usage.builder)
+              .message('Skipping ignored usage'),
+        );
         continue;
       }
 
@@ -178,28 +181,33 @@ abstract class ComponentUsageMigrator with ClassSuggestor {
   /// This allows custom migration code to assume that all usages are fully resolved,
   /// and thus can rely on static typing and other static information being available.
   void _verifyUsageIsResolved(
-      FluentComponentUsage usage, ResolvedUnitResult result) {
+    FluentComponentUsage usage,
+    ResolvedUnitResult result,
+  ) {
     String errorsMessage() => result.errors.isEmpty
         ? ''
         : ' \nAnalysis errors in file:\n${prettyPrintErrors(result.errors)}\n'
-            // TODO - reference analyzer issue for this once it's created
-            'If this is a part file and all of its imported members seem to be unresolved,'
-            ' make sure its library is resolved first.';
+              // TODO - reference analyzer issue for this once it's created
+              'If this is a part file and all of its imported members seem to be unresolved,'
+              ' make sure its library is resolved first.';
     final staticType = usage.builder.staticType;
     if (staticType == null || staticType.isDynamic) {
       final typeDescription = staticType == null
           ? 'null'
           : 'type \'${staticType.getDisplayString(withNullability: false)}\'';
       throw _unresolvedException(
-          'Builder static type could not be resolved; was $typeDescription. ${errorsMessage()}',
-          usage.builder);
+        'Builder static type could not be resolved; was $typeDescription. ${errorsMessage()}',
+        usage.builder,
+      );
     }
     final factory = usage.factory;
     if (factory != null) {
       if (factory.staticType == null ||
           (factory is Identifier && factory.staticElement == null)) {
         throw _unresolvedException(
-            'Factory could not be resolved. ${errorsMessage()}', factory);
+          'Factory could not be resolved. ${errorsMessage()}',
+          factory,
+        );
       }
     }
   }
@@ -267,7 +275,9 @@ abstract class ComponentUsageMigrator with ClassSuggestor {
               final expression = method.node.argumentList.arguments.firstOrNull;
               if (expression != null && !_isDataAttributePropKey(expression)) {
                 yieldBuilderMemberFixmePatch(
-                    method, '$name - manually verify prop key');
+                  method,
+                  '$name - manually verify prop key',
+                );
               }
             }
             break;
@@ -283,7 +293,9 @@ abstract class ComponentUsageMigrator with ClassSuggestor {
       if (shouldFlagExtensionMembers && prop.isExtensionMethod) {
         // Flag extension methods, since they could do anything.
         yieldBuilderMemberFixmePatch(
-            prop, '${prop.name.name} (extension) - manually verify');
+          prop,
+          '${prop.name.name} (extension) - manually verify',
+        );
       } else if (shouldFlagRefProp && prop.name.name == 'ref') {
         // Flag refs, since their type is likely to change.
         yieldPropFixmePatch(prop, 'manually verify ref type is correct');
@@ -293,14 +305,18 @@ abstract class ComponentUsageMigrator with ClassSuggestor {
           prop.prefix != null &&
           !safePropPrefixes.contains(prop.prefix!.name)) {
         yieldBuilderMemberFixmePatch(
-            prop, '${prop.prefix!.name} (prefix) - manually verify');
+          prop,
+          '${prop.prefix!.name} (prefix) - manually verify',
+        );
       }
     }
 
     for (final prop in usage.cascadedIndexAssignments) {
       if (shouldFlagUntypedSingleProp && !_isDataAttributePropKey(prop.index)) {
         yieldBuilderMemberFixmePatch(
-            prop, 'operator[]= - manually verify prop key');
+          prop,
+          'operator[]= - manually verify prop key',
+        );
       }
     }
 
@@ -308,7 +324,9 @@ abstract class ComponentUsageMigrator with ClassSuggestor {
       if (shouldFlagExtensionMembers && prop.isExtensionMethod) {
         // Flag extension methods, since they could do anything.
         yieldBuilderMemberFixmePatch(
-            prop, '${prop.name.name} (extension) - manually verify');
+          prop,
+          '${prop.name.name} (extension) - manually verify',
+        );
       }
     }
   }
@@ -334,17 +352,21 @@ abstract class ComponentUsageMigrator with ClassSuggestor {
   ///
   /// Automatically adds parentheses around the builder if they don't already
   /// exist.
-  void yieldAddPropPatch(FluentComponentUsage usage, String newPropCascade,
-      {NewPropPlacement placement = NewPropPlacement.auto}) {
+  void yieldAddPropPatch(
+    FluentComponentUsage usage,
+    String newPropCascade, {
+    NewPropPlacement placement = NewPropPlacement.auto,
+  }) {
     final function = usage.node.function;
     if (function is ParenthesizedExpression) {
-      int getInsertionOffsetWithinBuilderOnNextLineIfPossible(int offset) =>
-          min(
-            context.sourceFile.getOffsetOfLineAfter(offset),
-            // Ensure this position isn't outside of the cascade parens
-            // (e.g., single-line cascade, multiline cascade with non-aligned right paren).
-            function.rightParenthesis.offset,
-          );
+      int getInsertionOffsetWithinBuilderOnNextLineIfPossible(
+        int offset,
+      ) => min(
+        context.sourceFile.getOffsetOfLineAfter(offset),
+        // Ensure this position isn't outside of the cascade parens
+        // (e.g., single-line cascade, multiline cascade with non-aligned right paren).
+        function.rightParenthesis.offset,
+      );
 
       // If this is null, we default to right after the invocation.
       final int offset;
@@ -352,8 +374,9 @@ abstract class ComponentUsageMigrator with ClassSuggestor {
         case NewPropPlacement.auto:
           // Try to insert it after other props that aren't method calls or index expressions,
           // or members typically inserted at the end like addTestId, key, and ref.
-          final propToInsertAfter =
-              usage.cascadedMembers.lastWhereOrNull((element) {
+          final propToInsertAfter = usage.cascadedMembers.lastWhereOrNull((
+            element,
+          ) {
             if (element is BuilderMethodInvocation) {
               return false;
             } else if (element is PropAssignment) {
@@ -363,21 +386,26 @@ abstract class ComponentUsageMigrator with ClassSuggestor {
               return false;
             } else {
               throw ArgumentError.value(
-                  element, 'element', 'Unhandled BuilderMemberAccess subtype');
+                element,
+                'element',
+                'Unhandled BuilderMemberAccess subtype',
+              );
             }
           });
           // Insert at the beginning of the next line so that we're not fighting with
           // insertions at the beginning of that prop (e.g., fix-me comments).
           offset = propToInsertAfter != null
               ? getInsertionOffsetWithinBuilderOnNextLineIfPossible(
-                  propToInsertAfter.node.end)
+                  propToInsertAfter.node.end,
+                )
               : function.rightParenthesis.offset;
           break;
         case NewPropPlacement.start:
           // TODO would it be better formatting and insertion-wise to attempt to insert at the beginning of the line of the first prop (similar to above)?
           offset = usage.cascadeExpression != null
               ? getInsertionOffsetWithinBuilderOnNextLineIfPossible(
-                  usage.cascadeExpression!.offset)
+                  usage.cascadeExpression!.offset,
+                )
               : function.rightParenthesis.offset;
           break;
         case NewPropPlacement.end:
@@ -479,7 +507,9 @@ abstract class ComponentUsageMigrator with ClassSuggestor {
     if (additionalCascadeSection != null) {
       // Add spaces so that dartfmt has a better time in case the cascade section has leading line comments
       yieldInsertionPatch(
-          '\n  $additionalCascadeSection', prop.rightHandSide.end);
+        '\n  $additionalCascadeSection',
+        prop.rightHandSide.end,
+      );
     }
   }
 
@@ -492,7 +522,9 @@ abstract class ComponentUsageMigrator with ClassSuggestor {
   /// with a custom [message].
   void yieldUsageFixmePatch(FluentComponentUsage usage, String message) {
     yieldInsertionPatch(
-        lineComment('$fixmePrefix $message'), usage.node.offset);
+      lineComment('$fixmePrefix $message'),
+      usage.node.offset,
+    );
   }
 
   void yieldPropManualMigratePatch(PropAssignment prop) {
@@ -548,20 +580,24 @@ abstract class ComponentUsageMigrator with ClassSuggestor {
   /// )();
   /// ```
   void yieldBuilderMemberFixmePatch(
-      BuilderMemberAccess access, String message) {
+    BuilderMemberAccess access,
+    String message,
+  ) {
     // Add an extra newline beforehand so that the comment doesn't end up on
     // the same line as the cascade target (the builder) in single-prop cascades.
     // Add a space so that dartfmt indents comment with the next line as opposed to
     // keeping it at the beginning of the line.
     // This formatting makes the output nicer, but more importantly it keeps
     // formatting of expected output in tests more consistent and easier to predict.
-    final needsLeadingNewline = access.parentCascade != null &&
+    final needsLeadingNewline =
+        access.parentCascade != null &&
         context.sourceFile.getLine(access.parentCascade!.target.end) ==
             context.sourceFile.getLine(access.node.offset);
     yieldInsertionPatch(
-        (needsLeadingNewline ? '\n ' : '') +
-            lineComment('$fixmePrefix - $message'),
-        access.node.offset);
+      (needsLeadingNewline ? '\n ' : '') +
+          lineComment('$fixmePrefix - $message'),
+      access.node.offset,
+    );
   }
 
   /// Yields a patch with a fix-me comment before a given [child]
@@ -593,16 +629,20 @@ abstract class ComponentUsageMigrator with ClassSuggestor {
     // keeping it at the beginning of the line.
     // This formatting makes the output nicer, but more importantly it keeps
     // formatting of expected output in tests more consistent and easier to predict.
-    final needsLeadingNewline = context.sourceFile.getLine(child.node.parent!
-            .thisOrAncestorOfType<InvocationExpression>()!
-            .argumentList
-            .leftParenthesis
-            .end) ==
+    final needsLeadingNewline =
+        context.sourceFile.getLine(
+          child.node.parent!
+              .thisOrAncestorOfType<InvocationExpression>()!
+              .argumentList
+              .leftParenthesis
+              .end,
+        ) ==
         context.sourceFile.getLine(child.node.offset);
     yieldInsertionPatch(
-        (needsLeadingNewline ? '\n ' : '') +
-            lineComment('$fixmePrefix - $message'),
-        child.node.beginToken.offset);
+      (needsLeadingNewline ? '\n ' : '') +
+          lineComment('$fixmePrefix - $message'),
+      child.node.beginToken.offset,
+    );
   }
 
   static final _ignoreInfoForUnitCache = Expando<OrcmIgnoreInfo>();
@@ -611,8 +651,10 @@ abstract class ComponentUsageMigrator with ClassSuggestor {
   ///
   /// See [ComponentUsageMigrator] for comment formats.
   bool _isIgnored(FluentComponentUsage usage, CompilationUnit unit) {
-    final ignoreInfo = _ignoreInfoForUnitCache[unit] ??=
-        OrcmIgnoreInfo.forDart(unit, context.sourceText);
+    final ignoreInfo = _ignoreInfoForUnitCache[unit] ??= OrcmIgnoreInfo.forDart(
+      unit,
+      context.sourceText,
+    );
     // IgnoreInfo's line numbers are 1-based,
     // whereas SourceFile's are 0-based
     final line = context.sourceFile.getLine(usage.node.offset) + 1;
@@ -650,15 +692,21 @@ enum NewPropPlacement {
 /// Returns the values in [propNames] that do not correspond to the names of
 /// statically declared props in [usage]'s static type.
 Iterable<String> _getUnknownPropNames(
-    FluentComponentUsage usage, Iterable<String> propNames) {
+  FluentComponentUsage usage,
+  Iterable<String> propNames,
+) {
   final propsClassElement = usage.propsClassElement;
   if (propsClassElement != null) {
-    final library =
-        usage.builder.root.tryCast<CompilationUnit>()?.declaredElement!.library;
+    final library = usage.builder.root
+        .tryCast<CompilationUnit>()
+        ?.declaredElement!
+        .library;
     if (library != null) {
       return propNames
-          .where((propName) =>
-              propsClassElement.lookUpSetter(propName, library) == null)
+          .where(
+            (propName) =>
+                propsClassElement.lookUpSetter(propName, library) == null,
+          )
           .toList();
     }
   }
@@ -674,15 +722,18 @@ Iterable<String> _getUnknownPropNames(
 PropAssignment? getFirstPropWithName(FluentComponentUsage usage, String name) {
   final unknownPropNames = _getUnknownPropNames(usage, [name]);
   if (unknownPropNames.isNotEmpty) {
-    throw ArgumentError("prop '$name' is"
-        " not statically available on builder class '${usage.propsClassElement?.name}'"
-        " (declared in ${usage.propsClassElement?.enclosingElement.source.uri})."
-        " Double-check that that prop exists in that props class"
-        " and that the key in 'migratorsByName' does not have any typos.");
+    throw ArgumentError(
+      "prop '$name' is"
+      " not statically available on builder class '${usage.propsClassElement?.name}'"
+      " (declared in ${usage.propsClassElement?.enclosingElement.source.uri})."
+      " Double-check that that prop exists in that props class"
+      " and that the key in 'migratorsByName' does not have any typos.",
+    );
   }
 
-  return usage.cascadedProps
-      .firstWhereOrNull((element) => element.name.name == name);
+  return usage.cascadedProps.firstWhereOrNull(
+    (element) => element.name.name == name,
+  );
 }
 
 /// Iterates over the cascaded prop assignments in [usage] and calls the matching
@@ -712,11 +763,12 @@ void handleCascadedPropsByName(
   final unknownPropNames = _getUnknownPropNames(usage, propHandlersByName.keys);
   if (unknownPropNames.isNotEmpty) {
     throw ArgumentError(
-        "'migratorsByName' contains unknown prop name(s) '$unknownPropNames'"
-        " not statically available on builder class '${usage.propsClassElement?.name}'"
-        " (declared in ${usage.propsClassElement?.enclosingElement.source.uri})."
-        " Double-check that that prop exists in that props class"
-        " and that the key in 'migratorsByName' does not have any typos.");
+      "'migratorsByName' contains unknown prop name(s) '$unknownPropNames'"
+      " not statically available on builder class '${usage.propsClassElement?.name}'"
+      " (declared in ${usage.propsClassElement?.enclosingElement.source.uri})."
+      " Double-check that that prop exists in that props class"
+      " and that the key in 'migratorsByName' does not have any typos.",
+    );
   }
 
   for (final prop in usage.cascadedProps) {

--- a/lib/src/util/element_type_helpers.dart
+++ b/lib/src/util/element_type_helpers.dart
@@ -27,8 +27,10 @@ extension TypeHelpers on DartType {
     final element = typeOrBound.element;
     return element is InterfaceElement &&
         (element.isElementFromPackage(typeName, packageName) ||
-            element.allSupertypes.any((type) =>
-                type.element.isElementFromPackage(typeName, packageName)));
+            element.allSupertypes.any(
+              (type) =>
+                  type.element.isElementFromPackage(typeName, packageName),
+            ));
   }
 }
 

--- a/lib/src/util/get_all_state.dart
+++ b/lib/src/util/get_all_state.dart
@@ -38,9 +38,11 @@ List<FieldElement> getAllState(InterfaceElement stateElement) {
   // There are two UiState; one in component_base, and one in builder_helpers that extends from it.
   // Use the component_base one, since there are some edge-cases of props that don't extend from the
   // builder_helpers version.
-  final uiStateElement = stateAndSupertypeElements.firstWhereOrNull((i) =>
-      i.name == 'UiState' &&
-      i.library.name == 'over_react.component_declaration.component_base');
+  final uiStateElement = stateAndSupertypeElements.firstWhereOrNull(
+    (i) =>
+        i.name == 'UiState' &&
+        i.library.name == 'over_react.component_declaration.component_base',
+  );
 
   // If stateElement does not inherit from from UiState, it could still be a legacy mixin that doesn't implement UiState.
   // This check is only necessary to retrieve props when [stateElement] is itself a legacy mixin, and not when legacy
@@ -59,15 +61,18 @@ List<FieldElement> getAllState(InterfaceElement stateElement) {
     if (uiStateAndSupertypeElements?.contains(interface) ?? false) continue;
 
     // Filter out generated accessors mixins for legacy concrete props classes.
-    late final isFromGeneratedFile =
-        interface.source.uri.path.endsWith('.over_react.g.dart');
+    late final isFromGeneratedFile = interface.source.uri.path.endsWith(
+      '.over_react.g.dart',
+    );
     if (interface.name.endsWith('AccessorsMixin') && isFromGeneratedFile) {
       continue;
     }
 
-    final isMixinBasedPropsMixin = interface is MixinElement &&
+    final isMixinBasedPropsMixin =
+        interface is MixinElement &&
         interface.superclassConstraints.any((s) => s.element.name == 'UiState');
-    late final isLegacyStateOrStateMixinConsumerClass = !isFromGeneratedFile &&
+    late final isLegacyStateOrStateMixinConsumerClass =
+        !isFromGeneratedFile &&
         interface.metadata.any(_isStateOrStateMixinAnnotation);
 
     if (!isMixinBasedPropsMixin && !isLegacyStateOrStateMixinConsumerClass) {
@@ -79,7 +84,8 @@ List<FieldElement> getAllState(InterfaceElement stateElement) {
       if (field.isSynthetic) continue;
 
       final accessorAnnotation = _getAccessorAnnotation(field.metadata);
-      final isNoGenerate = accessorAnnotation
+      final isNoGenerate =
+          accessorAnnotation
               ?.computeConstantValue()
               ?.getField('doNotGenerate')
               ?.toBoolValue() ??
@@ -119,9 +125,13 @@ ElementAnnotation? _getAccessorAnnotation(List<ElementAnnotation> metadata) {
 extension on InterfaceElement {
   // Two separate collection implementations to micro-optimize collection creation/iteration based on usage.
 
-  Set<InterfaceElement> get thisAndSupertypesSet =>
-      {this, for (final s in allSupertypes) s.element};
+  Set<InterfaceElement> get thisAndSupertypesSet => {
+    this,
+    for (final s in allSupertypes) s.element,
+  };
 
-  List<InterfaceElement> get thisAndSupertypesList =>
-      [this, for (final s in allSupertypes) s.element];
+  List<InterfaceElement> get thisAndSupertypesList => [
+    this,
+    for (final s in allSupertypes) s.element,
+  ];
 }

--- a/lib/src/util/ignore_info.dart
+++ b/lib/src/util/ignore_info.dart
@@ -55,10 +55,8 @@ class OrcmIgnoreInfo {
   final List<_Ignore> _ignoredForFile = [];
 
   @override
-  String toString() => 'OrcmIgnoreInfo ${{
-        '_ignoredOnLine': _ignoredOnLine,
-        '_ignoredForFile': _ignoredForFile,
-      }}';
+  String toString() =>
+      'OrcmIgnoreInfo ${{'_ignoredOnLine': _ignoredOnLine, '_ignoredForFile': _ignoredForFile}}';
 
   /// Initialize a newly created instance of this class to represent the ignore
   /// comments in the given compilation [unit].
@@ -71,10 +69,9 @@ class OrcmIgnoreInfo {
         final location = lineInfo.getLocation(ignoreComment.comment.offset);
         var lineNumber = location.lineNumber;
         final beforeMatch = content.substring(
-            lineInfo.getOffsetOfLine(lineNumber - 1),
-            lineInfo.getOffsetOfLine(lineNumber - 1) +
-                location.columnNumber -
-                1);
+          lineInfo.getOffsetOfLine(lineNumber - 1),
+          lineInfo.getOffsetOfLine(lineNumber - 1) + location.columnNumber - 1,
+        );
         if (beforeMatch.trim().isEmpty) {
           // The comment is on its own line, so it refers to the next line.
           lineNumber++;
@@ -150,8 +147,10 @@ extension on CompilationUnit {
   ///     * ['// orcm_ignore: code', 'code']
   ///
   /// Resulting codes may be in a list ('code_1,code2').
-  static final RegExp _IGNORE_MATCHER =
-      RegExp(r'//+[ ]*orcm_ignore(:(.*))?\s*$', multiLine: true);
+  static final RegExp _IGNORE_MATCHER = RegExp(
+    r'//+[ ]*orcm_ignore(:(.*))?\s*$',
+    multiLine: true,
+  );
 
   /// A regular expression for matching 'ignore_for_file' comments.  Produces
   /// matches containing 2 groups.  For example:
@@ -159,8 +158,10 @@ extension on CompilationUnit {
   ///     * ['// orcm_ignore_for_file: code', 'code']
   ///
   /// Resulting codes may be in a list ('code_1,code2').
-  static final RegExp _IGNORE_FOR_FILE_MATCHER =
-      RegExp(r'//[ ]*orcm_ignore_for_file(:(.*))?\s*$', multiLine: true);
+  static final RegExp _IGNORE_FOR_FILE_MATCHER = RegExp(
+    r'//[ ]*orcm_ignore_for_file(:(.*))?\s*$',
+    multiLine: true,
+  );
 
   static List<_Ignore> _getIgnoresForMatch(Match match) {
     if (match.group(1) == null) return [_Ignore.all()];
@@ -175,10 +176,13 @@ extension on CompilationUnit {
   }
 
   static Iterable<IgnoreComment> _processPrecedingComments(
-      Token currentToken) sync* {
-    for (Token? comment = currentToken.precedingComments;
-        comment != null;
-        comment = comment.next) {
+    Token currentToken,
+  ) sync* {
+    for (
+      Token? comment = currentToken.precedingComments;
+      comment != null;
+      comment = comment.next
+    ) {
       final lexeme = comment.lexeme;
       var match = _IGNORE_MATCHER.matchAsPrefix(lexeme);
       if (match != null) {

--- a/lib/src/util/importer.dart
+++ b/lib/src/util/importer.dart
@@ -33,9 +33,10 @@ Suggestor importerSuggestorBuilder({
     // Parts that have not been generated can show up as `exists = false` but also `isPart = false`,
     // so using the unitResults is a little trickier than using the libraryElement to get it.
     final mainLibraryUnitResult = libraryResult.units.singleWhere(
-        (unitResult) =>
-            unitResult.unit.declaredElement ==
-            libraryResult.element.definingCompilationUnit);
+      (unitResult) =>
+          unitResult.unit.declaredElement ==
+          libraryResult.element.definingCompilationUnit,
+    );
 
     // Look for errors in the main compilation unit and its part files.
     // Ignore null partContexts and partContexts elements caused by
@@ -43,19 +44,25 @@ Suggestor importerSuggestorBuilder({
     final needsImport = libraryResult.units
         .expand((unitResult) => unitResult.errors)
         .where((error) => error.errorCode.name == 'UNDEFINED_IDENTIFIER')
-        .any((error) =>
-            error.message.contains("Undefined name '$importNamespace'"));
+        .any(
+          (error) =>
+              error.message.contains("Undefined name '$importNamespace'"),
+        );
 
     if (!needsImport) return;
 
     final insertInfo = insertionLocationForPackageImport(
-        importUri, mainLibraryUnitResult.unit, mainLibraryUnitResult.lineInfo);
+      importUri,
+      mainLibraryUnitResult.unit,
+      mainLibraryUnitResult.lineInfo,
+    );
     yield Patch(
-        insertInfo.leadingNewlines +
-            "import '$importUri' as $importNamespace;" +
-            insertInfo.trailingNewlines,
-        insertInfo.offset,
-        insertInfo.offset);
+      insertInfo.leadingNewlines +
+          "import '$importUri' as $importNamespace;" +
+          insertInfo.trailingNewlines,
+      insertInfo.offset,
+      insertInfo.offset,
+    );
   };
 }
 
@@ -80,16 +87,21 @@ class _InsertionLocation {
 /// otherwise inserting it in a new section relative to other imports
 /// or other directives.
 _InsertionLocation insertionLocationForPackageImport(
-    String importUri, CompilationUnit unit, LineInfo lineInfo) {
+  String importUri,
+  CompilationUnit unit,
+  LineInfo lineInfo,
+) {
   final imports = unit.directives.whereType<ImportDirective>();
   final firstImport = imports.firstOrNull;
 
-  final dartImports =
-      imports.where((i) => i.uri.stringValue?.startsWith('dart:') ?? false);
+  final dartImports = imports.where(
+    (i) => i.uri.stringValue?.startsWith('dart:') ?? false,
+  );
   final lastDartImport = dartImports.lastOrNull;
 
-  final packageImports =
-      imports.where((i) => i.uri.stringValue?.startsWith('package:') ?? false);
+  final packageImports = imports.where(
+    (i) => i.uri.stringValue?.startsWith('package:') ?? false,
+  );
   final firstPackageImportSortedAfterNewImport = packageImports
       .where((i) => i.uri.stringValue!.compareTo(importUri) > 0)
       .firstOrNull;
@@ -97,8 +109,9 @@ _InsertionLocation insertionLocationForPackageImport(
       .where((i) => i.uri.stringValue!.compareTo(importUri) < 0)
       .lastOrNull;
 
-  final firstNonImportDirective =
-      unit.directives.where((d) => d is! ImportDirective).firstOrNull;
+  final firstNonImportDirective = unit.directives
+      .where((d) => d is! ImportDirective)
+      .firstOrNull;
 
   final AstNode relativeNode;
   final bool insertAfter;
@@ -129,8 +142,10 @@ _InsertionLocation insertionLocationForPackageImport(
   } else {
     // No directive to insert relative to; insert before the first member or
     // at the beginning of the file.
-    return _InsertionLocation(unit.declarations.firstOrNull?.offset ?? 0,
-        trailingNewlineCount: 2);
+    return _InsertionLocation(
+      unit.declarations.firstOrNull?.offset ?? 0,
+      trailingNewlineCount: 2,
+    );
   }
 
   return _InsertionLocation(

--- a/lib/src/util/package_util.dart
+++ b/lib/src/util/package_util.dart
@@ -21,8 +21,9 @@ import 'package:path/path.dart' as p;
 final _logger = Logger('orcm.pubspec');
 
 bool _isPubGetNecessary(String packageRoot) {
-  final packageConfig =
-      File(p.join(packageRoot, '.dart_tool', 'package_config.json'));
+  final packageConfig = File(
+    p.join(packageRoot, '.dart_tool', 'package_config.json'),
+  );
   final pubspec = File(p.join(packageRoot, 'pubspec.yaml'));
   final pubspecLock = File(p.join(packageRoot, 'pubspec.lock'));
 
@@ -43,7 +44,8 @@ Future<void> runPubGetIfNeeded(String packageRoot) async {
     await runPubGet(packageRoot);
   } else {
     _logger.info(
-        'Skipping `dart pub get`, which has already been run, in `$packageRoot`');
+      'Skipping `dart pub get`, which has already been run, in `$packageRoot`',
+    );
   }
 }
 
@@ -55,19 +57,26 @@ Future<void> runPubGetIfNeeded(String packageRoot) async {
 Future<void> runPubGet(String workingDirectory) async {
   _logger.info('Running `dart pub get` in `$workingDirectory`...');
 
-  final process = await Process.start('dart', ['pub', 'get'],
-      workingDirectory: workingDirectory,
-      runInShell: true,
-      mode: ProcessStartMode.inheritStdio);
+  final process = await Process.start(
+    'dart',
+    ['pub', 'get'],
+    workingDirectory: workingDirectory,
+    runInShell: true,
+    mode: ProcessStartMode.inheritStdio,
+  );
   final exitCode = await process.exitCode;
 
   if (exitCode == 69) {
     _logger.info(
-        'Re-running `dart pub get` but with `--offline`, to hopefully fix the above error.');
-    final process = await Process.start('dart', ['pub', 'get', '--offline'],
-        workingDirectory: workingDirectory,
-        runInShell: true,
-        mode: ProcessStartMode.inheritStdio);
+      'Re-running `dart pub get` but with `--offline`, to hopefully fix the above error.',
+    );
+    final process = await Process.start(
+      'dart',
+      ['pub', 'get', '--offline'],
+      workingDirectory: workingDirectory,
+      runInShell: true,
+      mode: ProcessStartMode.inheritStdio,
+    );
     final exitCode = await process.exitCode;
     if (exitCode != 0) {
       throw Exception('dart pub get failed with exit code: $exitCode');
@@ -96,7 +105,7 @@ Future<void> runPubGet(String workingDirectory) async {
 String findPackageRootFor(String path) {
   final packageRoot = [
     path,
-    ...ancestorsOfPath(path)
+    ...ancestorsOfPath(path),
   ].firstWhereOrNull((path) => File(p.join(path, 'pubspec.yaml')).existsSync());
 
   if (packageRoot == null) {
@@ -130,6 +139,8 @@ bool isNotWithinTopLevelToolDir(File file) =>
 /// Returns whether [file] is within a top-level [topLevelDir] directory
 /// (e.g., `bin`, `lib`, `web`) of a package root.
 bool isWithinTopLevelDir(File file, String topLevelDir) =>
-    ancestorsOfPath(file.path).any((ancestor) =>
-        p.basename(ancestor) == topLevelDir &&
-        File(p.join(p.dirname(ancestor), 'pubspec.yaml')).existsSync());
+    ancestorsOfPath(file.path).any(
+      (ancestor) =>
+          p.basename(ancestor) == topLevelDir &&
+          File(p.join(p.dirname(ancestor), 'pubspec.yaml')).existsSync(),
+    );

--- a/lib/src/util/pubspec_upgrader.dart
+++ b/lib/src/util/pubspec_upgrader.dart
@@ -47,11 +47,13 @@ class PubspecUpgrader {
   /// found.
   final bool shouldAddDependencies;
 
-  PubspecUpgrader(this.packageName, this.targetConstraint,
-      {this.isDevDependency = false,
-      this.shouldAddDependencies = true,
-      this.hostedUrl})
-      : shouldIgnoreMin = false;
+  PubspecUpgrader(
+    this.packageName,
+    this.targetConstraint, {
+    this.isDevDependency = false,
+    this.shouldAddDependencies = true,
+    this.hostedUrl,
+  }) : shouldIgnoreMin = false;
 
   /// Constructor used to ignore checks and ensure that the codemod always
   /// tries to update the constraint.
@@ -60,11 +62,13 @@ class PubspecUpgrader {
   /// range, rather than a target upper or lower bound. The only time this
   /// will not update the pubspec is if the target version range is equal to
   /// the version that is already there (avoiding an empty patch error).
-  PubspecUpgrader.alwaysUpdate(this.packageName, this.targetConstraint,
-      {this.isDevDependency = false,
-      this.shouldAddDependencies = true,
-      this.hostedUrl})
-      : shouldIgnoreMin = true;
+  PubspecUpgrader.alwaysUpdate(
+    this.packageName,
+    this.targetConstraint, {
+    this.isDevDependency = false,
+    this.shouldAddDependencies = true,
+    this.hostedUrl,
+  }) : shouldIgnoreMin = true;
 
   String getPatch(String newVersionConstraint) {
     if (hostedUrl == null) {
@@ -91,15 +95,18 @@ class PubspecUpgrader {
         final constraint = VersionConstraint.parse(constraintValue);
 
         if (shouldUpdateVersionRange(
-            targetConstraint: targetConstraint,
-            constraint: constraint,
-            shouldIgnoreMin: shouldIgnoreMin)) {
+          targetConstraint: targetConstraint,
+          constraint: constraint,
+          shouldIgnoreMin: shouldIgnoreMin,
+        )) {
           final newConstraint =
               targetConstraint.toString().contains('-alpha') ||
-                      targetConstraint.toString().contains('-dev')
-                  ? targetConstraint
-                  : generateNewVersionRange(
-                      constraint as VersionRange, targetConstraint);
+                  targetConstraint.toString().contains('-dev')
+              ? targetConstraint
+              : generateNewVersionRange(
+                  constraint as VersionRange,
+                  targetConstraint,
+                );
 
           var newValue = friendlyVersionConstraint(newConstraint);
           // Wrap the new constraint in quotes if required.
@@ -135,13 +142,17 @@ class PubspecUpgrader {
         pubspec.update([depKey, packageName], targetConstraint.toString());
       } else {
         pubspec.update(
-            [depKey, packageName],
-            YamlMap.wrap({
-              'hosted': {'name': packageName, 'url': hostedUrl}
-            }));
+          [depKey, packageName],
+          YamlMap.wrap({
+            'hosted': {'name': packageName, 'url': hostedUrl},
+          }),
+        );
         // Add the version range separately so it will be correctly formatted with quotes.
-        pubspec.update(
-            [depKey, packageName, 'version'], targetConstraint.toString());
+        pubspec.update([
+          depKey,
+          packageName,
+          'version',
+        ], targetConstraint.toString());
       }
 
       // Update the pubspec and also replace any unnecessary spaces because

--- a/lib/src/util/unused_import_remover.dart
+++ b/lib/src/util/unused_import_remover.dart
@@ -28,12 +28,14 @@ Suggestor unusedImportRemoverSuggestorBuilder(String package) {
         .where((error) => error.errorCode.name.toLowerCase() == 'unused_import')
         .toList();
 
-    final allImports =
-        unitResult.unit.directives.whereType<ImportDirective>().toList();
+    final allImports = unitResult.unit.directives
+        .whereType<ImportDirective>()
+        .toList();
 
     for (final error in unusedImportErrors) {
-      final matchingImport = allImports
-          .singleWhere((import) => import.containsOffset(error.offset));
+      final matchingImport = allImports.singleWhere(
+        (import) => import.containsOffset(error.offset),
+      );
       final importUri = matchingImport.uri.stringValue;
       if (importUri != null && importUri.startsWith('package:$package/')) {
         final prevTokenEnd = matchingImport.beginToken.previous?.end;

--- a/lib/src/util/wsd_util.dart
+++ b/lib/src/util/wsd_util.dart
@@ -39,7 +39,9 @@ import 'package:over_react_codemod/src/util/component_usage.dart';
 /// print(newValue); // prints: newSmall
 /// ```
 V? mapWsdConstant<V>(
-    Expression expression, Map<String, V> wsdConstantToNewValue) {
+  Expression expression,
+  Map<String, V> wsdConstantToNewValue,
+) {
   return wsdConstantToNewValue.entries
       .where((element) => isWsdStaticConstant(expression, element.key))
       .map((e) => e.value)
@@ -64,16 +66,25 @@ V? mapWsdConstant<V>(
 bool isWsdStaticConstant(Expression expression, String constant) =>
     _isStaticConstant(expression, constant, fromPackage: 'web_skin_dart');
 
-bool _isStaticConstant(Expression expression, String constant,
-    {String? fromPackage}) {
+bool _isStaticConstant(
+  Expression expression,
+  String constant, {
+  String? fromPackage,
+}) {
   final constantParts = constant.split('.');
   if (constantParts.length != 2) {
     throw ArgumentError.value(
-        constant, 'constant', "Expected 'ClassName.constantName'");
+      constant,
+      'constant',
+      "Expected 'ClassName.constantName'",
+    );
   }
   if (!constantParts.every(_isValidSimpleIdentifier)) {
-    throw ArgumentError.value(constant, 'constant',
-        "Expected 'ClassName.constantName', where both parts are valid identifiers");
+    throw ArgumentError.value(
+      constant,
+      'constant',
+      "Expected 'ClassName.constantName', where both parts are valid identifiers",
+    );
   }
 
   final className = constantParts[0];
@@ -119,8 +130,11 @@ bool _isStaticConstant(Expression expression, String constant,
 /// ```
 bool usesWsdFactory(FluentComponentUsage usage, String wsdFactoryName) {
   if (!_isValidSimpleIdentifier(wsdFactoryName)) {
-    throw ArgumentError.value(wsdFactoryName, 'wsdFactoryName',
-        'must be a valid, non-namespaced identifier');
+    throw ArgumentError.value(
+      wsdFactoryName,
+      'wsdFactoryName',
+      'must be a valid, non-namespaced identifier',
+    );
   }
 
   final factoryElement = usage.factoryTopLevelVariableElement;
@@ -180,8 +194,11 @@ final _isValidSimpleIdentifier = RegExp(r'^[_$a-zA-Z][_$a-zA-Z0-9]*$').hasMatch;
 /// ```
 bool usesWsdPropsClass(FluentComponentUsage usage, String wsdPropsName) {
   if (!_isValidSimpleIdentifier(wsdPropsName)) {
-    throw ArgumentError.value(wsdPropsName, 'wsdPropsName',
-        'must be a valid, non-namespaced identifier');
+    throw ArgumentError.value(
+      wsdPropsName,
+      'wsdPropsName',
+      'must be a valid, non-namespaced identifier',
+    );
   }
 
   final propsClassElement = usage.propsClassElement;

--- a/lib/src/vendor/over_react_analyzer_plugin/get_all_props.dart
+++ b/lib/src/vendor/over_react_analyzer_plugin/get_all_props.dart
@@ -24,15 +24,18 @@ import 'package:collection/collection.dart';
 //     and an inefficient `thisOrAncestorOfType` impl: https://github.com/dart-lang/sdk/issues/53255
 
 Iterable<InterfaceElement> getAllPropsClassesOrMixins(
-    InterfaceElement propsElement) sync* {
+  InterfaceElement propsElement,
+) sync* {
   final propsAndSupertypeElements = propsElement.thisAndSupertypesList;
 
   // There are two UiProps; one in component_base, and one in builder_helpers that extends from it.
   // Use the component_base one, since there are some edge-cases of props that don't extend from the
   // builder_helpers version.
-  final uiPropsElement = propsAndSupertypeElements.firstWhereOrNull((i) =>
-      i.name == 'UiProps' &&
-      i.library.name == 'over_react.component_declaration.component_base');
+  final uiPropsElement = propsAndSupertypeElements.firstWhereOrNull(
+    (i) =>
+        i.name == 'UiProps' &&
+        i.library.name == 'over_react.component_declaration.component_base',
+  );
 
   // If propsElement does not inherit from from UiProps, it could still be a legacy mixin that doesn't implement UiProps.
   // This check is only necessary to retrieve props when [propsElement] is itself a legacy mixin, and not when legacy
@@ -51,15 +54,18 @@ Iterable<InterfaceElement> getAllPropsClassesOrMixins(
     if (uiPropsAndSupertypeElements?.contains(interface) ?? false) continue;
 
     // Filter out generated accessors mixins for legacy concrete props classes.
-    late final isFromGeneratedFile =
-        interface.source.uri.path.endsWith('.over_react.g.dart');
+    late final isFromGeneratedFile = interface.source.uri.path.endsWith(
+      '.over_react.g.dart',
+    );
     if (interface.name.endsWith('AccessorsMixin') && isFromGeneratedFile) {
       continue;
     }
 
-    final isMixinBasedPropsMixin = interface is MixinElement &&
+    final isMixinBasedPropsMixin =
+        interface is MixinElement &&
         interface.superclassConstraints.any((s) => s.element.name == 'UiProps');
-    late final isLegacyPropsOrPropsMixinConsumerClass = !isFromGeneratedFile &&
+    late final isLegacyPropsOrPropsMixinConsumerClass =
+        !isFromGeneratedFile &&
         interface.metadata.any(_isOneOfThePropsAnnotations);
 
     if (!isMixinBasedPropsMixin && !isLegacyPropsOrPropsMixinConsumerClass) {
@@ -71,13 +77,15 @@ Iterable<InterfaceElement> getAllPropsClassesOrMixins(
 }
 
 Iterable<FieldElement> getPropsDeclaredInMixin(
-    InterfaceElement interface) sync* {
+  InterfaceElement interface,
+) sync* {
   for (final field in interface.fields) {
     if (field.isStatic) continue;
     if (field.isSynthetic) continue;
 
     final accessorAnnotation = _getAccessorAnnotation(field.metadata);
-    final isNoGenerate = accessorAnnotation
+    final isNoGenerate =
+        accessorAnnotation
             ?.computeConstantValue()
             ?.getField('doNotGenerate')
             ?.toBoolValue() ??
@@ -106,8 +114,11 @@ bool _isOneOfThePropsAnnotations(ElementAnnotation e) {
   // [2]
   final element = e.element;
   return element is ConstructorElement &&
-      const {'Props', 'PropsMixin', 'AbstractProps'}
-          .contains(element.enclosingElement.name);
+      const {
+        'Props',
+        'PropsMixin',
+        'AbstractProps',
+      }.contains(element.enclosingElement.name);
 }
 
 bool _isPropsMixinAnnotation(ElementAnnotation e) {
@@ -129,9 +140,13 @@ ElementAnnotation? _getAccessorAnnotation(List<ElementAnnotation> metadata) {
 extension on InterfaceElement {
   // Two separate collection implementations to micro-optimize collection creation/iteration based on usage.
 
-  Set<InterfaceElement> get thisAndSupertypesSet =>
-      {this, for (final s in allSupertypes) s.element};
+  Set<InterfaceElement> get thisAndSupertypesSet => {
+    this,
+    for (final s in allSupertypes) s.element,
+  };
 
-  List<InterfaceElement> get thisAndSupertypesList =>
-      [this, for (final s in allSupertypes) s.element];
+  List<InterfaceElement> get thisAndSupertypesList => [
+    this,
+    for (final s in allSupertypes) s.element,
+  ];
 }

--- a/test/boilerplate_suggestors/boilerplate_utilities_test.dart
+++ b/test/boilerplate_suggestors/boilerplate_utilities_test.dart
@@ -19,33 +19,33 @@ import 'package:test/test.dart';
 
 void main() {
   group('Boilerplate Utilities', () {
-    group('getSemverHelper() with isPublic() and getPublicExportLocations()',
-        () {
-      group('with --treat-all-components-as-private flag', () {
-        semverUtilitiesTestHelper(
-          shouldTreatAllComponentsAsPrivate: true,
-        );
-      });
-
-      group('json file does not exist', () {
-        semverUtilitiesTestHelper(
-          path: 'test/boilerplate_suggestors/does_not_exist.json',
-          isValidFilePath: false,
-        );
-
+    group(
+      'getSemverHelper() with isPublic() and getPublicExportLocations()',
+      () {
         group('with --treat-all-components-as-private flag', () {
+          semverUtilitiesTestHelper(shouldTreatAllComponentsAsPrivate: true);
+        });
+
+        group('json file does not exist', () {
           semverUtilitiesTestHelper(
             path: 'test/boilerplate_suggestors/does_not_exist.json',
-            shouldTreatAllComponentsAsPrivate: true,
             isValidFilePath: false,
           );
-        });
-      });
 
-      group('json file does exist', () {
-        semverUtilitiesTestHelper();
-      });
-    });
+          group('with --treat-all-components-as-private flag', () {
+            semverUtilitiesTestHelper(
+              path: 'test/boilerplate_suggestors/does_not_exist.json',
+              shouldTreatAllComponentsAsPrivate: true,
+              isValidFilePath: false,
+            );
+          });
+        });
+
+        group('json file does exist', () {
+          semverUtilitiesTestHelper();
+        });
+      },
+    );
   });
 }
 
@@ -57,16 +57,19 @@ void semverUtilitiesTestHelper({
   late SemverHelper semverHelper;
 
   setUpAll(() {
-    semverHelper = getSemverHelper(path,
-        shouldTreatAllComponentsAsPrivate: shouldTreatAllComponentsAsPrivate);
+    semverHelper = getSemverHelper(
+      path,
+      shouldTreatAllComponentsAsPrivate: shouldTreatAllComponentsAsPrivate,
+    );
   });
 
   test('correct warning', () {
     expect(
-        semverHelper.warning,
-        isValidFilePath || shouldTreatAllComponentsAsPrivate
-            ? isNull
-            : 'Could not find semver_report.json.');
+      semverHelper.warning,
+      isValidFilePath || shouldTreatAllComponentsAsPrivate
+          ? isNull
+          : 'Could not find semver_report.json.',
+    );
   });
 
   group('if props class is not in export list', () {
@@ -84,15 +87,17 @@ void semverUtilitiesTestHelper({
 
       unit.declarations.whereType<ClassDeclaration>().forEach((classNode) {
         expect(
-            semverHelper.getPublicExportLocations(
-                classNode, 'lib/src/foo.dart'),
-            isValidFilePath || shouldTreatAllComponentsAsPrivate
-                ? isEmpty
-                : [
-                    'Semver report not available; this class is assumed to be public and thus will not be updated.'
-                  ]);
-        expect(isPublic(classNode, semverHelper, 'lib/src/foo.dart'),
-            !isValidFilePath && !shouldTreatAllComponentsAsPrivate);
+          semverHelper.getPublicExportLocations(classNode, 'lib/src/foo.dart'),
+          isValidFilePath || shouldTreatAllComponentsAsPrivate
+              ? isEmpty
+              : [
+                  'Semver report not available; this class is assumed to be public and thus will not be updated.',
+                ],
+        );
+        expect(
+          isPublic(classNode, semverHelper, 'lib/src/foo.dart'),
+          !isValidFilePath && !shouldTreatAllComponentsAsPrivate,
+        );
       });
     });
 
@@ -110,9 +115,9 @@ void semverUtilitiesTestHelper({
 
       unit.declarations.whereType<ClassDeclaration>().forEach((classNode) {
         expect(
-            semverHelper.getPublicExportLocations(
-                classNode, 'web/src/foo.dart'),
-            isEmpty);
+          semverHelper.getPublicExportLocations(classNode, 'web/src/foo.dart'),
+          isEmpty,
+        );
         expect(isPublic(classNode, semverHelper, 'web/src/foo.dart'), isFalse);
       });
     });
@@ -127,12 +132,9 @@ void semverUtilitiesTestHelper({
         }
       ''';
     final expectedOutput = isValidFilePath
-        ? [
-            'lib/web_skin_dart.dart/BarProps',
-            'lib/another_file.dart/BarProps',
-          ]
+        ? ['lib/web_skin_dart.dart/BarProps', 'lib/another_file.dart/BarProps']
         : [
-            'Semver report not available; this class is assumed to be public and thus will not be updated.'
+            'Semver report not available; this class is assumed to be public and thus will not be updated.',
           ];
 
     final unit = parseString(content: input).unit;
@@ -140,10 +142,13 @@ void semverUtilitiesTestHelper({
 
     unit.declarations.whereType<ClassDeclaration>().forEach((classNode) {
       expect(
-          semverHelper.getPublicExportLocations(classNode, 'lib/src/foo.dart'),
-          shouldTreatAllComponentsAsPrivate ? isEmpty : expectedOutput);
-      expect(isPublic(classNode, semverHelper, 'lib/src/foo.dart'),
-          !shouldTreatAllComponentsAsPrivate);
+        semverHelper.getPublicExportLocations(classNode, 'lib/src/foo.dart'),
+        shouldTreatAllComponentsAsPrivate ? isEmpty : expectedOutput,
+      );
+      expect(
+        isPublic(classNode, semverHelper, 'lib/src/foo.dart'),
+        !shouldTreatAllComponentsAsPrivate,
+      );
     });
   });
 }

--- a/test/dart2_9_suggestors/dart2_9_utilities_test.dart
+++ b/test/dart2_9_suggestors/dart2_9_utilities_test.dart
@@ -24,14 +24,16 @@ void main() {
       group('returns null', () {
         void _expectNullReturnValue(String input) {
           final unit = parseString(content: input).unit;
-          final argList = (unit.declarations
-                  .whereType<TopLevelVariableDeclaration>()
-                  .first
-                  .variables
-                  .variables
-                  .first
-                  .initializer! as MethodInvocation)
-              .argumentList;
+          final argList =
+              (unit.declarations
+                          .whereType<TopLevelVariableDeclaration>()
+                          .first
+                          .variables
+                          .variables
+                          .first
+                          .initializer!
+                      as MethodInvocation)
+                  .argumentList;
 
           expect(getGeneratedFactoryConfigArg(argList), isNull);
         }
@@ -68,14 +70,16 @@ void main() {
       group('returns the generated factory config', () {
         void _expectConfigName({required String input, String? expectedName}) {
           final unit = parseString(content: input).unit;
-          final argList = (unit.declarations
-                  .whereType<TopLevelVariableDeclaration>()
-                  .first
-                  .variables
-                  .variables
-                  .first
-                  .initializer! as MethodInvocation)
-              .argumentList;
+          final argList =
+              (unit.declarations
+                          .whereType<TopLevelVariableDeclaration>()
+                          .first
+                          .variables
+                          .variables
+                          .first
+                          .initializer!
+                      as MethodInvocation)
+                  .argumentList;
 
           final returnValue = getGeneratedFactoryConfigArg(argList)!;
           expect(returnValue, isA<SimpleIdentifier>());
@@ -150,14 +154,16 @@ void main() {
             ));
           ''';
           final unit = parseString(content: input).unit;
-          final memoArgList = (unit.declarations
-                  .whereType<TopLevelVariableDeclaration>()
-                  .first
-                  .variables
-                  .variables
-                  .first
-                  .initializer! as MethodInvocation)
-              .argumentList;
+          final memoArgList =
+              (unit.declarations
+                          .whereType<TopLevelVariableDeclaration>()
+                          .first
+                          .variables
+                          .variables
+                          .first
+                          .initializer!
+                      as MethodInvocation)
+                  .argumentList;
           final uiFunctionArgList = memoArgList.arguments
               .whereType<MethodInvocation>()
               .first
@@ -174,8 +180,9 @@ void main() {
       group('returns null and false, respectively', () {
         void _expectNullReturnValue(String input) {
           final unit = parseString(content: input).unit;
-          final decl =
-              unit.declarations.whereType<TopLevelVariableDeclaration>().first;
+          final decl = unit.declarations
+              .whereType<TopLevelVariableDeclaration>()
+              .first;
 
           expect(getGeneratedFactory(decl), isNull);
           expect(isClassOrConnectedComponentFactory(decl), isFalse);
@@ -207,11 +214,14 @@ void main() {
       });
 
       group('returns the generated factory and true, respectively', () {
-        void _expectGeneratedFactoryName(
-            {required String input, String? expectedName}) {
+        void _expectGeneratedFactoryName({
+          required String input,
+          String? expectedName,
+        }) {
           final unit = parseString(content: input).unit;
-          final decl =
-              unit.declarations.whereType<TopLevelVariableDeclaration>().first;
+          final decl = unit.declarations
+              .whereType<TopLevelVariableDeclaration>()
+              .first;
 
           final returnValue = getGeneratedFactory(decl)!;
           expect(returnValue, isA<SimpleIdentifier>());
@@ -270,7 +280,8 @@ void main() {
 
         test('with type casting function', () {
           _expectGeneratedFactoryName(
-            input: '''
+            input:
+                '''
             UiFactory<FooProps> Foo = $castFunctionName(_\$Foo); // ignore: undefined_identifier
           ''',
             expectedName: '_\$Foo',
@@ -302,7 +313,8 @@ void main() {
 
         test('for connected components with type casting', () {
           _expectGeneratedFactoryName(
-            input: '''
+            input:
+                '''
               UiFactory<FooProps> Foo = connect<SomeState, FooProps>(
                 mapStateToProps: (state) => (Foo()
                   ..foo = state.foo
@@ -340,67 +352,84 @@ void main() {
       group('returns false', () {
         void _expectFalse({required String input}) {
           final unit = parseString(content: input).unit;
-          final decl =
-              unit.declarations.whereType<TopLevelVariableDeclaration>().first;
+          final decl = unit.declarations
+              .whereType<TopLevelVariableDeclaration>()
+              .first;
 
           expect(isLegacyFactoryDecl(decl), isFalse);
         }
 
         test('when the initializer is not generated', () {
-          _expectFalse(input: '''
+          _expectFalse(
+            input: '''
             UiFactory<FooProps> Foo = someFactory;
-          ''');
+          ''',
+          );
         });
 
         test('when the input is not a component factory', () {
-          _expectFalse(input: '''
+          _expectFalse(
+            input: '''
             DriverFactory driverFactory = createDriver;
-          ''');
+          ''',
+          );
         });
 
         test('when the factory is not annotated', () {
-          _expectFalse(input: '''
+          _expectFalse(
+            input: '''
             UiFactory<FooProps> Foo = _\$Foo; // ignore: undefined_identifier
-          ''');
+          ''',
+          );
         });
 
         test('with type casting function', () {
-          _expectFalse(input: '''
+          _expectFalse(
+            input:
+                '''
             UiFactory<FooProps> Foo = $castFunctionName(_\$Foo); // ignore: undefined_identifier
-          ''');
+          ''',
+          );
         });
       });
 
       group('returns true', () {
         void _expectTrue({required String input}) {
           final unit = parseString(content: input).unit;
-          final decl =
-              unit.declarations.whereType<TopLevelVariableDeclaration>().first;
+          final decl = unit.declarations
+              .whereType<TopLevelVariableDeclaration>()
+              .first;
 
           expect(isLegacyFactoryDecl(decl), isTrue);
         }
 
         test('when the factory is annotated', () {
-          _expectTrue(input: '''
+          _expectTrue(
+            input: '''
             @Factory()
             UiFactory<FooProps> Foo = _\$Foo; // ignore: undefined_identifier
-          ''');
+          ''',
+          );
         });
 
         test('without ignore comment', () {
-          _expectTrue(input: '''
+          _expectTrue(
+            input: '''
             @Factory()
             UiFactory<FooProps> Foo = _\$Foo;
-          ''');
+          ''',
+          );
         });
 
         test('when the ignore comment is before the initializer', () {
-          _expectTrue(input: '''
+          _expectTrue(
+            input: '''
             @Factory()
             UiFactory<FooProps> Foo = 
               // ignore: undefined_identifier
               _\$Foo;
-          ''');
+          ''',
+          );
         });
       });
     });

--- a/test/dart2_9_suggestors/factory_and_config_ignore_comment_remover_test.dart
+++ b/test/dart2_9_suggestors/factory_and_config_ignore_comment_remover_test.dart
@@ -31,8 +31,9 @@ main() {
 }
 
 void ignoreRemoverTestHelper(String ignoreToRemove) {
-  final testSuggestor =
-      getSuggestorTester(FactoryAndConfigIgnoreCommentRemover(ignoreToRemove));
+  final testSuggestor = getSuggestorTester(
+    FactoryAndConfigIgnoreCommentRemover(ignoreToRemove),
+  );
 
   test('empty file', () async {
     await testSuggestor(expectedPatchCount: 0, input: '');
@@ -54,7 +55,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
       test('ignore comments from legacy boilerplate', () async {
         await testSuggestor(
           expectedPatchCount: 0,
-          input: '''
+          input:
+              '''
             @Factory()
             // ignore: $ignoreToRemove
             UiFactory<FooProps> Foo =
@@ -79,7 +81,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
       test('from a non-component factory declaration', () async {
         await testSuggestor(
           expectedPatchCount: 0,
-          input: '''
+          input:
+              '''
             DriverFactory driverFactory = createDriver; // ignore: $ignoreToRemove
           ''',
         );
@@ -90,7 +93,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
       test('when the comment is on the same line', () async {
         await testSuggestor(
           expectedPatchCount: 1,
-          input: '''
+          input:
+              '''
             UiFactory<FooProps> Foo = _\$Foo; // ignore: $ignoreToRemove
           ''',
           expectedOutput: '''
@@ -102,7 +106,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
       test('when the comment is on the initializer', () async {
         await testSuggestor(
           expectedPatchCount: 1,
-          input: '''
+          input:
+              '''
             UiFactory<FooProps> Foo =
               // ignore: $ignoreToRemove
               _\$Foo;
@@ -116,7 +121,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
       test('when the comment is on the preceding line', () async {
         await testSuggestor(
           expectedPatchCount: 1,
-          input: '''
+          input:
+              '''
             // ignore: $ignoreToRemove
             UiFactory<FooProps> Foo = _\$Foo;
           ''',
@@ -129,7 +135,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
       test('when there is another comment above it', () async {
         await testSuggestor(
           expectedPatchCount: 1,
-          input: '''
+          input:
+              '''
             // this is another comment
             // ignore: $ignoreToRemove
             UiFactory<FooProps> Foo = _\$Foo;
@@ -144,7 +151,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
       test('when there is a doc comment above it', () async {
         await testSuggestor(
           expectedPatchCount: 1,
-          input: '''
+          input:
+              '''
             /// this is a doc comment
             // ignore: $ignoreToRemove
             UiFactory<FooProps> Foo = _\$Foo;
@@ -159,7 +167,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
       test('when there are multiple factories', () async {
         await testSuggestor(
           expectedPatchCount: 3,
-          input: '''
+          input:
+              '''
             UiFactory<FooProps> Foo = _\$Foo; // ignore: $ignoreToRemove
 
             UiFactory<BarProps> Bar =
@@ -183,7 +192,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
         test('in the same comment', () async {
           await testSuggestor(
             expectedPatchCount: 1,
-            input: '''
+            input:
+                '''
               UiFactory<FooProps> Foo = _\$Foo; // ignore: invalid_assignment, $ignoreToRemove, unused_element
             ''',
             expectedOutput: '''
@@ -195,7 +205,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
         test('in different comments', () async {
           await testSuggestor(
             expectedPatchCount: 3,
-            input: '''
+            input:
+                '''
               // ignore: $ignoreToRemove, unused_element
               UiFactory<FooProps> Foo =
                 // ignore: $ignoreToRemove
@@ -212,10 +223,12 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
       test('when the factory is already updated', () async {
         await testSuggestor(
           expectedPatchCount: 1,
-          input: '''
+          input:
+              '''
             UiFactory<FooProps> Foo = $castFunctionName(_\$Foo); // ignore: $ignoreToRemove
           ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
             UiFactory<FooProps> Foo = $castFunctionName(_\$Foo);
           ''',
         );
@@ -229,7 +242,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
         test('after the comma', () async {
           await testSuggestor(
             expectedPatchCount: 1,
-            input: '''
+            input:
+                '''
               UiFactory<FooProps> Foo = connect<SomeState, FooProps>(
                 mapStateToProps: (state) => (Foo()
                   ..foo = state.foo
@@ -239,7 +253,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
                 $generatedArg, // ignore: $ignoreToRemove
               );
             ''',
-            expectedOutput: '''
+            expectedOutput:
+                '''
               UiFactory<FooProps> Foo = connect<SomeState, FooProps>(
                 mapStateToProps: (state) => (Foo()
                   ..foo = state.foo
@@ -255,7 +270,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
         test('after the semicolon', () async {
           await testSuggestor(
             expectedPatchCount: 1,
-            input: '''
+            input:
+                '''
               UiFactory<FooProps> Foo = connect<SomeState, FooProps>(
                 mapStateToProps: (state) => (Foo()
                   ..foo = state.foo
@@ -263,7 +279,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
                 ),
               )($generatedArg); // ignore: $ignoreToRemove
             ''',
-            expectedOutput: '''
+            expectedOutput:
+                '''
               UiFactory<FooProps> Foo = connect<SomeState, FooProps>(
                 mapStateToProps: (state) => (Foo()
                   ..foo = state.foo
@@ -278,7 +295,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
       test('and the comment is on the preceding line', () async {
         await testSuggestor(
           expectedPatchCount: 1,
-          input: '''
+          input:
+              '''
             UiFactory<FooProps> Foo = connect<SomeState, FooProps>(
               mapStateToProps: (state) => (Foo()
                 ..foo = state.foo
@@ -289,7 +307,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
               $generatedArg,
             );
           ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
             UiFactory<FooProps> Foo = connect<SomeState, FooProps>(
               mapStateToProps: (state) => (Foo()
                 ..foo = state.foo
@@ -331,7 +350,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
       test('for `connectFlux` function', () async {
         await testSuggestor(
           expectedPatchCount: 1,
-          input: '''
+          input:
+              '''
               UiFactory<FooProps> Foo = connectFlux<SomeState, FooProps>(
                 mapStateToProps: (state) => (Foo()
                   ..foo = state.foo
@@ -353,7 +373,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
       test('for `composeHocs` function', () async {
         await testSuggestor(
           expectedPatchCount: 1,
-          input: '''
+          input:
+              '''
             UiFactory<FooProps> Foo = composeHocs([
               connect<RandomColorStore, FooProps>(
                 context: randomColorStoreContext,
@@ -387,7 +408,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
       test('when there are two factories', () async {
         await testSuggestor(
           expectedPatchCount: 1,
-          input: '''
+          input:
+              '''
             UiFactory<FooProps> UnconnectedFoo = _\$UnconnectedFoo; // ignore: $ignoreToRemove
 
             UiFactory<FooProps> Foo =
@@ -415,7 +437,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
       test('when there are multiple ignores', () async {
         await testSuggestor(
           expectedPatchCount: 1,
-          input: '''
+          input:
+              '''
             UiFactory<FooProps> Foo = connect<SomeState, FooProps>(
               mapStateToProps: (state) => (Foo()
                 ..foo = state.foo
@@ -442,13 +465,15 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
         test('after the comma', () async {
           await testSuggestor(
             expectedPatchCount: 1,
-            input: '''
+            input:
+                '''
               final Foo = uiForwardRef<FooProps>(
                 (props, ref) {},
                 $configArg, // ignore: $ignoreToRemove
               );
             ''',
-            expectedOutput: '''
+            expectedOutput:
+                '''
               final Foo = uiForwardRef<FooProps>(
                 (props, ref) {},
                 $configArg,
@@ -460,12 +485,14 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
         test('after the semicolon', () async {
           await testSuggestor(
             expectedPatchCount: 1,
-            input: '''
+            input:
+                '''
               UiFactory<FooProps> Foo = uiFunction(
                 (props) {},
                 $configArg); // ignore: $ignoreToRemove
             ''',
-            expectedOutput: '''
+            expectedOutput:
+                '''
               UiFactory<FooProps> Foo = uiFunction(
                 (props) {},
                 $configArg);
@@ -477,14 +504,16 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
       test('and the comment is on the preceding line', () async {
         await testSuggestor(
           expectedPatchCount: 1,
-          input: '''
+          input:
+              '''
             UiFactory<FooProps> Foo = uiFunction(
               (props) {},
               // ignore: $ignoreToRemove
               $configArg,
             );
           ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
             UiFactory<FooProps> Foo = uiFunction(
               (props) {},
               $configArg,
@@ -521,7 +550,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
       test('when there are multiple factories', () async {
         await testSuggestor(
           expectedPatchCount: 2,
-          input: '''
+          input:
+              '''
             final Foo = uiForwardRef<FooProps>(
               (props, ref) {},
               \$FooConfig, // ignore: $ignoreToRemove
@@ -551,7 +581,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
         test('in the same comment', () async {
           await testSuggestor(
             expectedPatchCount: 1,
-            input: '''
+            input:
+                '''
               UiFactory<FooProps> Foo = uiFunction(
                 (props) {},
                 \$FooConfig, // ignore: invalid_assignment, $ignoreToRemove, unused_element
@@ -569,7 +600,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
         test('in different comments', () async {
           await testSuggestor(
             expectedPatchCount: 2,
-            input: '''
+            input:
+                '''
               final Foo = uiFunction<FooProps>(
                 (props) {},
                 // ignore: $ignoreToRemove
@@ -590,7 +622,8 @@ void ignoreRemoverTestHelper(String ignoreToRemove) {
       test('when wrapped in an hoc', () async {
         await testSuggestor(
           expectedPatchCount: 1,
-          input: '''
+          input:
+              '''
             UiFactory<FooProps> Foo = someHOC(uiFunction(
               (props) {},
               \$FooConfig, // ignore: $ignoreToRemove

--- a/test/dart2_9_suggestors/generated_factory_migrator_test.dart
+++ b/test/dart2_9_suggestors/generated_factory_migrator_test.dart
@@ -61,7 +61,8 @@ main() {
         test('if already updated', () async {
           await testSuggestor(
             expectedPatchCount: 0,
-            input: '''
+            input:
+                '''
               UiFactory<FooProps> Foo = $castFunctionName(_\$Foo); // ignore: undefined_identifier
             ''',
           );
@@ -74,7 +75,8 @@ main() {
           input: '''
             UiFactory<FooProps> Foo = _\$Foo; // ignore: undefined_identifier
           ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
             UiFactory<FooProps> Foo = $castFunctionName(_\$Foo); // ignore: undefined_identifier
           ''',
         );
@@ -105,7 +107,8 @@ main() {
             // ignore: undefined_identifier
             UiFactory<BazProps> Baz = _\$Baz;
           ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
             UiFactory<FooProps> Foo = $castFunctionName(_\$Foo); // ignore: undefined_identifier
 
             UiFactory<BarProps> Bar =
@@ -124,7 +127,8 @@ main() {
         test('if already updated', () async {
           await testSuggestor(
             expectedPatchCount: 0,
-            input: '''
+            input:
+                '''
               UiFactory<FooProps> Foo = connect<SomeState, FooProps>(
                 mapStateToProps: (state) => (Foo()
                   ..foo = state.foo
@@ -159,7 +163,8 @@ main() {
               ),
             )(_\$Foo); // ignore: undefined_identifier
           ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
             UiFactory<FooProps> Foo = connectFlux<SomeState, FooProps>(
               mapStateToProps: (state) => (Foo()
                 ..foo = state.foo
@@ -215,7 +220,8 @@ main() {
               ),
             )(_\$Foo); // ignore: undefined_identifier
           ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
             UiFactory<FooProps> Foo = connect<SomeState, FooProps>(
               mapStateToProps: (state) => (Foo()
                 ..foo = state.foo
@@ -239,7 +245,8 @@ main() {
               _\$Foo, // ignore: undefined_identifier
             );
           ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
             UiFactory<FooProps> Foo = connect<SomeState, FooProps>(
               mapStateToProps: (state) => (Foo()
                 ..foo = state.foo
@@ -266,7 +273,8 @@ main() {
               ),
             )(UnconnectedFoo);
           ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
             UiFactory<FooProps> UnconnectedFoo = $castFunctionName(_\$UnconnectedFoo); // ignore: undefined_identifier
 
             UiFactory<FooProps> Foo =

--- a/test/dart2_suggestors/pubspec_over_react_upgrader_test.dart
+++ b/test/dart2_suggestors/pubspec_over_react_upgrader_test.dart
@@ -36,11 +36,15 @@ main() {
 
     group('with shouldAlwaysUpdate false', () {
       final defaultTestSuggestor = getSuggestorTester(
-          PubspecOverReactUpgrader(parseVersionRange(versionRange)));
+        PubspecOverReactUpgrader(parseVersionRange(versionRange)),
+      );
 
-      final doNotAddDependencies = getSuggestorTester(PubspecOverReactUpgrader(
+      final doNotAddDependencies = getSuggestorTester(
+        PubspecOverReactUpgrader(
           parseVersionRange(versionRange),
-          shouldAddDependencies: false));
+          shouldAddDependencies: false,
+        ),
+      );
 
       sharedPubspecTest(
         testSuggestor: defaultTestSuggestor,
@@ -66,14 +70,16 @@ main() {
           expectedPatchCount: 1,
           shouldDartfmtOutput: false,
           validateContents: validatePubspecYaml,
-          input: ''
+          input:
+              ''
               'name: nothing\n'
               'version: 0.0.0\n'
               'dependencies:\n'
               '  over_react: ">=1.50.0 <2.0.0"\n'
               '  test: 1.5.1\n'
               '',
-          expectedOutput: ''
+          expectedOutput:
+              ''
               'name: nothing\n'
               'version: 0.0.0\n'
               'dependencies:\n'
@@ -89,7 +95,8 @@ main() {
             expectedPatchCount: 0,
             shouldDartfmtOutput: false,
             validateContents: validatePubspecYaml,
-            input: ''
+            input:
+                ''
                 'dependency_overrides:\n'
                 '  over_react:\n'
                 '    git:\n'
@@ -103,7 +110,8 @@ main() {
             expectedPatchCount: 0,
             shouldDartfmtOutput: false,
             validateContents: validatePubspecYaml,
-            input: ''
+            input:
+                ''
                 'dependency_overrides:\n'
                 '  over_react:\n'
                 '    path: ../\n',
@@ -114,8 +122,8 @@ main() {
 
     group('with shouldAlwaysUpdate true', () {
       final defaultTestSuggestor = getSuggestorTester(
-          PubspecOverReactUpgrader.alwaysUpdate(
-              parseVersionRange(versionRange)));
+        PubspecOverReactUpgrader.alwaysUpdate(parseVersionRange(versionRange)),
+      );
 
       sharedPubspecTest(
         testSuggestor: defaultTestSuggestor,
@@ -129,21 +137,24 @@ main() {
       group('does not attempt to update dependency_overrides', () {
         test('git', () async {
           await defaultTestSuggestor(
-              expectedPatchCount: 0,
-              shouldDartfmtOutput: false,
-              validateContents: validatePubspecYaml,
-              input: ''
-                  'dependency_overrides:\n'
-                  '  over_react:\n'
-                  '    git:\n'
-                  '      url: git@github.com:cleandart/react-dart.git\n'
-                  '      ref: 5.0.0-wip\n',
-              expectedOutput: ''
-                  'dependency_overrides:\n'
-                  '  over_react:\n'
-                  '    git:\n'
-                  '      url: git@github.com:cleandart/react-dart.git\n'
-                  '      ref: 5.0.0-wip\n');
+            expectedPatchCount: 0,
+            shouldDartfmtOutput: false,
+            validateContents: validatePubspecYaml,
+            input:
+                ''
+                'dependency_overrides:\n'
+                '  over_react:\n'
+                '    git:\n'
+                '      url: git@github.com:cleandart/react-dart.git\n'
+                '      ref: 5.0.0-wip\n',
+            expectedOutput:
+                ''
+                'dependency_overrides:\n'
+                '  over_react:\n'
+                '    git:\n'
+                '      url: git@github.com:cleandart/react-dart.git\n'
+                '      ref: 5.0.0-wip\n',
+          );
         });
 
         test('path', () async {
@@ -151,11 +162,13 @@ main() {
             expectedPatchCount: 0,
             shouldDartfmtOutput: false,
             validateContents: validatePubspecYaml,
-            input: ''
+            input:
+                ''
                 'dependency_overrides:\n'
                 '  over_react:\n'
                 '    path: ../\n',
-            expectedOutput: ''
+            expectedOutput:
+                ''
                 'dependency_overrides:\n'
                 '  over_react:\n'
                 '    path: ../\n',
@@ -170,8 +183,8 @@ String getExpectedOutput({bool? useMidVersionMin = false, String? hostedUrl}) {
   if (useMidVersionMin!) {
     final expected =
         VersionConstraint.parse('^2.0.0').allows(Version.parse(midRangeMark))
-            ? '^$midRangeMark'
-            : '">=$midRangeMark <3.0.0"';
+        ? '^$midRangeMark'
+        : '">=$midRangeMark <3.0.0"';
 
     return ''
         'dependencies:\n'

--- a/test/dependency_validator/ignore_updaters/v1_updater_test.dart
+++ b/test/dependency_validator/ignore_updaters/v1_updater_test.dart
@@ -32,11 +32,14 @@ Map<String, String Function(String command)> contexts = {
 main() {
   group('V1DependencyUpdater', () {
     const addedDependency = 'an_added_dependency';
-    final testSuggestor =
-        getSuggestorTester(V1DependencyValidatorUpdater(addedDependency));
+    final testSuggestor = getSuggestorTester(
+      V1DependencyValidatorUpdater(addedDependency),
+    );
 
-    void sharedCommandTests(String contextName,
-        String Function(String command) getCommandWithinContext) {
+    void sharedCommandTests(
+      String contextName,
+      String Function(String command) getCommandWithinContext,
+    ) {
       group(contextName, () {
         test('makes no updates when there is no command', () async {
           await testSuggestor(
@@ -50,11 +53,13 @@ main() {
         group('adds the dependency when', () {
           test('there are no other args on the command', () async {
             await testSuggestor(
-                shouldDartfmtOutput: false,
-                expectedPatchCount: 1,
-                input: getCommandWithinContext(depValidatorCommand),
-                expectedOutput: getCommandWithinContext(
-                    '$depValidatorCommand -i $addedDependency'));
+              shouldDartfmtOutput: false,
+              expectedPatchCount: 1,
+              input: getCommandWithinContext(depValidatorCommand),
+              expectedOutput: getCommandWithinContext(
+                '$depValidatorCommand -i $addedDependency',
+              ),
+            );
           });
 
           test('the exclude flag is present', () async {
@@ -62,9 +67,11 @@ main() {
               shouldDartfmtOutput: false,
               expectedPatchCount: 1,
               input: getCommandWithinContext(
-                  '$depValidatorCommand -x app/,bin/,random/'),
+                '$depValidatorCommand -x app/,bin/,random/',
+              ),
               expectedOutput: getCommandWithinContext(
-                  '$depValidatorCommand -i $addedDependency -x app/,bin/,random/'),
+                '$depValidatorCommand -i $addedDependency -x app/,bin/,random/',
+              ),
             );
           });
 
@@ -73,9 +80,11 @@ main() {
               shouldDartfmtOutput: false,
               expectedPatchCount: 1,
               input: getCommandWithinContext(
-                  '$depValidatorCommand --no-fatal-unused -x app/,bin/,random/ --no-fatal-missing'),
+                '$depValidatorCommand --no-fatal-unused -x app/,bin/,random/ --no-fatal-missing',
+              ),
               expectedOutput: getCommandWithinContext(
-                  '$depValidatorCommand -i $addedDependency --no-fatal-unused -x app/,bin/,random/ --no-fatal-missing'),
+                '$depValidatorCommand -i $addedDependency --no-fatal-unused -x app/,bin/,random/ --no-fatal-missing',
+              ),
             );
           });
 
@@ -85,9 +94,11 @@ main() {
                 shouldDartfmtOutput: false,
                 expectedPatchCount: 1,
                 input: getCommandWithinContext(
-                    '$depValidatorCommand -i over_react'),
+                  '$depValidatorCommand -i over_react',
+                ),
                 expectedOutput: getCommandWithinContext(
-                    '$depValidatorCommand -i over_react,$addedDependency'),
+                  '$depValidatorCommand -i over_react,$addedDependency',
+                ),
               );
             });
 
@@ -96,9 +107,11 @@ main() {
                 shouldDartfmtOutput: false,
                 expectedPatchCount: 1,
                 input: getCommandWithinContext(
-                    '$depValidatorCommand -iover_react'),
+                  '$depValidatorCommand -iover_react',
+                ),
                 expectedOutput: getCommandWithinContext(
-                    '$depValidatorCommand -iover_react,$addedDependency'),
+                  '$depValidatorCommand -iover_react,$addedDependency',
+                ),
               );
             });
 
@@ -107,9 +120,11 @@ main() {
                 shouldDartfmtOutput: false,
                 expectedPatchCount: 1,
                 input: getCommandWithinContext(
-                    '$depValidatorCommand --ignore over_react'),
+                  '$depValidatorCommand --ignore over_react',
+                ),
                 expectedOutput: getCommandWithinContext(
-                    '$depValidatorCommand --ignore over_react,$addedDependency'),
+                  '$depValidatorCommand --ignore over_react,$addedDependency',
+                ),
               );
             });
 
@@ -118,9 +133,11 @@ main() {
                 shouldDartfmtOutput: false,
                 expectedPatchCount: 1,
                 input: getCommandWithinContext(
-                    '$depValidatorCommand --ignore=over_react'),
+                  '$depValidatorCommand --ignore=over_react',
+                ),
                 expectedOutput: getCommandWithinContext(
-                    '$depValidatorCommand --ignore=over_react,$addedDependency'),
+                  '$depValidatorCommand --ignore=over_react,$addedDependency',
+                ),
               );
             });
 
@@ -129,9 +146,11 @@ main() {
                 shouldDartfmtOutput: false,
                 expectedPatchCount: 1,
                 input: getCommandWithinContext(
-                    '$depValidatorCommand -i over_react,'),
+                  '$depValidatorCommand -i over_react,',
+                ),
                 expectedOutput: getCommandWithinContext(
-                    '$depValidatorCommand -i over_react,$addedDependency'),
+                  '$depValidatorCommand -i over_react,$addedDependency',
+                ),
               );
             });
 
@@ -140,9 +159,11 @@ main() {
                 shouldDartfmtOutput: false,
                 expectedPatchCount: 1,
                 input: getCommandWithinContext(
-                    '$depValidatorCommand -i over_react -x app/,bin/,random/ --no-fatal-missing'),
+                  '$depValidatorCommand -i over_react -x app/,bin/,random/ --no-fatal-missing',
+                ),
                 expectedOutput: getCommandWithinContext(
-                    '$depValidatorCommand -i over_react,$addedDependency -x app/,bin/,random/ --no-fatal-missing'),
+                  '$depValidatorCommand -i over_react,$addedDependency -x app/,bin/,random/ --no-fatal-missing',
+                ),
               );
             });
 
@@ -151,36 +172,42 @@ main() {
                 shouldDartfmtOutput: false,
                 expectedPatchCount: 1,
                 input: getCommandWithinContext(
-                    '$depValidatorCommand -x app/,bin/,random/ --no-fatal-missing -i over_react'),
+                  '$depValidatorCommand -x app/,bin/,random/ --no-fatal-missing -i over_react',
+                ),
                 expectedOutput: getCommandWithinContext(
-                    '$depValidatorCommand -x app/,bin/,random/ --no-fatal-missing -i over_react,$addedDependency'),
+                  '$depValidatorCommand -x app/,bin/,random/ --no-fatal-missing -i over_react,$addedDependency',
+                ),
               );
             });
 
-            test('when there are args on both sides of the ignore arg',
-                () async {
+            test('when there are args on both sides of the ignore arg', () async {
               await testSuggestor(
                 shouldDartfmtOutput: false,
                 expectedPatchCount: 1,
                 input: getCommandWithinContext(
-                    '$depValidatorCommand -x app/,bin/,random/ -i over_react --no-fatal-missing'),
+                  '$depValidatorCommand -x app/,bin/,random/ -i over_react --no-fatal-missing',
+                ),
                 expectedOutput: getCommandWithinContext(
-                    '$depValidatorCommand -x app/,bin/,random/ -i over_react,$addedDependency --no-fatal-missing'),
+                  '$depValidatorCommand -x app/,bin/,random/ -i over_react,$addedDependency --no-fatal-missing',
+                ),
               );
             });
 
             test(
-                'when the dependency name is part of an existing ignore dependency',
-                () async {
-              await testSuggestor(
-                shouldDartfmtOutput: false,
-                expectedPatchCount: 1,
-                input: getCommandWithinContext(
-                    '$depValidatorCommand -i ${addedDependency}_plus_more'),
-                expectedOutput: getCommandWithinContext(
-                    '$depValidatorCommand -i ${addedDependency}_plus_more,$addedDependency'),
-              );
-            });
+              'when the dependency name is part of an existing ignore dependency',
+              () async {
+                await testSuggestor(
+                  shouldDartfmtOutput: false,
+                  expectedPatchCount: 1,
+                  input: getCommandWithinContext(
+                    '$depValidatorCommand -i ${addedDependency}_plus_more',
+                  ),
+                  expectedOutput: getCommandWithinContext(
+                    '$depValidatorCommand -i ${addedDependency}_plus_more,$addedDependency',
+                  ),
+                );
+              },
+            );
           });
         });
       });
@@ -193,49 +220,58 @@ main() {
     test('adds to all locations within a file', () async {
       final getCommandWithinContext = contexts['basic-dockerfile'];
       await testSuggestor(
-          shouldDartfmtOutput: false,
-          expectedPatchCount: 2,
-          input: getCommandWithinContext!(
-              '$depValidatorCommand\n$depValidatorCommand'),
-          expectedOutput: getCommandWithinContext(
-              '$depValidatorCommand -i $addedDependency\n$depValidatorCommand -i $addedDependency'));
+        shouldDartfmtOutput: false,
+        expectedPatchCount: 2,
+        input: getCommandWithinContext!(
+          '$depValidatorCommand\n$depValidatorCommand',
+        ),
+        expectedOutput: getCommandWithinContext(
+          '$depValidatorCommand -i $addedDependency\n$depValidatorCommand -i $addedDependency',
+        ),
+      );
     });
 
     test('Adds a fixme if there are two ignore flags', () async {
       await testSuggestor(
-          shouldDartfmtOutput: false,
-          expectedPatchCount: 1,
-          input: '''
+        shouldDartfmtOutput: false,
+        expectedPatchCount: 1,
+        input:
+            '''
 RUN pub get
 RUN $depValidatorCommand -i over_react -x app/ -i over_react
 RUN dart format -l 80 --set-exit-if-changed lib/ test/
 RUN dart analyze --fatal-infos --fatal-warnings lib
 ''',
-          expectedOutput: '''
+        expectedOutput:
+            '''
 RUN pub get
 //FIXME: unexpected outcome; there should only be one ignore argument
 RUN $depValidatorCommand -i over_react -x app/ -i over_react
 RUN dart format -l 80 --set-exit-if-changed lib/ test/
 RUN dart analyze --fatal-infos --fatal-warnings lib
-''');
+''',
+      );
     });
   });
 }
 
-String basicDockerFile(String command) => '''
+String basicDockerFile(String command) =>
+    '''
 RUN pub get
 RUN $command
 RUN dart format -l 80 --set-exit-if-changed lib/ test/
 RUN dart analyze --fatal-infos --fatal-warnings lib
 ''';
 
-String chainedDockerfileCommand(String command) => '''
+String chainedDockerfileCommand(String command) =>
+    '''
 RUN pub get && \\
         $command && \\
         pub run dart_dev analyze
 ''';
 
-String dartCommand(String command) => '''
+String dartCommand(String command) =>
+    '''
 await Future.wait([
     run('$command',
         workingDirectory: analyzeDir),
@@ -243,7 +279,8 @@ await Future.wait([
   ]);
 ''';
 
-String dartDevTask(String command) => '''
+String dartDevTask(String command) =>
+    '''
 import 'package:dart_dev/dart_dev.dart'
     show dev, config, Environment, TestRunnerConfig;
 
@@ -276,7 +313,8 @@ main(List<String> args) async {
 }
 ''';
 
-String yamlScript(String command) => '''
+String yamlScript(String command) =>
+    '''
 language: dart
 
 dart:
@@ -291,7 +329,8 @@ script:
   - pub run test --concurrency=4 -p vm --reporter=expanded test/vm/
 ''';
 
-String yamlCiWorkflow(String command) => '''
+String yamlCiWorkflow(String command) =>
+    '''
 name: Dart CI
 
 on:
@@ -319,7 +358,8 @@ jobs:
         if: always() && steps.install.outcome == 'success'
 ''';
 
-String yamlSkynet(String command) => '''
+String yamlSkynet(String command) =>
+    '''
 ---
 # TODO: Remove this plan once the core checks cause failures.
 name: code_quality_analysis

--- a/test/dependency_validator/ignore_updaters/v2_updater_test.dart
+++ b/test/dependency_validator/ignore_updaters/v2_updater_test.dart
@@ -20,257 +20,279 @@ import '../../util.dart';
 main() {
   group('V2DependencyUpdater', () {
     const addedDependency = 'an_added_dependency';
-    final testSuggestor =
-        getSuggestorTester(V2DependencyValidatorUpdater(addedDependency));
+    final testSuggestor = getSuggestorTester(
+      V2DependencyValidatorUpdater(addedDependency),
+    );
 
     test('updates when the file is empty', () async {
       await testSuggestor(
-          shouldDartfmtOutput: false,
-          expectedPatchCount: 1,
-          input: '''''',
-          expectedOutput: ''
-              'dependency_validator:\n'
-              '  ignore:\n'
-              '    - $addedDependency\n'
-              '');
+        shouldDartfmtOutput: false,
+        expectedPatchCount: 1,
+        input: '''''',
+        expectedOutput:
+            ''
+            'dependency_validator:\n'
+            '  ignore:\n'
+            '    - $addedDependency\n'
+            '',
+      );
     });
 
     test('adds a dependency validator config if none exists', () async {
       await testSuggestor(
-          shouldDartfmtOutput: false,
-          expectedPatchCount: 1,
-          input: ''
-              'name: a_package\n'
-              'version: 1.3.4\n'
-              '\n'
-              '# a comment above environment\n'
-              'environment: ">=2.11.0 <3.0.0"\n'
-              '\n'
-              'dependencies:\n'
-              '  # a comment above a dependency\n'
-              '  a_dependency: ^1.0.0\n'
-              '',
-          expectedOutput: ''
-              'name: a_package\n'
-              'version: 1.3.4\n'
-              '\n'
-              '# a comment above environment\n'
-              'environment: ">=2.11.0 <3.0.0"\n'
-              '\n'
-              'dependencies:\n'
-              '  # a comment above a dependency\n'
-              '  a_dependency: ^1.0.0\n'
-              '\n'
-              'dependency_validator:\n'
-              '  ignore:\n'
-              '    - $addedDependency\n'
-              '');
+        shouldDartfmtOutput: false,
+        expectedPatchCount: 1,
+        input:
+            ''
+            'name: a_package\n'
+            'version: 1.3.4\n'
+            '\n'
+            '# a comment above environment\n'
+            'environment: ">=2.11.0 <3.0.0"\n'
+            '\n'
+            'dependencies:\n'
+            '  # a comment above a dependency\n'
+            '  a_dependency: ^1.0.0\n'
+            '',
+        expectedOutput:
+            ''
+            'name: a_package\n'
+            'version: 1.3.4\n'
+            '\n'
+            '# a comment above environment\n'
+            'environment: ">=2.11.0 <3.0.0"\n'
+            '\n'
+            'dependencies:\n'
+            '  # a comment above a dependency\n'
+            '  a_dependency: ^1.0.0\n'
+            '\n'
+            'dependency_validator:\n'
+            '  ignore:\n'
+            '    - $addedDependency\n'
+            '',
+      );
     });
 
     group('adds an ignore tag if one is not present', () {
       test('and the config is at the bottom of the pubspec', () async {
         await testSuggestor(
-            shouldDartfmtOutput: false,
-            expectedPatchCount: 1,
-            input: ''
-                'name: a_package\n'
-                'version: 1.3.4\n'
-                '\n'
-                '# a comment above environment\n'
-                'environment: ">=2.11.0 <3.0.0"\n'
-                '\n'
-                'dependencies:\n'
-                '  # a comment above a dependency\n'
-                '  a_dependency: ^1.0.0\n'
-                '\n'
-                'dependency_validator:\n'
-                '  exclude:\n'
-                '    # a comment above an excluded directory\n'
-                '    - app\n'
-                '',
-            expectedOutput: ''
-                'name: a_package\n'
-                'version: 1.3.4\n'
-                '\n'
-                '# a comment above environment\n'
-                'environment: ">=2.11.0 <3.0.0"\n'
-                '\n'
-                'dependencies:\n'
-                '  # a comment above a dependency\n'
-                '  a_dependency: ^1.0.0\n'
-                '\n'
-                'dependency_validator:\n'
-                '  exclude:\n'
-                '    # a comment above an excluded directory\n'
-                '    - app\n'
-                '  ignore:\n'
-                '    - $addedDependency\n'
-                '');
-      });
-
-      test('and the config is not at the bottom of the pubspec', () async {
-        await testSuggestor(
-            shouldDartfmtOutput: false,
-            expectedPatchCount: 1,
-            input: ''
-                'name: a_package\n'
-                'version: 1.3.4\n'
-                '\n'
-                '# a comment above environment\n'
-                'environment: ">=2.11.0 <3.0.0"\n'
-                '\n'
-                'dependencies:\n'
-                '  # a comment above a dependency\n'
-                '  a_dependency: ^1.0.0\n'
-                '\n'
-                'dependency_validator:\n'
-                '  exclude:\n'
-                '    # a comment above an excluded directory\n'
-                '    - app\n'
-                '\n'
-                'dependency_overrides:\n'
-                '  over_react:\n'
-                '    path: ../over_react\n'
-                '',
-            expectedOutput: ''
-                'name: a_package\n'
-                'version: 1.3.4\n'
-                '\n'
-                '# a comment above environment\n'
-                'environment: ">=2.11.0 <3.0.0"\n'
-                '\n'
-                'dependencies:\n'
-                '  # a comment above a dependency\n'
-                '  a_dependency: ^1.0.0\n'
-                '\n'
-                'dependency_validator:\n'
-                '  exclude:\n'
-                '    # a comment above an excluded directory\n'
-                '    - app\n'
-                '  ignore:\n'
-                '    - $addedDependency\n'
-                '\n'
-                'dependency_overrides:\n'
-                '  over_react:\n'
-                '    path: ../over_react\n'
-                '');
-      });
-    });
-
-    group('appends the new dependency to the ignore tag if the tag is present',
-        () {
-      test('and the config is at the bottom of the pubspec', () async {
-        await testSuggestor(
-            shouldDartfmtOutput: false,
-            expectedPatchCount: 1,
-            input: ''
-                'name: a_package\n'
-                'version: 1.3.4\n'
-                '\n'
-                'environment: ">=2.11.0 <3.0.0"\n'
-                '\n'
-                'dependencies:\n'
-                '  a_dependency: ^1.0.0\n'
-                '\n'
-                'dependency_validator:\n'
-                '  exclude:\n'
-                '    # a comment above an excluded directory\n'
-                '    - app\n'
-                '  ignore:\n'
-                '    # a comment above an excluded dependency\n'
-                '    - a_dependency\n'
-                '',
-            expectedOutput: ''
-                'name: a_package\n'
-                'version: 1.3.4\n'
-                '\n'
-                'environment: ">=2.11.0 <3.0.0"\n'
-                '\n'
-                'dependencies:\n'
-                '  a_dependency: ^1.0.0\n'
-                '\n'
-                'dependency_validator:\n'
-                '  exclude:\n'
-                '    # a comment above an excluded directory\n'
-                '    - app\n'
-                '  ignore:\n'
-                '    # a comment above an excluded dependency\n'
-                '    - a_dependency\n'
-                '    - $addedDependency\n'
-                '');
-      });
-
-      test('and the config is not in the bottom of the pubspec', () async {
-        await testSuggestor(
-            shouldDartfmtOutput: false,
-            expectedPatchCount: 1,
-            input: ''
-                'name: a_package\n'
-                'version: 1.3.4\n'
-                '\n'
-                'environment: ">=2.11.0 <3.0.0"\n'
-                '\n'
-                'dependencies:\n'
-                '  a_dependency: ^1.0.0\n'
-                '\n'
-                'dependency_validator:\n'
-                '  exclude:\n'
-                '    # a comment above an excluded directory\n'
-                '    - app\n'
-                '  ignore:\n'
-                '    # a comment above an excluded dependency\n'
-                '    - a_dependency\n'
-                '\n'
-                'dependency_overrides:\n'
-                '  over_react:\n'
-                '    path: ../over_react\n'
-                '',
-            expectedOutput: ''
-                'name: a_package\n'
-                'version: 1.3.4\n'
-                '\n'
-                'environment: ">=2.11.0 <3.0.0"\n'
-                '\n'
-                'dependencies:\n'
-                '  a_dependency: ^1.0.0\n'
-                '\n'
-                'dependency_validator:\n'
-                '  exclude:\n'
-                '    # a comment above an excluded directory\n'
-                '    - app\n'
-                '  ignore:\n'
-                '    # a comment above an excluded dependency\n'
-                '    - a_dependency\n'
-                '    - $addedDependency\n'
-                '\n'
-                'dependency_overrides:\n'
-                '  over_react:\n'
-                '    path: ../over_react\n'
-                '');
-      });
-    });
-
-    test('makes no change if the dependency is already there', () async {
-      await testSuggestor(
           shouldDartfmtOutput: false,
-          expectedPatchCount: 0,
-          input: ''
+          expectedPatchCount: 1,
+          input:
+              ''
               'name: a_package\n'
               'version: 1.3.4\n'
               '\n'
+              '# a comment above environment\n'
               'environment: ">=2.11.0 <3.0.0"\n'
               '\n'
               'dependencies:\n'
+              '  # a comment above a dependency\n'
               '  a_dependency: ^1.0.0\n'
+              '\n'
+              'dependency_validator:\n'
+              '  exclude:\n'
+              '    # a comment above an excluded directory\n'
+              '    - app\n'
+              '',
+          expectedOutput:
+              ''
+              'name: a_package\n'
+              'version: 1.3.4\n'
+              '\n'
+              '# a comment above environment\n'
+              'environment: ">=2.11.0 <3.0.0"\n'
+              '\n'
+              'dependencies:\n'
+              '  # a comment above a dependency\n'
+              '  a_dependency: ^1.0.0\n'
+              '\n'
               'dependency_validator:\n'
               '  exclude:\n'
               '    # a comment above an excluded directory\n'
               '    - app\n'
               '  ignore:\n'
-              '    # a comment above an excluded dependency\n'
-              '    - a_dependency\n'
               '    - $addedDependency\n'
-              '');
+              '',
+        );
+      });
+
+      test('and the config is not at the bottom of the pubspec', () async {
+        await testSuggestor(
+          shouldDartfmtOutput: false,
+          expectedPatchCount: 1,
+          input:
+              ''
+              'name: a_package\n'
+              'version: 1.3.4\n'
+              '\n'
+              '# a comment above environment\n'
+              'environment: ">=2.11.0 <3.0.0"\n'
+              '\n'
+              'dependencies:\n'
+              '  # a comment above a dependency\n'
+              '  a_dependency: ^1.0.0\n'
+              '\n'
+              'dependency_validator:\n'
+              '  exclude:\n'
+              '    # a comment above an excluded directory\n'
+              '    - app\n'
+              '\n'
+              'dependency_overrides:\n'
+              '  over_react:\n'
+              '    path: ../over_react\n'
+              '',
+          expectedOutput:
+              ''
+              'name: a_package\n'
+              'version: 1.3.4\n'
+              '\n'
+              '# a comment above environment\n'
+              'environment: ">=2.11.0 <3.0.0"\n'
+              '\n'
+              'dependencies:\n'
+              '  # a comment above a dependency\n'
+              '  a_dependency: ^1.0.0\n'
+              '\n'
+              'dependency_validator:\n'
+              '  exclude:\n'
+              '    # a comment above an excluded directory\n'
+              '    - app\n'
+              '  ignore:\n'
+              '    - $addedDependency\n'
+              '\n'
+              'dependency_overrides:\n'
+              '  over_react:\n'
+              '    path: ../over_react\n'
+              '',
+        );
+      });
+    });
+
+    group(
+      'appends the new dependency to the ignore tag if the tag is present',
+      () {
+        test('and the config is at the bottom of the pubspec', () async {
+          await testSuggestor(
+            shouldDartfmtOutput: false,
+            expectedPatchCount: 1,
+            input:
+                ''
+                'name: a_package\n'
+                'version: 1.3.4\n'
+                '\n'
+                'environment: ">=2.11.0 <3.0.0"\n'
+                '\n'
+                'dependencies:\n'
+                '  a_dependency: ^1.0.0\n'
+                '\n'
+                'dependency_validator:\n'
+                '  exclude:\n'
+                '    # a comment above an excluded directory\n'
+                '    - app\n'
+                '  ignore:\n'
+                '    # a comment above an excluded dependency\n'
+                '    - a_dependency\n'
+                '',
+            expectedOutput:
+                ''
+                'name: a_package\n'
+                'version: 1.3.4\n'
+                '\n'
+                'environment: ">=2.11.0 <3.0.0"\n'
+                '\n'
+                'dependencies:\n'
+                '  a_dependency: ^1.0.0\n'
+                '\n'
+                'dependency_validator:\n'
+                '  exclude:\n'
+                '    # a comment above an excluded directory\n'
+                '    - app\n'
+                '  ignore:\n'
+                '    # a comment above an excluded dependency\n'
+                '    - a_dependency\n'
+                '    - $addedDependency\n'
+                '',
+          );
+        });
+
+        test('and the config is not in the bottom of the pubspec', () async {
+          await testSuggestor(
+            shouldDartfmtOutput: false,
+            expectedPatchCount: 1,
+            input:
+                ''
+                'name: a_package\n'
+                'version: 1.3.4\n'
+                '\n'
+                'environment: ">=2.11.0 <3.0.0"\n'
+                '\n'
+                'dependencies:\n'
+                '  a_dependency: ^1.0.0\n'
+                '\n'
+                'dependency_validator:\n'
+                '  exclude:\n'
+                '    # a comment above an excluded directory\n'
+                '    - app\n'
+                '  ignore:\n'
+                '    # a comment above an excluded dependency\n'
+                '    - a_dependency\n'
+                '\n'
+                'dependency_overrides:\n'
+                '  over_react:\n'
+                '    path: ../over_react\n'
+                '',
+            expectedOutput:
+                ''
+                'name: a_package\n'
+                'version: 1.3.4\n'
+                '\n'
+                'environment: ">=2.11.0 <3.0.0"\n'
+                '\n'
+                'dependencies:\n'
+                '  a_dependency: ^1.0.0\n'
+                '\n'
+                'dependency_validator:\n'
+                '  exclude:\n'
+                '    # a comment above an excluded directory\n'
+                '    - app\n'
+                '  ignore:\n'
+                '    # a comment above an excluded dependency\n'
+                '    - a_dependency\n'
+                '    - $addedDependency\n'
+                '\n'
+                'dependency_overrides:\n'
+                '  over_react:\n'
+                '    path: ../over_react\n'
+                '',
+          );
+        });
+      },
+    );
+
+    test('makes no change if the dependency is already there', () async {
+      await testSuggestor(
+        shouldDartfmtOutput: false,
+        expectedPatchCount: 0,
+        input:
+            ''
+            'name: a_package\n'
+            'version: 1.3.4\n'
+            '\n'
+            'environment: ">=2.11.0 <3.0.0"\n'
+            '\n'
+            'dependencies:\n'
+            '  a_dependency: ^1.0.0\n'
+            'dependency_validator:\n'
+            '  exclude:\n'
+            '    # a comment above an excluded directory\n'
+            '    - app\n'
+            '  ignore:\n'
+            '    # a comment above an excluded dependency\n'
+            '    - a_dependency\n'
+            '    - $addedDependency\n'
+            '',
+      );
     });
   });
 }

--- a/test/dependency_validator/ignore_updaters/v3_updater_test.dart
+++ b/test/dependency_validator/ignore_updaters/v3_updater_test.dart
@@ -20,46 +20,54 @@ import '../../util.dart';
 main() {
   group('V3DependencyUpdater', () {
     const addedDependency = 'an_added_dependency';
-    final testSuggestor =
-        getSuggestorTester(V3DependencyValidatorUpdater(addedDependency));
+    final testSuggestor = getSuggestorTester(
+      V3DependencyValidatorUpdater(addedDependency),
+    );
 
     test('updates when the file is empty', () async {
       await testSuggestor(
-          shouldDartfmtOutput: false,
-          expectedPatchCount: 1,
-          input: '''''',
-          expectedOutput: ''
-              'ignore:\n'
-              '  - $addedDependency\n'
-              '');
+        shouldDartfmtOutput: false,
+        expectedPatchCount: 1,
+        input: '''''',
+        expectedOutput:
+            ''
+            'ignore:\n'
+            '  - $addedDependency\n'
+            '',
+      );
     });
 
     test('adds an ignore tag if one is not present', () async {
       await testSuggestor(
-          shouldDartfmtOutput: false,
-          expectedPatchCount: 1,
-          input: ''
-              '# a comment above exclude\n'
-              'exclude:\n'
-              '  # a comment above an excluded directory\n'
-              '  - app\n'
-              '',
-          expectedOutput: ''
-              '# a comment above exclude\n'
-              'exclude:\n'
-              '  # a comment above an excluded directory\n'
-              '  - app\n'
-              'ignore:\n'
-              '  - $addedDependency\n'
-              '');
+        shouldDartfmtOutput: false,
+        expectedPatchCount: 1,
+        input:
+            ''
+            '# a comment above exclude\n'
+            'exclude:\n'
+            '  # a comment above an excluded directory\n'
+            '  - app\n'
+            '',
+        expectedOutput:
+            ''
+            '# a comment above exclude\n'
+            'exclude:\n'
+            '  # a comment above an excluded directory\n'
+            '  - app\n'
+            'ignore:\n'
+            '  - $addedDependency\n'
+            '',
+      );
     });
 
-    test('appends the new dependency to the ignore tag if the tag is present',
-        () async {
-      await testSuggestor(
+    test(
+      'appends the new dependency to the ignore tag if the tag is present',
+      () async {
+        await testSuggestor(
           shouldDartfmtOutput: false,
           expectedPatchCount: 1,
-          input: ''
+          input:
+              ''
               '# a comment above exclude\n'
               'exclude:\n'
               '  # a comment above an excluded directory\n'
@@ -68,7 +76,8 @@ main() {
               '  # a comment above a specific dependency\n'
               '  - a_dependency\n'
               '',
-          expectedOutput: ''
+          expectedOutput:
+              ''
               '# a comment above exclude\n'
               'exclude:\n'
               '  # a comment above an excluded directory\n'
@@ -77,23 +86,27 @@ main() {
               '  # a comment above a specific dependency\n'
               '  - a_dependency\n'
               '  - $addedDependency\n'
-              '');
-    });
+              '',
+        );
+      },
+    );
 
     test('makes no change if the dependency is already there', () async {
       await testSuggestor(
-          shouldDartfmtOutput: false,
-          expectedPatchCount: 0,
-          input: ''
-              '# a comment above exclude\n'
-              'exclude:\n'
-              '  # a comment above an excluded directory\n'
-              '  - app\n'
-              'ignore:\n'
-              '  # a comment above a specific dependency\n'
-              '  - a_dependency\n'
-              '  - $addedDependency\n'
-              '');
+        shouldDartfmtOutput: false,
+        expectedPatchCount: 0,
+        input:
+            ''
+            '# a comment above exclude\n'
+            'exclude:\n'
+            '  # a comment above an excluded directory\n'
+            '  - app\n'
+            'ignore:\n'
+            '  # a comment above a specific dependency\n'
+            '  - a_dependency\n'
+            '  - $addedDependency\n'
+            '',
+      );
     });
   });
 }

--- a/test/executables/intl_message_migration_test.dart
+++ b/test/executables/intl_message_migration_test.dart
@@ -30,156 +30,184 @@ String condenseWhitespace(String input) =>
 void main() {
   group('intl_message_migration executable', () {
     final script = p.join(
-        findPackageRootFor(p.current), 'bin/intl_message_migration.dart');
+      findPackageRootFor(p.current),
+      'bin/intl_message_migration.dart',
+    );
 
-    testCodemod('--help outputs usage help text and does not run the codemod',
-        script: script,
-        input: inputFiles(),
-        expectedOutput: inputFiles(),
-        expectedExitCode: 0,
-        args: ['--help'], body: (out, err) {
-      expect(
+    testCodemod(
+      '--help outputs usage help text and does not run the codemod',
+      script: script,
+      input: inputFiles(),
+      expectedOutput: inputFiles(),
+      expectedExitCode: 0,
+      args: ['--help'],
+      body: (out, err) {
+        expect(
           condenseWhitespace(err),
           allOf(
             contains(condenseWhitespace(codemodArgParser.usage)),
             contains('Migrates literal strings'),
-          ));
-    });
-
-    testCodemod('applies all patches via --yes-to-all,',
-        script: script,
-        input: inputFiles(),
-        expectedOutput: expectedOutputFiles(),
-        args: ['--yes-to-all']);
-
-    testCodemod('--fail-on-changes exits with 0 when no changes needed',
-        script: script,
-        input: expectedOutputFiles(),
-        expectedOutput: expectedOutputFiles(),
-        args: ['--fail-on-changes'], body: (out, err) {
-      expect(out, contains('No changes needed.'));
-    });
+          ),
+        );
+      },
+    );
 
     testCodemod(
-        '--fail-on-changes exits with non-zero when changes needed and does not update files',
-        script: script,
-        input: inputFiles(),
-        expectedOutput: inputFiles(),
-        args: ['--fail-on-changes'],
-        expectedExitCode: 1, body: (out, err) {
-      expect(err, contains(' change(s) needed.'));
-    });
+      'applies all patches via --yes-to-all,',
+      script: script,
+      input: inputFiles(),
+      expectedOutput: expectedOutputFiles(),
+      args: ['--yes-to-all'],
+    );
+
+    testCodemod(
+      '--fail-on-changes exits with 0 when no changes needed',
+      script: script,
+      input: expectedOutputFiles(),
+      expectedOutput: expectedOutputFiles(),
+      args: ['--fail-on-changes'],
+      body: (out, err) {
+        expect(out, contains('No changes needed.'));
+      },
+    );
+
+    testCodemod(
+      '--fail-on-changes exits with non-zero when changes needed and does not update files',
+      script: script,
+      input: inputFiles(),
+      expectedOutput: inputFiles(),
+      args: ['--fail-on-changes'],
+      expectedExitCode: 1,
+      body: (out, err) {
+        expect(err, contains(' change(s) needed.'));
+      },
+    );
 
     // It would be nice to verify that the file modification date is newer, but
     // the codemod test framework doesn't really support that.
-    testCodemod('--no-migrate exits with zero, does not does not update files',
-        script: script,
-        input: inputFiles(),
-        expectedOutput: inputFiles(),
-        args: ['--no-migrate']);
+    testCodemod(
+      '--no-migrate exits with zero, does not does not update files',
+      script: script,
+      input: inputFiles(),
+      expectedOutput: inputFiles(),
+      args: ['--no-migrate'],
+    );
 
-    testCodemod('Output is sorted',
-        script: script,
-        input: inputFiles(additionalFilesInLib: [extraInput()]),
-        expectedOutput: expectedOutputFiles(
-            additionalFilesInLib: [extraOutput()],
-            messages: [...defaultMessages, ...extraMessages, ...longMessages]
-              ..sort()),
-        args: ['--yes-to-all']);
+    testCodemod(
+      'Output is sorted',
+      script: script,
+      input: inputFiles(additionalFilesInLib: [extraInput()]),
+      expectedOutput: expectedOutputFiles(
+        additionalFilesInLib: [extraOutput()],
+        messages: [...defaultMessages, ...extraMessages, ...longMessages]
+          ..sort(),
+      ),
+      args: ['--yes-to-all'],
+    );
 
     // Test that additional information (desc, meaning) are preserved if we read and then rewrite the file.
-    testCodemod('Manual modifications are preserved',
-        script: script,
-        input: expectedOutputFiles(additionalFilesInLib: [
-          extraInput()
-        ], messages: [
-          ...defaultMessages,
-          ...annotatedMessages,
-        ]),
-        expectedOutput: expectedOutputFiles(
-            additionalFilesInLib: [extraOutput()],
-            messages: [
-              ...defaultMessages,
-              ...annotatedMessages,
-              ...longMessages,
-            ]..sort()),
-        args: ['--yes-to-all']);
+    testCodemod(
+      'Manual modifications are preserved',
+      script: script,
+      input: expectedOutputFiles(
+        additionalFilesInLib: [extraInput()],
+        messages: [...defaultMessages, ...annotatedMessages],
+      ),
+      expectedOutput: expectedOutputFiles(
+        additionalFilesInLib: [extraOutput()],
+        messages: [...defaultMessages, ...annotatedMessages, ...longMessages]
+          ..sort(),
+      ),
+      args: ['--yes-to-all'],
+    );
 
     // We've removed the file for some that were already in the _intl.dart file,
     // and we expect them to be removed.
-    testCodemod('Unused messages are removed',
-        script: script,
-        input: expectedOutputFiles(additionalFilesInLib: [], messages: [
-          ...defaultMessages,
-          ...annotatedMessages,
-        ]),
-        expectedOutput: expectedOutputFiles(
-            additionalFilesInLib: [], messages: [...defaultMessages]..sort()),
-        args: ['--yes-to-all', '--prune-unused']);
+    testCodemod(
+      'Unused messages are removed',
+      script: script,
+      input: expectedOutputFiles(
+        additionalFilesInLib: [],
+        messages: [...defaultMessages, ...annotatedMessages],
+      ),
+      expectedOutput: expectedOutputFiles(
+        additionalFilesInLib: [],
+        messages: [...defaultMessages]..sort(),
+      ),
+      args: ['--yes-to-all', '--prune-unused'],
+    );
 
     // Don't prune, but remove the input file. Also add some extra messages to force
     // the file to be rewritten, and ensure the unused messages are still there.
-    testCodemod("Unused messages are not removed if we don't pass the flag",
-        script: script,
-        input: expectedOutputFiles(additionalFilesInLib: [
-          extraInput()
-        ], messages: [
-          ...defaultMessages,
-          ...annotatedMessages,
-        ]),
-        expectedOutput: expectedOutputFiles(
-            additionalFilesInLib: [],
-            messages: [
-              ...defaultMessages,
-              ...annotatedMessages,
-              ...longMessages
-            ]..sort()),
-        args: ['--yes-to-all']);
+    testCodemod(
+      "Unused messages are not removed if we don't pass the flag",
+      script: script,
+      input: expectedOutputFiles(
+        additionalFilesInLib: [extraInput()],
+        messages: [...defaultMessages, ...annotatedMessages],
+      ),
+      expectedOutput: expectedOutputFiles(
+        additionalFilesInLib: [],
+        messages: [...defaultMessages, ...annotatedMessages, ...longMessages]
+          ..sort(),
+      ),
+      args: ['--yes-to-all'],
+    );
 
     // Test that we update the file to use the w_intl import, even if there are no other changes.
-    testCodemod('Import is updated',
-        script: script,
-        input: expectedOutputFiles(additionalFilesInLib: [
-          extraInput()
-        ], messages: [
-          ...defaultMessages,
-          ...annotatedMessages,
-        ], intlImport: 'intl/intl.dart'),
-        expectedOutput: expectedOutputFiles(
-            additionalFilesInLib: [extraOutput()],
-            messages: [
-              ...defaultMessages,
-              ...annotatedMessages,
-              ...longMessages
-            ]..sort()),
-        args: ['--yes-to-all']);
+    testCodemod(
+      'Import is updated',
+      script: script,
+      input: expectedOutputFiles(
+        additionalFilesInLib: [extraInput()],
+        messages: [...defaultMessages, ...annotatedMessages],
+        intlImport: 'intl/intl.dart',
+      ),
+      expectedOutput: expectedOutputFiles(
+        additionalFilesInLib: [extraOutput()],
+        messages: [...defaultMessages, ...annotatedMessages, ...longMessages]
+          ..sort(),
+      ),
+      args: ['--yes-to-all'],
+    );
 
-    testCodemod('Import is updated without other modifications',
-        script: script,
-        input: expectedOutputFiles(intlImport: 'intl/intl.dart'),
-        expectedOutput: expectedOutputFiles(),
-        args: ['--yes-to-all']);
+    testCodemod(
+      'Import is updated without other modifications',
+      script: script,
+      input: expectedOutputFiles(intlImport: 'intl/intl.dart'),
+      expectedOutput: expectedOutputFiles(),
+      args: ['--yes-to-all'],
+    );
 
-    testCodemod('Specify a single file',
-        // We add some extra files, but we specify just the original, so they shouldn't be included.
-        script: script,
-        input: inputFiles(additionalFilesInLib: [extraInput()]),
-        expectedOutput: expectedOutputFiles(messages: defaultMessages),
-        args: ['--yes-to-all', 'lib/usage.dart']);
+    testCodemod(
+      'Specify a single file',
+      // We add some extra files, but we specify just the original, so they shouldn't be included.
+      script: script,
+      input: inputFiles(additionalFilesInLib: [extraInput()]),
+      expectedOutput: expectedOutputFiles(messages: defaultMessages),
+      args: ['--yes-to-all', 'lib/usage.dart'],
+    );
 
-    testCodemod('Specifying only part files is an error',
-        script: script,
-        input: inputFiles(additionalFilesInLib: [
+    testCodemod(
+      'Specifying only part files is an error',
+      script: script,
+      input: inputFiles(
+        additionalFilesInLib: [
           d.file(
-              'a_part_file.dart', /*language=dart*/ '''part of something.bigger;
+            'a_part_file.dart',
+            /*language=dart*/ '''part of something.bigger;
 
-someMoreStrings() => (mui.Button()..aria.label='orange')('aquamarine');''')
-        ]),
-        expectedOutput: inputFiles(),
-        args: ['--yes-to-all', 'lib/a_part_file.dart'],
-        expectedExitCode: 1, body: (out, err) {
-      expect(err, contains('Only part files were specified'));
-    });
+someMoreStrings() => (mui.Button()..aria.label='orange')('aquamarine');''',
+          ),
+        ],
+      ),
+      expectedOutput: inputFiles(),
+      args: ['--yes-to-all', 'lib/a_part_file.dart'],
+      expectedExitCode: 1,
+      body: (out, err) {
+        expect(err, contains('Only part files were specified'));
+      },
+    );
   }, tags: 'wsd');
 
   group('limit paths', () {
@@ -191,8 +219,10 @@ someMoreStrings() => (mui.Button()..aria.label='orange')('aquamarine');''')
 
     test('multiples all match', () {
       var allowed = ['lib/b.dart', 'lib/src/a.dart'];
-      expect(
-          limitPaths(all, allowed: allowed), ['lib/src/a.dart', 'lib/b.dart']);
+      expect(limitPaths(all, allowed: allowed), [
+        'lib/src/a.dart',
+        'lib/b.dart',
+      ]);
     });
     test('multiples some match', () {
       var allowed = ['lib/nothere.dart', 'lib/src/a/c.dart'];
@@ -200,15 +230,20 @@ someMoreStrings() => (mui.Button()..aria.label='orange')('aquamarine');''')
     });
     test('directory match', () {
       var allowed = ['lib/src'];
-      expect(limitPaths(all, allowed: allowed),
-          ['lib/src/a.dart', 'lib/src/a/c.dart']);
+      expect(limitPaths(all, allowed: allowed), [
+        'lib/src/a.dart',
+        'lib/src/a/c.dart',
+      ]);
     });
 
     test('directory plus file', () {
       var allowed = ['lib/src', 'test/foo.dart'];
       var allFiles = [...all, 'test/foo.dart', 'test/other.dart'];
-      expect(limitPaths(allFiles, allowed: allowed),
-          ['lib/src/a.dart', 'lib/src/a/c.dart', 'test/foo.dart']);
+      expect(limitPaths(allFiles, allowed: allowed), [
+        'lib/src/a.dart',
+        'lib/src/a/c.dart',
+        'test/foo.dart',
+      ]);
     });
     test('no match for file', () {
       var allowed = ['lib/src/nothere.dart'];
@@ -224,8 +259,9 @@ someMoreStrings() => (mui.Button()..aria.label='orange')('aquamarine');''')
 
 /// An extra input file we can use.
 d.FileDescriptor extraInput() {
-  return d.file('more_stuff.dart',
-      /*language=dart*/ '''import 'package:react_material_ui/react_material_ui.dart' as mui;
+  return d.file(
+    'more_stuff.dart',
+    /*language=dart*/ '''import 'package:react_material_ui/react_material_ui.dart' as mui;
 
 someMoreStrings() => (mui.Button()
   ..aria.label='orange'
@@ -235,30 +271,33 @@ with multiple
    lines""")
     ('aquamarine',
      'two adjacent '
-     'strings on separate lines');''');
+     'strings on separate lines');''',
+  );
 }
 
 d.FileDescriptor extraOutput() {
-  return d.file('more_stuff.dart',
-      /*language=dart*/ '''import 'package:react_material_ui/react_material_ui.dart' as mui;
+  return d.file(
+    'more_stuff.dart',
+    /*language=dart*/ '''import 'package:react_material_ui/react_material_ui.dart' as mui;
 import 'package:test_project/src/intl/test_project_intl.dart';
 
 someMoreStrings() => (mui.Button()
   ..aria.label=TestProjectIntl.orange
   ..label=TestProjectIntl.aLongStringwithMultipleLines)
     (TestProjectIntl.aquamarine,
-     TestProjectIntl.twoAdjacentStringsOnSeparate);''');
+     TestProjectIntl.twoAdjacentStringsOnSeparate);''',
+  );
 }
 
 List<String> extraMessages = [
   "  static String get orange => Intl.message('orange', name: 'TestProjectIntl_orange');",
-  "  static String get aquamarine => Intl.message('aquamarine', name: 'TestProjectIntl_aquamarine');"
+  "  static String get aquamarine => Intl.message('aquamarine', name: 'TestProjectIntl_aquamarine');",
 ];
 
 /// Messages that have extra parameters we want to preserve.
 List<String> annotatedMessages = [
   "  static String get orange => Intl.message('orange', name: 'TestProjectIntl_orange', desc: 'The color.');",
-  "  static String get aquamarine => Intl.message('aquamarine', name: 'TestProjectIntl_aquamarine', desc: 'The color', meaning: 'blueish');"
+  "  static String get aquamarine => Intl.message('aquamarine', name: 'TestProjectIntl_aquamarine', desc: 'The color', meaning: 'blueish');",
 ];
 
 List<String> longMessages = [
@@ -268,8 +307,9 @@ with multiple
    lines''', name: 'TestProjectIntl_aLongStringwithMultipleLines');""",
 ];
 
-d.DirectoryDescriptor inputFiles(
-    {Iterable<d.Descriptor> additionalFilesInLib = const []}) {
+d.DirectoryDescriptor inputFiles({
+  Iterable<d.Descriptor> additionalFilesInLib = const [],
+}) {
   String rmuiVersionConstraint = '^1.1.1';
   return d.dir('project', [
     d.file('pubspec.yaml', /*language=yaml*/ '''
@@ -284,10 +324,12 @@ dependencies:
     version: $rmuiVersionConstraint'''),
     d.dir('lib', [
       ...additionalFilesInLib,
-      d.file('usage.dart',
-          /*language=dart*/ '''import 'package:react_material_ui/react_material_ui.dart' as mui;
+      d.file(
+        'usage.dart',
+        /*language=dart*/ '''import 'package:react_material_ui/react_material_ui.dart' as mui;
 
-usage() => (mui.Button()..aria.label='Sorts later')('Literal String');''')
+usage() => (mui.Button()..aria.label='Sorts later')('Literal String');''',
+      ),
     ]),
   ]);
 }
@@ -297,11 +339,12 @@ const List<String> defaultMessages = [
   "  static String get sortsLater => Intl.message('Sorts later', name: 'TestProjectIntl_sortsLater');",
 ];
 
-d.DirectoryDescriptor expectedOutputFiles(
-    {Iterable<d.Descriptor> additionalFilesInLib = const [],
-    List<String> messages = defaultMessages,
-    String rmuiVersionConstraint = '^1.1.1',
-    String intlImport = '${wIntl}/intl_wrapper.dart'}) {
+d.DirectoryDescriptor expectedOutputFiles({
+  Iterable<d.Descriptor> additionalFilesInLib = const [],
+  List<String> messages = defaultMessages,
+  String rmuiVersionConstraint = '^1.1.1',
+  String intlImport = '${wIntl}/intl_wrapper.dart',
+}) {
   return d.dir('project', [
     // Note that the codemod doesn't currently add the intl dependency to the pubspec.
     d.file('pubspec.yaml', /*language=yaml*/ '''
@@ -316,11 +359,14 @@ dependencies:
     version: $rmuiVersionConstraint'''),
     d.dir('lib', [
       ...additionalFilesInLib,
-      d.file('usage.dart', /*language=dart*/ '''
+      d.file(
+        'usage.dart',
+        /*language=dart*/ '''
 import 'package:react_material_ui/react_material_ui.dart' as mui;
 import 'package:test_project/src/intl/test_project_intl.dart';
 
-usage() => (mui.Button()..aria.label=TestProjectIntl.sortsLater)(TestProjectIntl.literalString);'''),
+usage() => (mui.Button()..aria.label=TestProjectIntl.sortsLater)(TestProjectIntl.literalString);''',
+      ),
       d.dir('src', [
         d.dir('intl', [
           d.file('test_project_intl.dart', /*language=dart*/ '''
@@ -333,7 +379,7 @@ ${IntlMessages.introComment}
 class TestProjectIntl {
 ${messages.join('\n\n')}
 
-}''')
+}'''),
         ]),
       ]),
     ]),

--- a/test/executables/mui_migration_test.dart
+++ b/test/executables/mui_migration_test.dart
@@ -28,52 +28,67 @@ import 'package:test_descriptor/test_descriptor.dart' as d;
 final _debug = false;
 
 void main() {
-  group('mui_migration executable', () {
-    final muiCodemodScript =
-        p.join(findPackageRootFor(p.current), 'bin/mui_migration.dart');
+  group(
+    'mui_migration executable',
+    () {
+      final muiCodemodScript = p.join(
+        findPackageRootFor(p.current),
+        'bin/mui_migration.dart',
+      );
 
-    testCodemod('--help outputs usage help text and does not run the codemod',
+      testCodemod(
+        '--help outputs usage help text and does not run the codemod',
         script: muiCodemodScript,
         input: inputFiles(),
         expectedOutput: inputFiles(),
         expectedExitCode: 0,
-        args: ['--help'], body: (out, err) {
-      expect(
-          err,
-          allOf(
-            contains(codemodArgParser.usage),
-            contains('MUI Migration Options:'),
-          ));
-    });
+        args: ['--help'],
+        body: (out, err) {
+          expect(
+            err,
+            allOf(
+              contains(codemodArgParser.usage),
+              contains('MUI Migration Options:'),
+            ),
+          );
+        },
+      );
 
-    testCodemod(
+      testCodemod(
         'applies all patches via --yes-to-all,'
         'and also correctly runs `pub get` if needed, migrates components,'
         ' adds MUI imports, and removes WSD imports all in a single run',
         script: muiCodemodScript,
         input: inputFiles(),
         expectedOutput: expectedOutputFiles(),
-        args: ['--yes-to-all']);
+        args: ['--yes-to-all'],
+      );
 
-    testCodemod('--fail-on-changes exits with 0 when no changes needed',
+      testCodemod(
+        '--fail-on-changes exits with 0 when no changes needed',
         script: muiCodemodScript,
         input: expectedOutputFiles(),
         expectedOutput: expectedOutputFiles(),
-        args: ['--fail-on-changes'], body: (out, err) {
-      expect(out, contains('No changes needed.'));
-    });
+        args: ['--fail-on-changes'],
+        body: (out, err) {
+          expect(out, contains('No changes needed.'));
+        },
+      );
 
-    testCodemod(
+      testCodemod(
         '--fail-on-changes exits with non-zero when changes needed and does not update files',
         script: muiCodemodScript,
         input: inputFiles(),
         expectedOutput: inputFiles(),
         args: ['--fail-on-changes'],
-        expectedExitCode: 1, body: (out, err) {
-      expect(err, contains(' change(s) needed.'));
-    });
+        expectedExitCode: 1,
+        body: (out, err) {
+          expect(err, contains(' change(s) needed.'));
+        },
+      );
 
-    testCodemod('fails when component factories cannot be resolved',
+      testCodemod(
+        'fails when component factories cannot be resolved',
         script: muiCodemodScript,
         input: d.dir('project', [
           // Use a pubspec without WSD so this runs a little faster
@@ -83,52 +98,68 @@ environment:
   sdk: ">=2.11.0 <3.0.0"
 dependencies:'''),
           d.dir('lib', [
-            d.file('usage.dart', /*language=dart*/ '''usage() => Button()();''')
+            d.file(
+              'usage.dart',
+              /*language=dart*/ '''usage() => Button()();''',
+            ),
           ]),
         ]),
         args: ['--yes-to-all'],
-        expectedExitCode: 70, body: (out, err) {
-      expect(err, contains('Builder static type could not be resolved'));
-    });
+        expectedExitCode: 70,
+        body: (out, err) {
+          expect(err, contains('Builder static type could not be resolved'));
+        },
+      );
 
-    testCodemod('resolves part files even when they come before library files',
+      testCodemod(
+        'resolves part files even when they come before library files',
         script: muiCodemodScript,
-        input: inputFiles(additionalFilesInLib: [
-          d.file('a_part.dart', /*language=dart*/ '''
+        input: inputFiles(
+          additionalFilesInLib: [
+            d.file('a_part.dart', /*language=dart*/ '''
             part of 'library.dart';
 
             usage() => Button()();'''),
-          d.file('library.dart', /*language=dart*/ '''
+            d.file('library.dart', /*language=dart*/ '''
             import 'package:web_skin_dart/component2/button.dart';
 
             part 'a_part.dart';'''),
-        ]),
-        expectedOutput: expectedOutputFiles(additionalFilesInLib: [
-          d.file('a_part.dart', /*language=dart*/ '''
+          ],
+        ),
+        expectedOutput: expectedOutputFiles(
+          additionalFilesInLib: [
+            d.file('a_part.dart', /*language=dart*/ '''
             part of 'library.dart';
 
             usage() => mui.Button()();'''),
-          d.file('library.dart', /*language=dart*/ '''
+            d.file('library.dart', /*language=dart*/ '''
             import 'package:react_material_ui/react_material_ui.dart' as mui;
 
             part 'a_part.dart';'''),
-        ]),
-        args: ['--yes-to-all']);
+          ],
+        ),
+        args: ['--yes-to-all'],
+      );
 
-    group('--component flag', () {
-      testCodemod('fails with no components given',
+      group('--component flag', () {
+        testCodemod(
+          'fails with no components given',
           script: muiCodemodScript,
           input: inputFiles(),
           expectedOutput: inputFiles(),
           args: ['--yes-to-all', '--component'],
-          expectedExitCode: 255, body: (out, err) {
-        expect(err, contains('Missing argument for "component"'));
-      });
+          expectedExitCode: 255,
+          body: (out, err) {
+            expect(err, contains('Missing argument for "component"'));
+          },
+        );
 
-      testCodemod('for one component',
+        testCodemod(
+          'for one component',
           script: muiCodemodScript,
-          input: inputFiles(additionalFilesInLib: [
-            d.file('usage2.dart', /*language=dart*/ '''
+          input: inputFiles(
+            additionalFilesInLib: [
+              d.file('usage2.dart', /*language=dart*/ '''
               import 'package:web_skin_dart/component2/all.dart';
 
               usage() => ButtonToolbar()(
@@ -138,9 +169,11 @@ dependencies:'''),
                   Button()(),
                 ),
               );'''),
-          ]),
-          expectedOutput: expectedOutputFiles(additionalFilesInLib: [
-            d.file('usage2.dart', /*language=dart*/ '''
+            ],
+          ),
+          expectedOutput: expectedOutputFiles(
+            additionalFilesInLib: [
+              d.file('usage2.dart', /*language=dart*/ '''
               import 'package:react_material_ui/react_material_ui.dart' as mui;
 import 'package:web_skin_dart/component2/all.dart';
 
@@ -151,13 +184,17 @@ import 'package:web_skin_dart/component2/all.dart';
                   mui.Button()(),
                 ),
               );'''),
-          ]),
-          args: ['--yes-to-all', '--component=Button']);
+            ],
+          ),
+          args: ['--yes-to-all', '--component=Button'],
+        );
 
-      testCodemod('for multiple components',
+        testCodemod(
+          'for multiple components',
           script: muiCodemodScript,
-          input: inputFiles(additionalFilesInLib: [
-            d.file('usage2.dart', /*language=dart*/ '''
+          input: inputFiles(
+            additionalFilesInLib: [
+              d.file('usage2.dart', /*language=dart*/ '''
               import 'package:web_skin_dart/component2/all.dart';
 
               usage() => ButtonToolbar()(
@@ -167,9 +204,11 @@ import 'package:web_skin_dart/component2/all.dart';
                   Button()(),
                 ),
               );'''),
-          ]),
-          expectedOutput: expectedOutputFiles(additionalFilesInLib: [
-            d.file('usage2.dart', /*language=dart*/ '''
+            ],
+          ),
+          expectedOutput: expectedOutputFiles(
+            additionalFilesInLib: [
+              d.file('usage2.dart', /*language=dart*/ '''
               import 'package:react_material_ui/react_material_ui.dart' as mui;
 import 'package:web_skin_dart/component2/all.dart';
 
@@ -180,22 +219,32 @@ import 'package:web_skin_dart/component2/all.dart';
                   mui.Button()(),
                 ),
               );'''),
-          ]),
-          args: ['--yes-to-all', '--component=Button,ButtonToolbar']);
+            ],
+          ),
+          args: ['--yes-to-all', '--component=Button,ButtonToolbar'],
+        );
 
-      testCodemod('fails if one of the components does not have a migrator',
+        testCodemod(
+          'fails if one of the components does not have a migrator',
           script: muiCodemodScript,
           input: inputFiles(),
           expectedOutput: inputFiles(),
           args: ['--yes-to-all', '--component=Button,DoesNotExist'],
-          expectedExitCode: 255, body: (out, err) {
-        expect(err, contains('is not an allowed value for option "component"'));
-      });
+          expectedExitCode: 255,
+          body: (out, err) {
+            expect(
+              err,
+              contains('is not an allowed value for option "component"'),
+            );
+          },
+        );
 
-      testCodemod('updates all components when the flag is not present',
+        testCodemod(
+          'updates all components when the flag is not present',
           script: muiCodemodScript,
-          input: inputFiles(additionalFilesInLib: [
-            d.file('usage2.dart', /*language=dart*/ '''
+          input: inputFiles(
+            additionalFilesInLib: [
+              d.file('usage2.dart', /*language=dart*/ '''
               import 'package:web_skin_dart/component2/all.dart';
 
               usage() => ButtonToolbar()(
@@ -205,9 +254,11 @@ import 'package:web_skin_dart/component2/all.dart';
                   Button()(),
                 ),
               );'''),
-          ]),
-          expectedOutput: expectedOutputFiles(additionalFilesInLib: [
-            d.file('usage2.dart', /*language=dart*/ '''
+            ],
+          ),
+          expectedOutput: expectedOutputFiles(
+            additionalFilesInLib: [
+              d.file('usage2.dart', /*language=dart*/ '''
               import 'package:react_material_ui/react_material_ui.dart' as mui;
 
               usage() => mui.ButtonToolbar()(
@@ -217,18 +268,22 @@ import 'package:web_skin_dart/component2/all.dart';
                   mui.Button()(),
                 ),
               );'''),
-          ]),
-          args: ['--yes-to-all']);
-    });
+            ],
+          ),
+          args: ['--yes-to-all'],
+        );
+      });
 
-    testCodemod(
+      testCodemod(
         '--rmui-version flag sets the version used in the react_material_ui version constraint',
         script: muiCodemodScript,
         input: inputFiles(),
         expectedOutput: expectedOutputFiles(rmuiVersionConstraint: '^9.9.9'),
-        args: ['--yes-to-all', '--rmui-version=9.9.9']);
+        args: ['--yes-to-all', '--rmui-version=9.9.9'],
+      );
 
-    testCodemod('nested pubspecs',
+      testCodemod(
+        'nested pubspecs',
         script: muiCodemodScript,
         input: d.dir('project', [
           d.file('pubspec.yaml', /*language=yaml*/ '''
@@ -238,9 +293,7 @@ environment:
 dependencies:
   over_react: ^4.2.0
   react: ^6.1.0'''),
-          d.dir('lib', [
-            inputFiles(),
-          ]),
+          d.dir('lib', [inputFiles()]),
           inputFiles(),
         ]),
         expectedOutput: d.dir('project', [
@@ -257,14 +310,14 @@ dependencies:
       url: https://pub.workiva.org
     version: ^1.1.1
 '''),
-          d.dir('lib', [
-            expectedOutputFiles(),
-          ]),
+          d.dir('lib', [expectedOutputFiles()]),
           expectedOutputFiles(),
         ]),
-        args: ['--yes-to-all']);
+        args: ['--yes-to-all'],
+      );
 
-    testCodemod('fails when pub get fails',
+      testCodemod(
+        'fails when pub get fails',
         script: muiCodemodScript,
         input: d.dir('project', [
           d.file('pubspec.yaml', /*language=yaml*/ '''
@@ -282,7 +335,7 @@ dependencies:
             d.file('usage.dart', /*language=dart*/ '''
           import 'package:web_skin_dart/component2/button.dart';
 
-          usage() => Button()();''')
+          usage() => Button()();'''),
           ]),
         ]),
         expectedOutput: d.dir('project', [
@@ -301,23 +354,28 @@ dependencies:
             d.file('usage.dart', /*language=dart*/ '''
           import 'package:web_skin_dart/component2/button.dart';
 
-          usage() => Button()();''')
+          usage() => Button()();'''),
           ]),
         ]),
         args: ['--yes-to-all'],
-        expectedExitCode: 255, body: (out, err) {
-      expect(err, contains('pub get failed'));
-    });
+        expectedExitCode: 255,
+        body: (out, err) {
+          expect(err, contains('pub get failed'));
+        },
+      );
 
-    // Set a longer timeout since some of these need to `pub get` and resolve WSD.
-    // Even with a primed pub cache, the longest of these tests take ~35 seconds locally.
-  }, tags: 'wsd', timeout: Timeout(Duration(minutes: 2)));
+      // Set a longer timeout since some of these need to `pub get` and resolve WSD.
+      // Even with a primed pub cache, the longest of these tests take ~35 seconds locally.
+    },
+    tags: 'wsd',
+    timeout: Timeout(Duration(minutes: 2)),
+  );
 }
 
-d.DirectoryDescriptor inputFiles(
-        {Iterable<d.Descriptor> additionalFilesInLib = const []}) =>
-    d.dir('project', [
-      d.file('pubspec.yaml', /*language=yaml*/ '''
+d.DirectoryDescriptor inputFiles({
+  Iterable<d.Descriptor> additionalFilesInLib = const [],
+}) => d.dir('project', [
+  d.file('pubspec.yaml', /*language=yaml*/ '''
 name: test_project
 environment:
   sdk: '>=2.11.0 <3.0.0'
@@ -327,21 +385,20 @@ dependencies:
       name: web_skin_dart
       url: https://pub.workiva.org
     version: ^2.56.0'''),
-      d.dir('lib', [
-        ...additionalFilesInLib,
-        d.file('usage.dart', /*language=dart*/ '''
+  d.dir('lib', [
+    ...additionalFilesInLib,
+    d.file('usage.dart', /*language=dart*/ '''
           import 'package:web_skin_dart/component2/button.dart';
             
-          usage() => Button()();''')
-      ]),
-    ]);
+          usage() => Button()();'''),
+  ]),
+]);
 
 d.DirectoryDescriptor expectedOutputFiles({
   Iterable<d.Descriptor> additionalFilesInLib = const [],
   String rmuiVersionConstraint = '^1.1.1',
-}) =>
-    d.dir('project', [
-      d.file('pubspec.yaml', /*language=yaml*/ '''
+}) => d.dir('project', [
+  d.file('pubspec.yaml', /*language=yaml*/ '''
 name: test_project
 environment:
   sdk: '>=2.11.0 <3.0.0'
@@ -356,14 +413,14 @@ dependencies:
       name: web_skin_dart
       url: https://pub.workiva.org
     version: ^2.56.0'''),
-      d.dir('lib', [
-        ...additionalFilesInLib,
-        d.file('usage.dart', /*language=dart*/ '''
+  d.dir('lib', [
+    ...additionalFilesInLib,
+    d.file('usage.dart', /*language=dart*/ '''
           import 'package:react_material_ui/react_material_ui.dart' as mui;
             
-          usage() => mui.Button()();''')
-      ]),
-    ]);
+          usage() => mui.Button()();'''),
+  ]),
+]);
 
 // Adapted from `testCodemod` in https://github.com/Workiva/dart_codemod/blob/c5d245308554b0e1e7a15a54fbd2c79a9231e2be/test/functional/run_interactive_codemod_test.dart#L39
 // Intentionally does not run `pub get` on the project, since we want to test that the MUI executable does that.
@@ -382,22 +439,26 @@ Future<Null> testCodemod(
     final projectDir = input;
     await projectDir.create();
 
-    final processArgs = [
-      script,
-      ...?args,
-    ];
+    final processArgs = [script, ...?args];
     if (_debug) {
       processArgs.add('--verbose');
     }
-    final process = await Process.start('dart', processArgs,
-        workingDirectory: projectDir.io.path);
+    final process = await Process.start(
+      'dart',
+      processArgs,
+      workingDirectory: projectDir.io.path,
+    );
 
     // If _debug, split these single-subscription streams into two
     // so that we can display the output as it comes in.
     final stdoutStreams = StreamSplitter.splitFrom(
-        process.stdout.transform(utf8.decoder), _debug ? 2 : 1);
+      process.stdout.transform(utf8.decoder),
+      _debug ? 2 : 1,
+    );
     final stderrStreams = StreamSplitter.splitFrom(
-        process.stderr.transform(utf8.decoder), _debug ? 2 : 1);
+      process.stderr.transform(utf8.decoder),
+      _debug ? 2 : 1,
+    );
     if (_debug) {
       stdoutStreams[1]
           .transform(LineSplitter())
@@ -414,10 +475,14 @@ Future<Null> testCodemod(
     final codemodStdout = await stdoutStreams[0].join();
     final codemodStderr = await stderrStreams[0].join();
 
-    expect(codemodExitCode, expectedExitCode,
-        reason: 'Expected codemod to exit with code $expectedExitCode, but '
-            'it exited with $codemodExitCode.\n'
-            'Process stderr:\n$codemodStderr');
+    expect(
+      codemodExitCode,
+      expectedExitCode,
+      reason:
+          'Expected codemod to exit with code $expectedExitCode, but '
+          'it exited with $codemodExitCode.\n'
+          'Process stderr:\n$codemodStderr',
+    );
 
     if (expectedOutput != null) {
       // Expect that the modified projet matches the gold files.

--- a/test/executables/react_18_upgrade_test.dart
+++ b/test/executables/react_18_upgrade_test.dart
@@ -21,120 +21,133 @@ import 'mui_migration_test.dart';
 
 void main() {
   group('react_18_upgrade executable', () {
-    final react18CodemodScript =
-        p.join(findPackageRootFor(p.current), 'bin/react_18_upgrade.dart');
+    final react18CodemodScript = p.join(
+      findPackageRootFor(p.current),
+      'bin/react_18_upgrade.dart',
+    );
 
     group('updates script tags', () {
-      testCodemod('dev',
-          script: react18CodemodScript,
-          input: d.dir('project', [
-            d.file('dev.html', /*language=html*/ '''
+      testCodemod(
+        'dev',
+        script: react18CodemodScript,
+        input: d.dir('project', [
+          d.file('dev.html', /*language=html*/ '''
 <script src="packages/react/react.js"></script>
         <script src="packages/react/react_dom.js"></script>'''),
-            d.file('dev_with_addons.html', /*language=html*/ '''
+          d.file('dev_with_addons.html', /*language=html*/ '''
 <script src="packages/react/react_with_addons.js"></script>
         <script src="packages/react/react_dom.js"></script>'''),
-          ]),
-          expectedOutput: d.dir('project', [
-            d.file('dev.html', /*language=html*/ '''
+        ]),
+        expectedOutput: d.dir('project', [
+          d.file('dev.html', /*language=html*/ '''
 <script src="packages/react/js/react.dev.js"></script>
 '''),
-            d.file('dev_with_addons.html', /*language=html*/ '''
+          d.file('dev_with_addons.html', /*language=html*/ '''
 <script src="packages/react/js/react.dev.js"></script>
 '''),
-          ]),
-          args: ['--yes-to-all']);
+        ]),
+        args: ['--yes-to-all'],
+      );
 
-      testCodemod('prod',
-          script: react18CodemodScript,
-          input: d.dir('project', [
-            d.file('prod.html', /*language=html*/ '''
+      testCodemod(
+        'prod',
+        script: react18CodemodScript,
+        input: d.dir('project', [
+          d.file('prod.html', /*language=html*/ '''
 <script src="packages/react/react_prod.js"></script>
         <script src="packages/react/react_dom_prod.js"></script>'''),
-            d.file('prod_with_addons.html', /*language=html*/ '''
+          d.file('prod_with_addons.html', /*language=html*/ '''
 <script src="packages/react/react_with_react_dom_prod.js"></script>
-        <script src="packages/react/react_dom_prod.js"></script>''')
-          ]),
-          expectedOutput: d.dir('project', [
-            d.file('prod.html', /*language=html*/ '''
+        <script src="packages/react/react_dom_prod.js"></script>'''),
+        ]),
+        expectedOutput: d.dir('project', [
+          d.file('prod.html', /*language=html*/ '''
 <script src="packages/react/js/react.min.js"></script>
 '''),
-            d.file('prod_with_addons.html', /*language=html*/ '''
+          d.file('prod_with_addons.html', /*language=html*/ '''
 <script src="packages/react/js/react.min.js"></script>
-''')
-          ]),
-          args: ['--yes-to-all']);
+'''),
+        ]),
+        args: ['--yes-to-all'],
+      );
     });
 
     group('updates link tags', () {
-      testCodemod('dev',
-          script: react18CodemodScript,
-          input: d.dir('project', [
-            d.file('dev.html', /*language=html*/ '''
+      testCodemod(
+        'dev',
+        script: react18CodemodScript,
+        input: d.dir('project', [
+          d.file('dev.html', /*language=html*/ '''
 <link href="packages/react/react.js">
         <link href="packages/react/react_dom.js">'''),
-            d.file('dev_with_addons.html', /*language=html*/ '''
+          d.file('dev_with_addons.html', /*language=html*/ '''
 <link href="packages/react/react_with_addons.js">
         <link href="packages/react/react_dom.js">'''),
-          ]),
-          expectedOutput: d.dir('project', [
-            d.file('dev.html', /*language=html*/ '''
+        ]),
+        expectedOutput: d.dir('project', [
+          d.file('dev.html', /*language=html*/ '''
 <link href="packages/react/js/react.dev.js">
 '''),
-            d.file('dev_with_addons.html', /*language=html*/ '''
+          d.file('dev_with_addons.html', /*language=html*/ '''
 <link href="packages/react/js/react.dev.js">
 '''),
-          ]),
-          args: ['--yes-to-all']);
+        ]),
+        args: ['--yes-to-all'],
+      );
 
-      testCodemod('prod',
-          script: react18CodemodScript,
-          input: d.dir('project', [
-            d.file('prod.html', /*language=html*/ '''
+      testCodemod(
+        'prod',
+        script: react18CodemodScript,
+        input: d.dir('project', [
+          d.file('prod.html', /*language=html*/ '''
 <link href="packages/react/react_prod.js">
         <link href="packages/react/react_dom_prod.js">'''),
-            d.file('prod_with_addons.html', /*language=html*/ '''
+          d.file('prod_with_addons.html', /*language=html*/ '''
 <link href="packages/react/react_with_react_dom_prod.js">
-        <link href="packages/react/react_dom_prod.js">''')
-          ]),
-          expectedOutput: d.dir('project', [
-            d.file('prod.html', /*language=html*/ '''
+        <link href="packages/react/react_dom_prod.js">'''),
+        ]),
+        expectedOutput: d.dir('project', [
+          d.file('prod.html', /*language=html*/ '''
 <link href="packages/react/js/react.min.js">
 '''),
-            d.file('prod_with_addons.html', /*language=html*/ '''
+          d.file('prod_with_addons.html', /*language=html*/ '''
 <link href="packages/react/js/react.min.js">
-''')
-          ]),
-          args: ['--yes-to-all']);
+'''),
+        ]),
+        args: ['--yes-to-all'],
+      );
     });
 
     group('in Dart files', () {
-      testCodemod('list',
-          script: react18CodemodScript,
-          input: d.dir('project', [
-            d.file('main.dart', /*language=dart*/ '''
+      testCodemod(
+        'list',
+        script: react18CodemodScript,
+        input: d.dir('project', [
+          d.file('main.dart', /*language=dart*/ '''
               List<String> _reactHtmlHeaders = const [
                 '<script src="packages/react/react.js"></script>',
                 '<script src="packages/react/react_dom.js"></script>',
                 '<link rel="preload" href="packages/react/react.js" as="script">',
                 '<link rel="preload" href="packages/react/react_dom.js" as="script">',
               ];
-            ''')
-          ]),
-          expectedOutput: d.dir('project', [
-            d.file('main.dart', /*language=dart*/ '''
+            '''),
+        ]),
+        expectedOutput: d.dir('project', [
+          d.file('main.dart', /*language=dart*/ '''
               List<String> _reactHtmlHeaders = const [
                 '<script src="packages/react/js/react.dev.js"></script>',
                 '<link rel="preload" href="packages/react/js/react.dev.js" as="script">',
               ];
-            ''')
-          ]),
-          args: ['--yes-to-all']);
+            '''),
+        ]),
+        args: ['--yes-to-all'],
+      );
 
-      testCodemod('string const',
-          script: react18CodemodScript,
-          input: d.dir('project', [
-            d.file('main.dart', '''
+      testCodemod(
+        'string const',
+        script: react18CodemodScript,
+        input: d.dir('project', [
+          d.file('main.dart', '''
               const expectedWithReact = \'\'\'
                 <!DOCTYPE html>
                 <html>
@@ -152,10 +165,10 @@ void main() {
                 <body></body>
                 </html>
               \'\'\';
-            ''')
-          ]),
-          expectedOutput: d.dir('project', [
-            d.file('main.dart', '''
+            '''),
+        ]),
+        expectedOutput: d.dir('project', [
+          d.file('main.dart', '''
               const expectedWithReact = \'\'\'
                 <!DOCTYPE html>
                 <html>
@@ -172,35 +185,39 @@ void main() {
                 <body></body>
                 </html>
               \'\'\';
-            ''')
-          ]),
-          args: ['--yes-to-all']);
+            '''),
+        ]),
+        args: ['--yes-to-all'],
+      );
     });
 
-    testCodemod('--fail-on-changes exits with 0 when no changes needed',
-        script: react18CodemodScript,
-        input: d.dir('project', [
-          d.file('dev.html', /*language=html*/ '''
+    testCodemod(
+      '--fail-on-changes exits with 0 when no changes needed',
+      script: react18CodemodScript,
+      input: d.dir('project', [
+        d.file('dev.html', /*language=html*/ '''
 <script src="packages/react/js/react.dev.js"></script>'''),
-          d.file('dev_with_addons.html', /*language=html*/ '''
+        d.file('dev_with_addons.html', /*language=html*/ '''
 <script src="packages/react/js/react.dev.js"></script>'''),
-          d.file('prod.html', /*language=html*/ '''
+        d.file('prod.html', /*language=html*/ '''
 <script src="packages/react/js/react.min.js"></script>'''),
-          d.file('prod_with_addons.html', /*language=html*/ '''
-<script src="packages/react/js/react.min.js"></script>''')
-        ]),
-        expectedOutput: d.dir('project', [
-          d.file('dev.html', /*language=html*/ '''
-<script src="packages/react/js/react.dev.js"></script>'''),
-          d.file('dev_with_addons.html', /*language=html*/ '''
-<script src="packages/react/js/react.dev.js"></script>'''),
-          d.file('prod.html', /*language=html*/ '''
+        d.file('prod_with_addons.html', /*language=html*/ '''
 <script src="packages/react/js/react.min.js"></script>'''),
-          d.file('prod_with_addons.html', /*language=html*/ '''
-<script src="packages/react/js/react.min.js"></script>''')
-        ]),
-        args: ['--fail-on-changes'], body: (out, err) {
-      expect(out, contains('No changes needed.'));
-    });
+      ]),
+      expectedOutput: d.dir('project', [
+        d.file('dev.html', /*language=html*/ '''
+<script src="packages/react/js/react.dev.js"></script>'''),
+        d.file('dev_with_addons.html', /*language=html*/ '''
+<script src="packages/react/js/react.dev.js"></script>'''),
+        d.file('prod.html', /*language=html*/ '''
+<script src="packages/react/js/react.min.js"></script>'''),
+        d.file('prod_with_addons.html', /*language=html*/ '''
+<script src="packages/react/js/react.min.js"></script>'''),
+      ]),
+      args: ['--fail-on-changes'],
+      body: (out, err) {
+        expect(out, contains('No changes needed.'));
+      },
+    );
   });
 }

--- a/test/intl_suggestors/constant_migrator_test.dart
+++ b/test/intl_suggestors/constant_migrator_test.dart
@@ -22,12 +22,14 @@ void main() {
     // Idempotency isn't a worry for this suggestor, and testing it throws off
     // checking for duplicates, so disable it for these tests.
     // TODO: Avoid duplicating this between test files.
-    Future<void> testSuggestor(
-            {required String input, required String expectedOutput}) =>
-        basicSuggestor(
-            input: input,
-            expectedOutput: expectedOutput,
-            testIdempotency: false);
+    Future<void> testSuggestor({
+      required String input,
+      required String expectedOutput,
+    }) => basicSuggestor(
+      input: input,
+      expectedOutput: expectedOutput,
+      testIdempotency: false,
+    );
 
     setUp(() async {
       final Directory tmp = await fs.systemTempDirectory.createTemp();
@@ -102,10 +104,7 @@ void main() {
             // ignore_statement: intl_message_migration
             const foo = 'I am a user-visible constant';
             ''';
-        await testSuggestor(
-          input: input,
-          expectedOutput: input,
-        );
+        await testSuggestor(input: input, expectedOutput: input);
         final expectedFileContent = '';
         expect(messages.messageContents(), expectedFileContent);
       });
@@ -116,10 +115,7 @@ void main() {
             // ignore_statement: intl_message_migration
             const foo = 'I am a user-visible constant';
             ''';
-        await testSuggestor(
-          input: input,
-          expectedOutput: input,
-        );
+        await testSuggestor(input: input, expectedOutput: input);
         final expectedFileContent = '';
         expect(messages.messageContents(), expectedFileContent);
       });
@@ -150,10 +146,7 @@ void main() {
             var y = x == 5 ? x : 42;
             const foo = 'I am a user-visible constant';
             ''';
-        await testSuggestor(
-          input: input,
-          expectedOutput: input,
-        );
+        await testSuggestor(input: input, expectedOutput: input);
         final expectedFileContent = '';
         expect(messages.messageContents(), expectedFileContent);
       });
@@ -238,8 +231,10 @@ void main() {
   static String get foo => Intl.message(\'I am a user-visible constant\', name: \'TestClassIntl_foo\');
 
 ''';
-        expect(messages.messageContents().trim(),
-            expectedFileContent.trim()); // Avoid the leading return.
+        expect(
+          messages.messageContents().trim(),
+          expectedFileContent.trim(),
+        ); // Avoid the leading return.
       });
 
       test('duplicate static names with duplicated text', () async {
@@ -271,14 +266,17 @@ void main() {
   static String get foo => Intl.message(\'I am a user-visible constant\', name: \'TestClassIntl_foo\');
 
 ''';
-        expect(messages.messageContents().trim(),
-            expectedFileContent.trim()); // Avoid the leading return.
+        expect(
+          messages.messageContents().trim(),
+          expectedFileContent.trim(),
+        ); // Avoid the leading return.
       });
 
-      test('duplicate static names with duplicated text, with double quotes',
-          () async {
-        await testSuggestor(
-          input: '''
+      test(
+        'duplicate static names with duplicated text, with double quotes',
+        () async {
+          await testSuggestor(
+            input: '''
           class Bar {
             static const foo = "I am a user-visible constant";
           }
@@ -287,7 +285,7 @@ void main() {
           }
           const foo = "Another static";
             ''',
-          expectedOutput: '''
+            expectedOutput: '''
           class Bar { 
             static final String foo = TestClassIntl.foo;
           }
@@ -298,16 +296,19 @@ void main() {
           final String foo = TestClassIntl.anotherStatic;
           
             ''',
-        );
-        final expectedFileContent = '''
+          );
+          final expectedFileContent = '''
   static String get anotherStatic => Intl.message(\'Another static\', name: \'TestClassIntl_anotherStatic\');
 
   static String get foo => Intl.message(\'I am a user-visible constant\', name: \'TestClassIntl_foo\');
 
 ''';
-        expect(messages.messageContents().trim(),
-            expectedFileContent.trim()); // Avoid the leading return.
-      });
+          expect(
+            messages.messageContents().trim(),
+            expectedFileContent.trim(),
+          ); // Avoid the leading return.
+        },
+      );
 
       test('duplicate getter names increment', () async {
         await testSuggestor(
@@ -330,8 +331,10 @@ void main() {
   static String get dueDate1 => Intl.message(\'Due date\', name: \'TestClassIntl_dueDate1\');
 
 ''';
-        expect(messages.messageContents().trim(),
-            expectedFileContent.trim()); // Avoid the leading return.
+        expect(
+          messages.messageContents().trim(),
+          expectedFileContent.trim(),
+        ); // Avoid the leading return.
       });
     });
   });

--- a/test/intl_suggestors/intl_configs_migrator_test.dart
+++ b/test/intl_suggestors/intl_configs_migrator_test.dart
@@ -46,9 +46,10 @@ void main() {
 
     test('correctly changes display name', () async {
       testSuggestor = getSuggestorTester(
-          ConfigsMigrator('TestClassIntl', messages),
-          resolvedContext: resolvedContext,
-          inputUrl: 'test/input/display_name_config.dart');
+        ConfigsMigrator('TestClassIntl', messages),
+        resolvedContext: resolvedContext,
+        inputUrl: 'test/input/display_name_config.dart',
+      );
       await testSuggestor!(
         input: '''
             class TestExperienceConfig {
@@ -70,9 +71,10 @@ void main() {
 
     test('correctly changes name', () async {
       testSuggestor = getSuggestorTester(
-          ConfigsMigrator('TestClassIntl', messages),
-          resolvedContext: resolvedContext,
-          inputUrl: 'test/input/name_config.dart');
+        ConfigsMigrator('TestClassIntl', messages),
+        resolvedContext: resolvedContext,
+        inputUrl: 'test/input/name_config.dart',
+      );
 
       await testSuggestor!(
         input: '''
@@ -95,9 +97,10 @@ void main() {
 
     test('correctly changes title', () async {
       testSuggestor = getSuggestorTester(
-          ConfigsMigrator('TestClassIntl', messages),
-          resolvedContext: resolvedContext,
-          inputUrl: 'test/input/title_config.dart');
+        ConfigsMigrator('TestClassIntl', messages),
+        resolvedContext: resolvedContext,
+        inputUrl: 'test/input/title_config.dart',
+      );
       await testSuggestor!(
         input: '''
             class TestExperienceConfig {

--- a/test/intl_suggestors/intl_importer_test.dart
+++ b/test/intl_suggestors/intl_importer_test.dart
@@ -35,88 +35,92 @@ void main() {
     );
 
     group(
-        'adds a `TestProjectIntl` import when there is an undefined `TestProjectIntl` identifier in the file',
-        () {
-      bool isFakeUriError(AnalysisError error) =>
-          error.errorCode.name.toLowerCase() == 'uri_does_not_exist' &&
-          error.message.contains('fake');
+      'adds a `TestProjectIntl` import when there is an undefined `TestProjectIntl` identifier in the file',
+      () {
+        bool isFakeUriError(AnalysisError error) =>
+            error.errorCode.name.toLowerCase() == 'uri_does_not_exist' &&
+            error.message.contains('fake');
 
-      test('when there are no other imports', () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
-              content() => TestProjectIntl.testString;
-          ''',
-          isExpectedError: isUndefinedIntlError,
-          expectedOutput: /*language=dart*/ '''
-              import 'package:test_project/src/intl/test_project_intl.dart';
-              content() => TestProjectIntl.testString;
-          ''',
-        );
-      });
-
-      group('when there are other imports', () {
-        test('(alphabetized before `TestProjectIntl`)', () async {
+        test('when there are no other imports', () async {
           await testSuggestor(
             input: /*language=dart*/ '''
-              import 'package:over_react/over_react.dart';
               content() => TestProjectIntl.testString;
-            ''',
+          ''',
             isExpectedError: isUndefinedIntlError,
             expectedOutput: /*language=dart*/ '''
+              import 'package:test_project/src/intl/test_project_intl.dart';
+              content() => TestProjectIntl.testString;
+          ''',
+          );
+        });
+
+        group('when there are other imports', () {
+          test('(alphabetized before `TestProjectIntl`)', () async {
+            await testSuggestor(
+              input: /*language=dart*/ '''
+              import 'package:over_react/over_react.dart';
+              content() => TestProjectIntl.testString;
+            ''',
+              isExpectedError: isUndefinedIntlError,
+              expectedOutput: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
               import 'package:test_project/src/intl/test_project_intl.dart';
               content() => TestProjectIntl.testString;
             ''',
-          );
-        });
+            );
+          });
 
-        test('(alphabetized after TestProjectIntl)', () async {
-          await testSuggestor(
-            input: /*language=dart*/ '''
+          test('(alphabetized after TestProjectIntl)', () async {
+            await testSuggestor(
+              input: /*language=dart*/ '''
               import 'package:z_fake_package/z_fake_package.dart';
               content() => TestProjectIntl.testString;
             ''',
-            isExpectedError: (e) =>
-                isUndefinedIntlError(e) || isFakeUriError(e),
-            expectedOutput: /*language=dart*/ '''
+              isExpectedError: (e) =>
+                  isUndefinedIntlError(e) || isFakeUriError(e),
+              expectedOutput: /*language=dart*/ '''
               import 'package:test_project/src/intl/test_project_intl.dart';
               import 'package:z_fake_package/z_fake_package.dart';
               content() => TestProjectIntl.testString;
             ''',
-          );
-        });
+            );
+          });
 
-        test('(one alphabetized before and after `TestProjectIntl`)', () async {
-          await testSuggestor(
-            input: /*language=dart*/ '''
+          test(
+            '(one alphabetized before and after `TestProjectIntl`)',
+            () async {
+              await testSuggestor(
+                input: /*language=dart*/ '''
                 import 'package:over_react/over_react.dart';
                 import 'package:z_fake_package/z_fake_package.dart';
               content() => TestProjectIntl.testString;
             ''',
-            isExpectedError: (e) =>
-                isUndefinedIntlError(e) || isFakeUriError(e),
-            expectedOutput: /*language=dart*/ '''
+                isExpectedError: (e) =>
+                    isUndefinedIntlError(e) || isFakeUriError(e),
+                expectedOutput: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
               import 'package:test_project/src/intl/test_project_intl.dart';
               import 'package:z_fake_package/z_fake_package.dart';
               content() => TestProjectIntl.testString;
             ''',
+              );
+            },
           );
-        });
 
-        test('(more than one alphabetized before and after `TestProjectIntl`)',
+          test(
+            '(more than one alphabetized before and after `TestProjectIntl`)',
             () async {
-          await testSuggestor(
-            input: /*language=dart*/ '''
+              await testSuggestor(
+                input: /*language=dart*/ '''
                 import 'package:over_react/over_react.dart';
                 import 'package:over_react/components.dart';
                 import 'package:z_fake_package/z_fake_package_1.dart';
                 import 'package:z_fake_package/z_fake_package_2.dart';
               content() => TestProjectIntl.testString;
             ''',
-            isExpectedError: (e) =>
-                isUndefinedIntlError(e) || isFakeUriError(e),
-            expectedOutput: /*language=dart*/ '''
+                isExpectedError: (e) =>
+                    isUndefinedIntlError(e) || isFakeUriError(e),
+                expectedOutput: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
               import 'package:over_react/components.dart';
               import 'package:test_project/src/intl/test_project_intl.dart';
@@ -124,148 +128,158 @@ void main() {
               import 'package:z_fake_package/z_fake_package_2.dart';
               content() => TestProjectIntl.testString;
             ''',
+              );
+            },
           );
-        });
 
-        test('(a relative import, alphabetized before `TestProjectIntl`)',
+          test(
+            '(a relative import, alphabetized before `TestProjectIntl`)',
             () async {
-          await testSuggestor(
-            input: /*language=dart*/ '''
+              await testSuggestor(
+                input: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
               import 'a/fake_relative_file.dart';
               content() => TestProjectIntl.testString;
             ''',
-            isExpectedError: (e) =>
-                isUndefinedIntlError(e) || isFakeUriError(e),
-            expectedOutput: /*language=dart*/ '''
+                isExpectedError: (e) =>
+                    isUndefinedIntlError(e) || isFakeUriError(e),
+                expectedOutput: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
               import '../../../../../src/intl/test_project_intl.dart';
               import 'a/fake_relative_file.dart';
               content() => TestProjectIntl.testString;
             ''',
+              );
+            },
           );
-        });
 
-        test('(a dart import)', () async {
-          await testSuggestor(
-            input: /*language=dart*/ '''
+          test('(a dart import)', () async {
+            await testSuggestor(
+              input: /*language=dart*/ '''
               import 'dart:html';
 
               content() => TestProjectIntl.testString;
               
             ''',
-            isExpectedError: (e) =>
-                isUndefinedIntlError(e) || isFakeUriError(e),
-            expectedOutput: /*language=dart*/ '''
+              isExpectedError: (e) =>
+                  isUndefinedIntlError(e) || isFakeUriError(e),
+              expectedOutput: /*language=dart*/ '''
               import 'dart:html';
 
               import 'package:test_project/src/intl/test_project_intl.dart';
 
               content() => TestProjectIntl.testString;
             ''',
-          );
+            );
+          });
         });
-      });
 
-      test('when there are Dart  and Package', () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
+        test('when there are Dart  and Package', () async {
+          await testSuggestor(
+            input: /*language=dart*/ '''
               import 'dart:html';
               import 'package:over_react/over_react.dart';
 
 
               content() => TestProjectIntl.testString;
           ''',
-          isExpectedError: (e) => isUndefinedIntlError(e) || isFakeUriError(e),
-          expectedOutput: /*language=dart*/ '''
+            isExpectedError: (e) =>
+                isUndefinedIntlError(e) || isFakeUriError(e),
+            expectedOutput: /*language=dart*/ '''
               import 'dart:html';
               import 'package:over_react/over_react.dart';
               import 'package:test_project/src/intl/test_project_intl.dart';
 
               content() => TestProjectIntl.testString;
           ''',
-        );
-      });
-      test('package import in the same package should produce relative import',
+          );
+        });
+        test(
+          'package import in the same package should produce relative import',
           () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
+            await testSuggestor(
+              input: /*language=dart*/ '''
            
             content() => TestProjectIntl.testString;
   ''',
-          isExpectedError: (e) => isUndefinedIntlError(e) || isFakeUriError(e),
-          expectedOutput: /*language=dart*/ '''
+              isExpectedError: (e) =>
+                  isUndefinedIntlError(e) || isFakeUriError(e),
+              expectedOutput: /*language=dart*/ '''
           import 'package:test_project/src/intl/test_project_intl.dart';
     content() => TestProjectIntl.testString;
   ''',
+            );
+          },
         );
-      });
 
-      test('when there is just a library declaration', () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
+        test('when there is just a library declaration', () async {
+          await testSuggestor(
+            input: /*language=dart*/ '''
               library lib;
 
               content() => TestProjectIntl.testString;
           ''',
-          isExpectedError: (e) => isUndefinedIntlError(e) || isFakeUriError(e),
-          expectedOutput: /*language=dart*/ '''
+            isExpectedError: (e) =>
+                isUndefinedIntlError(e) || isFakeUriError(e),
+            expectedOutput: /*language=dart*/ '''
               library lib;
 
               import 'package:test_project/src/intl/test_project_intl.dart';
 
               content() => TestProjectIntl.testString;
           ''',
-        );
-      });
+          );
+        });
 
-      test('when there are only parts', () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
+        test('when there are only parts', () async {
+          await testSuggestor(
+            input: /*language=dart*/ '''
               part 'fake_part.dart';
 
               content() => TestProjectIntl.testString;
           ''',
-          isExpectedError: (e) => isUndefinedIntlError(e) || isFakeUriError(e),
-          expectedOutput: /*language=dart*/ '''
+            isExpectedError: (e) =>
+                isUndefinedIntlError(e) || isFakeUriError(e),
+            expectedOutput: /*language=dart*/ '''
               import 'package:test_project/src/intl/test_project_intl.dart';
 
               part 'fake_part.dart';
 
               content() => TestProjectIntl.testString;
           ''',
-        );
-      });
+          );
+        });
 
-      test('when there are only exports', () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
+        test('when there are only exports', () async {
+          await testSuggestor(
+            input: /*language=dart*/ '''
               export 'package:over_react/over_react.dart';
 
               content() => TestProjectIntl.testString;
           ''',
-          isExpectedError: isUndefinedIntlError,
-          expectedOutput: /*language=dart*/ '''
+            isExpectedError: isUndefinedIntlError,
+            expectedOutput: /*language=dart*/ '''
               import 'package:test_project/src/intl/test_project_intl.dart';
 
               export 'package:over_react/over_react.dart';
 
               content() => TestProjectIntl.testString;
           ''',
-        );
-      });
+          );
+        });
 
-      test('when there are imports and parts', () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
+        test('when there are imports and parts', () async {
+          await testSuggestor(
+            input: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
 
               part 'fake_part.dart';
 
               content() => TestProjectIntl.testString;
           ''',
-          isExpectedError: (e) => isUndefinedIntlError(e) || isFakeUriError(e),
-          expectedOutput: /*language=dart*/ '''
+            isExpectedError: (e) =>
+                isUndefinedIntlError(e) || isFakeUriError(e),
+            expectedOutput: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
               import 'package:test_project/src/intl/test_project_intl.dart';
 
@@ -273,45 +287,21 @@ void main() {
 
               content() => TestProjectIntl.testString;
           ''',
-        );
-      });
+          );
+        });
 
-      test('when there are exports and parts', () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
+        test('when there are exports and parts', () async {
+          await testSuggestor(
+            input: /*language=dart*/ '''
               export 'package:over_react/over_react.dart';
 
               part 'fake_part.dart';
 
               content() => TestProjectIntl.testString;
           ''',
-          isExpectedError: (e) => isUndefinedIntlError(e) || isFakeUriError(e),
-          expectedOutput: /*language=dart*/ '''
-              import 'package:test_project/src/intl/test_project_intl.dart';
-
-              export 'package:over_react/over_react.dart';
-
-              part 'fake_part.dart';
-
-              content() => TestProjectIntl.testString;
-          ''',
-        );
-      });
-
-      test('when there are imports, exports, and parts', () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
-              import 'package:over_react/over_react.dart';
-
-              export 'package:over_react/over_react.dart';
-
-              part 'fake_part.dart';
-
-              content() => TestProjectIntl.testString;
-          ''',
-          isExpectedError: (e) => isUndefinedIntlError(e) || isFakeUriError(e),
-          expectedOutput: /*language=dart*/ '''
-              import 'package:over_react/over_react.dart';
+            isExpectedError: (e) =>
+                isUndefinedIntlError(e) || isFakeUriError(e),
+            expectedOutput: /*language=dart*/ '''
               import 'package:test_project/src/intl/test_project_intl.dart';
 
               export 'package:over_react/over_react.dart';
@@ -320,21 +310,49 @@ void main() {
 
               content() => TestProjectIntl.testString;
           ''',
-        );
-      });
-    });
+          );
+        });
+
+        test('when there are imports, exports, and parts', () async {
+          await testSuggestor(
+            input: /*language=dart*/ '''
+              import 'package:over_react/over_react.dart';
+
+              export 'package:over_react/over_react.dart';
+
+              part 'fake_part.dart';
+
+              content() => TestProjectIntl.testString;
+          ''',
+            isExpectedError: (e) =>
+                isUndefinedIntlError(e) || isFakeUriError(e),
+            expectedOutput: /*language=dart*/ '''
+              import 'package:over_react/over_react.dart';
+              import 'package:test_project/src/intl/test_project_intl.dart';
+
+              export 'package:over_react/over_react.dart';
+
+              part 'fake_part.dart';
+
+              content() => TestProjectIntl.testString;
+          ''',
+          );
+        });
+      },
+    );
 
     test(
-        'adds a `TestProjectIntl` import when there is an undefined `TestProjectIntl` identifier in a part file',
-        () async {
-      // testSuggestor isn't really set up for multiple files,
-      // so the test setup here is a little more manual.
+      'adds a `TestProjectIntl` import when there is an undefined `TestProjectIntl` identifier in a part file',
+      () async {
+        // testSuggestor isn't really set up for multiple files,
+        // so the test setup here is a little more manual.
 
-      const partFilename = 'intl_importer_test_part.dart';
-      const mainLibraryFilename = 'intl_importer_test_main_library.dart';
+        const partFilename = 'intl_importer_test_part.dart';
+        const mainLibraryFilename = 'intl_importer_test_main_library.dart';
 
-      final partFileContext =
-          await resolvedContext.resolvedFileContextForTest('''
+        final partFileContext = await resolvedContext
+            .resolvedFileContextForTest(
+              '''
             part of '${mainLibraryFilename}';
 
             content() => TestProjectIntl.testString;
@@ -342,30 +360,39 @@ void main() {
               filename: partFilename,
               // Don't pre-resolve since this isn't a library.
               preResolveLibrary: false,
-              throwOnAnalysisErrors: false);
+              throwOnAnalysisErrors: false,
+            );
 
-      final mainLibraryFileContext =
-          await resolvedContext.resolvedFileContextForTest(
-        '''
+        final mainLibraryFileContext = await resolvedContext
+            .resolvedFileContextForTest(
+              '''
             part '${partFilename}';
         ''',
-        filename: mainLibraryFilename,
-        isExpectedError: isUndefinedIntlError,
-      );
+              filename: mainLibraryFilename,
+              isExpectedError: isUndefinedIntlError,
+            );
 
-      final mainPatches = await intlImporter(
-              mainLibraryFileContext, 'test_project', 'TestProjectIntl')
-          .toList();
-      expect(mainPatches, [
-        hasPatchText(contains(
-            "import 'package:test_project/src/intl/test_project_intl.dart';")),
-      ]);
+        final mainPatches = await intlImporter(
+          mainLibraryFileContext,
+          'test_project',
+          'TestProjectIntl',
+        ).toList();
+        expect(mainPatches, [
+          hasPatchText(
+            contains(
+              "import 'package:test_project/src/intl/test_project_intl.dart';",
+            ),
+          ),
+        ]);
 
-      final partPatches =
-          await intlImporter(partFileContext, 'test_project', 'TestProjectIntl')
-              .toList();
-      expect(partPatches, isEmpty);
-    });
+        final partPatches = await intlImporter(
+          partFileContext,
+          'test_project',
+          'TestProjectIntl',
+        ).toList();
+        expect(partPatches, isEmpty);
+      },
+    );
 
     group('does not add an `TestProjectIntl` import when', () {
       test('a `Intl` identifier in the file is not undefined', () async {

--- a/test/intl_suggestors/intl_messages_test.dart
+++ b/test/intl_suggestors/intl_messages_test.dart
@@ -15,7 +15,7 @@ void main() {
     test('methodName', () {
       var names = [
         for (var method in sampleMethods)
-          MessageParser.forMethod(method).methods.first.name
+          MessageParser.forMethod(method).methods.first.name,
       ];
       expect(names, [
         'orange',
@@ -25,7 +25,7 @@ void main() {
         'aPlural',
         'formatted',
         'formattedNonArrow',
-        'someSelect'
+        'someSelect',
       ]);
     });
     test('Tabs instead of spaces', () {
@@ -35,19 +35,22 @@ void main() {
         name: 'TestProjectIntl_activateTheSelectedNode',
       );
       ''';
-      expect(MessageParser.forMethod(tabbed).methods.first.name,
-          'activateTheSelectedNode');
+      expect(
+        MessageParser.forMethod(tabbed).methods.first.name,
+        'activateTheSelectedNode',
+      );
     });
 
     test('Rewrite invalid name', () {
       var badName =
           '''static String get foo => Intl.message('Foo', name: 'foo');''';
       expect(
-          MessageParser.forMethod(badName, className: 'AbcIntl')
-              .methods
-              .first
-              .source,
-          contains("name: 'AbcIntl_foo'"));
+        MessageParser.forMethod(
+          badName,
+          className: 'AbcIntl',
+        ).methods.first.source,
+        contains("name: 'AbcIntl_foo'"),
+      );
     });
 
     test('Add missing name', () {
@@ -57,10 +60,13 @@ void main() {
       // Check that this parses as valid Dart code and the resulting declaration has the same source,
       // i.e. we didn't mess anything up too badly.
       var parsed = parseString(
-          content: 'class AbcIntl {${parser.methods.first.source}}');
+        content: 'class AbcIntl {${parser.methods.first.source}}',
+      );
       var theClass = parsed.unit.declarations.first as ClassDeclaration;
-      expect(theClass.members.first.toSource(),
-          parser.methods.first.source.trim());
+      expect(
+        theClass.members.first.toSource(),
+        parser.methods.first.source.trim(),
+      );
     });
   });
 
@@ -87,13 +93,16 @@ void main() {
       var classSource = 'class Foo { $method }';
       var parsed = parseString(content: classSource);
       var intlClass = parsed.unit.declarations.first as ClassDeclaration;
-      var methodDeclarations =
-          intlClass.members.toList().cast<MethodDeclaration>();
-      var argument = ((methodDeclarations.first.body.childEntities.toList()[1]
-              as MethodInvocation)
-          .argumentList
-          .arguments
-          .first as StringLiteral);
+      var methodDeclarations = intlClass.members
+          .toList()
+          .cast<MethodDeclaration>();
+      var argument =
+          ((methodDeclarations.first.body.childEntities.toList()[1]
+                      as MethodInvocation)
+                  .argumentList
+                  .arguments
+                  .first
+              as StringLiteral);
       messages = IntlMessages('TestProject', output: intlFile);
       var derivedName = messages.syntax.nameForNode(argument);
       expect(derivedName, 'adjacentStringsOnTwoLines');
@@ -106,7 +115,8 @@ void main() {
 
     writeExisting(List<String> methods) {
       intlFile.writeAsStringSync(
-          "${IntlMessages.prologueFor('TestProjectIntl')}\n${methods.join('\n\n')}\n}\n");
+        "${IntlMessages.prologueFor('TestProjectIntl')}\n${methods.join('\n\n')}\n}\n",
+      );
       messages = IntlMessages('TestProject', output: intlFile);
     }
 
@@ -127,33 +137,43 @@ void main() {
         'aPlural',
         'formatted',
         'formattedNonArrow',
-        'someSelect'
+        'someSelect',
       ]);
-      expect(messages.methods.values.map((each) => each.source).toList(),
-          sampleMethods);
+      expect(
+        messages.methods.values.map((each) => each.source).toList(),
+        sampleMethods,
+      );
     });
 
     test('messages written as expected', () {
       messages.write(force: true);
       messages.format();
-      expect(messages.outputFile.readAsStringSync(),
-          expectedFile(sortedSampleMethods.join('\n\n') + '\n'));
+      expect(
+        messages.outputFile.readAsStringSync(),
+        expectedFile(sortedSampleMethods.join('\n\n') + '\n'),
+      );
     });
 
     test('Function in formattedMessage parameters rewritten to Object', () {
       // Write the file with a method in it that has a parameter typed Function.
       var formattedMethod = messages.methods['formatted']!;
-      formattedMethod.source =
-          formattedMethod.source.replaceFirst('(Object ', '(Function ');
+      formattedMethod.source = formattedMethod.source.replaceFirst(
+        '(Object ',
+        '(Function ',
+      );
       messages.write(force: true);
-      expect(messages.outputFile.readAsStringSync(),
-          isNot(equals(expectedFile(sortedSampleMethods.join('\n\n')))));
+      expect(
+        messages.outputFile.readAsStringSync(),
+        isNot(equals(expectedFile(sortedSampleMethods.join('\n\n')))),
+      );
       // Read it back and re-write it.
       var newMessages = IntlMessages('TestProject', output: intlFile);
       newMessages.write(force: true);
       // Check that the Function parameter is back to normal.
-      expect(messages.outputFile.readAsStringSync(),
-          expectedFile(sortedSampleMethods.join('\n\n') + '\n'));
+      expect(
+        messages.outputFile.readAsStringSync(),
+        expectedFile(sortedSampleMethods.join('\n\n') + '\n'),
+      );
     });
 
     test('annotated messages rewritten properly when new ones are added', () {
@@ -163,8 +183,10 @@ void main() {
           "  static String get zzNewMessage => Intl.message('new', name: 'TestProjectIntl_zzNewMessage');\n";
       messages.addMethod(extra);
       messages.write();
-      expect(messages.outputFile.readAsStringSync(),
-          expectedFile([...sortedSampleMethods, extra].join('\n\n')));
+      expect(
+        messages.outputFile.readAsStringSync(),
+        expectedFile([...sortedSampleMethods, extra].join('\n\n')),
+      );
     });
 
     test('duplicate names with different content throw in addMethod', () {
@@ -172,8 +194,7 @@ void main() {
       expect(() => messages.addMethod(tweaked), throwsA(isA<AssertionError>()));
     });
 
-    test('duplicate names with different content give a valid name if asked',
-        () {
+    test('duplicate names with different content give a valid name if asked', () {
       /// Modify the message text, but also change the name so that when it parses the function it will
       /// find it. So we're really exercising the nameForString more than the addMethod.
       var tweaked = sampleMethods[3].replaceFirst('def', 'zzzz');
@@ -193,7 +214,8 @@ void main() {
 }
 
 String wIntl = 'w_intl';
-String expectedFile(String methods) => '''
+String expectedFile(String methods) =>
+    '''
 import 'package:${wIntl}/intl_wrapper.dart';
 
 ${IntlMessages.introComment}
@@ -213,7 +235,7 @@ string''', name: 'TestProjectIntl_long');""",
   """  static String aPlural(int n) => Intl.plural(n, zero: 'zero', other: 'other', name: 'TestProjectIntl_aPlural', args: [n]);""",
   """  static List<Object> formatted(Object f) => Intl.formattedMessage([f, 'foo'], name: 'TestProjectIntl_formatted', args: [f]);""",
   """  static List<Object> formattedNonArrow(Object f) {Intl.formattedMessage([f, 'foo'], name: 'TestProjectIntl_formattedNonArrow', args: [f]);}""",
-  """  static String someSelect(Object choice) => Intl.select(choice, {'a' : 'b'}, name: 'TestProjectIntl_someSelect', args: [choice]);"""
+  """  static String someSelect(Object choice) => Intl.select(choice, {'a' : 'b'}, name: 'TestProjectIntl_someSelect', args: [choice]);""",
 ];
 
 // The sample methods in a hard-coded sorted order.

--- a/test/intl_suggestors/intl_migrator_test.dart
+++ b/test/intl_suggestors/intl_migrator_test.dart
@@ -22,12 +22,14 @@ void main() {
     // Idempotency isn't a worry for this suggestor, and testing it throws off
     // using a global counter for numbering messages whose name isn't otherwise
     // unique, so skip that check.
-    Future<void> testSuggestor(
-            {required String input, required String expectedOutput}) =>
-        basicSuggestor(
-            input: input,
-            expectedOutput: expectedOutput,
-            testIdempotency: false);
+    Future<void> testSuggestor({
+      required String input,
+      required String expectedOutput,
+    }) => basicSuggestor(
+      input: input,
+      expectedOutput: expectedOutput,
+      testIdempotency: false,
+    );
 
     setUp(() async {
       final Directory tmp = await fs.systemTempDirectory.createTemp();
@@ -1363,7 +1365,8 @@ void main() {
 
     group('Ignore', () {
       test('Ignore statement with ignore comment', () async {
-        final source = 'import \'package:over_react/over_react.dart\';\n'
+        final source =
+            'import \'package:over_react/over_react.dart\';\n'
             '\n'
             'mixin FooProps on UiProps {}\n'
             '\n'
@@ -1388,7 +1391,8 @@ void main() {
             '  _\$FooConfig, //ignore: undefined_identifier\n'
             ');\n'
             '';
-        final output = 'import \'package:over_react/over_react.dart\';\n'
+        final output =
+            'import \'package:over_react/over_react.dart\';\n'
             '\n'
             'mixin FooProps on UiProps {}\n'
             '\n'
@@ -1414,10 +1418,7 @@ void main() {
             ');\n'
             '';
 
-        await testSuggestor(
-          input: source,
-          expectedOutput: output,
-        );
+        await testSuggestor(input: source, expectedOutput: output);
       });
 
       test('Ignore line within a component', () async {
@@ -1459,15 +1460,12 @@ mixin FooProps on UiProps {}
   );
 ''';
 
-        await testSuggestor(
-          input: source,
-          expectedOutput: output,
-        );
+        await testSuggestor(input: source, expectedOutput: output);
       });
 
-      test('Ignore statement with ignore comment with leading spaces',
-          () async {
-        final source = 'import \'package:over_react/over_react.dart\';\n'
+      test('Ignore statement with ignore comment with leading spaces', () async {
+        final source =
+            'import \'package:over_react/over_react.dart\';\n'
             '\n'
             'mixin FooProps on UiProps {}\n'
             '\n'
@@ -1494,7 +1492,8 @@ mixin FooProps on UiProps {}
             '  _\$FooConfig, //ignore: undefined_identifier\n'
             ');\n'
             '';
-        final output = 'import \'package:over_react/over_react.dart\';\n'
+        final output =
+            'import \'package:over_react/over_react.dart\';\n'
             '\n'
             'mixin FooProps on UiProps {}\n'
             '\n'
@@ -1522,10 +1521,7 @@ mixin FooProps on UiProps {}
             ');\n'
             '';
 
-        await testSuggestor(
-          input: source,
-          expectedOutput: output,
-        );
+        await testSuggestor(input: source, expectedOutput: output);
       });
 
       test('Ignore file with ignore comment', () async {
@@ -1547,10 +1543,7 @@ mixin FooProps on UiProps {}
             );
             ''';
 
-        await testSuggestor(
-          input: source,
-          expectedOutput: source,
-        );
+        await testSuggestor(input: source, expectedOutput: source);
 
         expect(messages.messageContents(), '');
       });

--- a/test/intl_suggestors/utils_test.dart
+++ b/test/intl_suggestors/utils_test.dart
@@ -66,9 +66,12 @@ void main() {
         final fileStr = 'test1';
         final refStr = 'test2';
         final result = escapeApos(
-            'Now that you\'ve transitioned your $fileStr, you\'ll want to freeze $refStr or update permissions to prevent others from using $refStr.');
-        expect(result,
-            'Now that you\\\'ve transitioned your $fileStr, you\\\'ll want to freeze $refStr or update permissions to prevent others from using $refStr.');
+          'Now that you\'ve transitioned your $fileStr, you\'ll want to freeze $refStr or update permissions to prevent others from using $refStr.',
+        );
+        expect(
+          result,
+          'Now that you\\\'ve transitioned your $fileStr, you\\\'ll want to freeze $refStr or update permissions to prevent others from using $refStr.',
+        );
       });
     });
 
@@ -80,20 +83,27 @@ void main() {
       setUpAll(sharedContext.warmUpAnalysis);
 
       void runResults(
-          String testStr, bool isMultiline, String expectedResult) async {
+        String testStr,
+        bool isMultiline,
+        String expectedResult,
+      ) async {
         final parsedExpression = await sharedContext.parseExpression(testStr);
         expect(parsedExpression is StringInterpolation, isTrue);
 
         final parsedInterpolation = parsedExpression as StringInterpolation;
         expect(parsedInterpolation.isMultiline, isMultiline);
-        final testResult = IntlMessages('Test')
-            .syntax
-            .functionDefinition(parsedInterpolation, 'Namespace', "NamePrefix");
+        final testResult = IntlMessages('Test').syntax.functionDefinition(
+          parsedInterpolation,
+          'Namespace',
+          "NamePrefix",
+        );
         expect(testResult, expectedResult);
       }
 
       void ignoreSingleLineAndMultiline(
-          String testStr, bool isMultiline) async {
+        String testStr,
+        bool isMultiline,
+      ) async {
         final parsedExpression = await sharedContext.parseExpression(testStr);
         expect(parsedExpression is StringInterpolation, isTrue);
         var parsedInterpolation = parsedExpression as StringInterpolation;

--- a/test/mui_suggestors/components/mui_button_group_migrator_test.dart
+++ b/test/mui_suggestors/components/mui_button_group_migrator_test.dart
@@ -33,25 +33,27 @@ void main() {
     );
 
     group('migrates WSD ButtonGroups', () {
-      test('that are either unnamespaced or namespaced, and either v1 or v2',
-          () async {
-        await testSuggestor(
-          input: withOverReactAndWsdImports(/*language=dart*/ '''
+      test(
+        'that are either unnamespaced or namespaced, and either v1 or v2',
+        () async {
+          await testSuggestor(
+            input: withOverReactAndWsdImports(/*language=dart*/ '''
               content() {
                 ButtonGroup()();
                 wsd_v1.ButtonGroup()();
                 wsd_v2.ButtonGroup()();
               }
           '''),
-          expectedOutput: withOverReactAndWsdImports(/*language=dart*/ '''
+            expectedOutput: withOverReactAndWsdImports(/*language=dart*/ '''
               content() {
                 mui.ButtonGroup()();
                 mui.ButtonGroup()();
                 mui.ButtonGroup()();
               }
           '''),
-        );
-      });
+          );
+        },
+      );
 
       test('and not non-WSD ButtonGroups or other components', () async {
         await testSuggestor(

--- a/test/mui_suggestors/components/mui_button_migrator_test.dart
+++ b/test/mui_suggestors/components/mui_button_migrator_test.dart
@@ -33,10 +33,11 @@ void main() {
     );
 
     test(
-        'does not migrate non-WSD Button/FormSubmitInput/FormResetInput factories,'
-        ' toolbar factories, or other components', () async {
-      await testSuggestor(
-        input: withOverReactAndWsdImports(/*language=dart*/ '''
+      'does not migrate non-WSD Button/FormSubmitInput/FormResetInput factories,'
+      ' toolbar factories, or other components',
+      () async {
+        await testSuggestor(
+          input: withOverReactAndWsdImports(/*language=dart*/ '''
             // Shadows the WSD factories
             UiFactory Button;
             UiFactory FormSubmitInput;
@@ -58,8 +59,9 @@ void main() {
               Dom.div()();
             }
         '''),
-      );
-    });
+        );
+      },
+    );
 
     group('does not migrate Buttons within buttonBefore or buttonAfter', () {
       test('directly assigned to', () async {
@@ -143,8 +145,7 @@ void main() {
         );
       });
 
-      group(
-          'for FormResetInput (potentially namespaced or v1/v2),'
+      group('for FormResetInput (potentially namespaced or v1/v2),'
           ' also adding relevant props', () {
         test('when there are no props', () async {
           await testSuggestor(
@@ -188,8 +189,7 @@ void main() {
         });
       });
 
-      group(
-          'for FormSubmit (potentially namespaced or v1/v2),'
+      group('for FormSubmit (potentially namespaced or v1/v2),'
           ' also adding relevant props', () {
         test('when there are no parens around the builder', () async {
           await testSuggestor(
@@ -328,23 +328,24 @@ void main() {
 
       group('skin', () {
         test(
-            'mapping link skin constants properly and changing the factory to LinkButton',
-            () async {
-          await testSuggestor(
-            input: withOverReactAndWsdImports(/*language=dart*/ '''
+          'mapping link skin constants properly and changing the factory to LinkButton',
+          () async {
+            await testSuggestor(
+              input: withOverReactAndWsdImports(/*language=dart*/ '''
                 content() {
                   (Button()..skin = ButtonSkin.LINK)();
                   (Button()..skin = ButtonSkin.OUTLINE_LINK)();
                 }
             '''),
-            expectedOutput: withOverReactAndWsdImports(/*language=dart*/ '''
+              expectedOutput: withOverReactAndWsdImports(/*language=dart*/ '''
                 content() {
                   (mui.LinkButton())();
                   (mui.LinkButton()..variant = mui.ButtonVariant.outlined)();
                 }
             '''),
-          );
-        });
+            );
+          },
+        );
 
         test('mapping skin constants properly', () async {
           await testSuggestor(
@@ -600,8 +601,7 @@ void main() {
       });
     });
 
-    group(
-        'migrates tooltipContent to use a wrapper OverlayTrigger,'
+    group('migrates tooltipContent to use a wrapper OverlayTrigger,'
         ' when the prop is', () {
       test('by itself', () async {
         await testSuggestor(
@@ -1139,23 +1139,25 @@ void main() {
       });
     });
 
-    test('flags buttons when `DialogFooter` occurs somewhere in the same file',
-        () async {
-      await testSuggestor(
-        input: withOverReactAndWsdImports(/*language=dart*/ '''
+    test(
+      'flags buttons when `DialogFooter` occurs somewhere in the same file',
+      () async {
+        await testSuggestor(
+          input: withOverReactAndWsdImports(/*language=dart*/ '''
             renderFooter() => DialogFooter()();
             content() {   
               Button()();
             }
         '''),
-        expectedOutput: withOverReactAndWsdImports(/*language=dart*/ '''
+          expectedOutput: withOverReactAndWsdImports(/*language=dart*/ '''
             renderFooter() => DialogFooter()();
             content() {
               // FIXME(mui_migration) check whether this button is nested inside a DialogFooter. If so, wrap it in a mui.ButtonToolbar with `..sx = {'float': 'right'}`.
               mui.Button()();
             }
         '''),
-      );
-    });
+        );
+      },
+    );
   }, tags: 'wsd');
 }

--- a/test/mui_suggestors/components/mui_button_toolbar_migrator_test.dart
+++ b/test/mui_suggestors/components/mui_button_toolbar_migrator_test.dart
@@ -33,25 +33,27 @@ void main() {
     );
 
     group('migrates WSD ButtonToolbars', () {
-      test('that are either unnamespaced or namespaced, and either v1 or v2',
-          () async {
-        await testSuggestor(
-          input: withOverReactAndWsdImports(/*language=dart*/ '''
+      test(
+        'that are either unnamespaced or namespaced, and either v1 or v2',
+        () async {
+          await testSuggestor(
+            input: withOverReactAndWsdImports(/*language=dart*/ '''
               content() {
                 ButtonToolbar()();
                 wsd_v1.ButtonToolbar()();
                 wsd_v2.ButtonToolbar()();
               }
           '''),
-          expectedOutput: withOverReactAndWsdImports(/*language=dart*/ '''
+            expectedOutput: withOverReactAndWsdImports(/*language=dart*/ '''
               content() {
                 mui.ButtonToolbar()();
                 mui.ButtonToolbar()();
                 mui.ButtonToolbar()();
               }
           '''),
-        );
-      });
+          );
+        },
+      );
 
       test('and not non-WSD ButtonToolbars or other components', () async {
         await testSuggestor(

--- a/test/mui_suggestors/components/mui_inline_alert_migrator_test.dart
+++ b/test/mui_suggestors/components/mui_inline_alert_migrator_test.dart
@@ -33,25 +33,27 @@ void main() {
     );
 
     group('migrates WSD Alerts', () {
-      test('that are either unnamespaced or namespaced, and either v1 or v2',
-          () async {
-        await testSuggestor(
-          input: withOverReactAndWsdImports(/*language=dart*/ '''
+      test(
+        'that are either unnamespaced or namespaced, and either v1 or v2',
+        () async {
+          await testSuggestor(
+            input: withOverReactAndWsdImports(/*language=dart*/ '''
               content() {
                 Alert()();
                 wsd_v1.Alert()();
                 wsd_v2.Alert()();
               }
           '''),
-          expectedOutput: withOverReactAndWsdImports(/*language=dart*/ '''
+            expectedOutput: withOverReactAndWsdImports(/*language=dart*/ '''
               content() {
                 mui.Alert()();
                 mui.Alert()();
                 mui.Alert()();
               }
           '''),
-        );
-      });
+          );
+        },
+      );
 
       test('and not non-WSD Alert or other components', () async {
         await testSuggestor(

--- a/test/mui_suggestors/components/shared.dart
+++ b/test/mui_suggestors/components/shared.dart
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-String withOverReactAndWsdImports(String source) => /*language=dart*/ '''
+String withOverReactAndWsdImports(String source) => /*language=dart*/
+    '''
     import 'dart:html';
     
     import 'package:over_react/over_react.dart';

--- a/test/mui_suggestors/system_props_to_sx_migrator_test.dart
+++ b/test/mui_suggestors/system_props_to_sx_migrator_test.dart
@@ -42,7 +42,8 @@ void main() {
       muiUri = Uri.file(muiFile.path).toString();
     });
 
-    String withImports(String source) => '''
+    String withImports(String source) =>
+        '''
       //@dart=2.19
       import 'package:over_react/over_react.dart';
       import ${jsonEncode(muiUri.toString())};
@@ -65,8 +66,9 @@ void main() {
       late ResolvedUnitResult unit;
 
       setUpAll(() async {
-        final file =
-            await resolvedContext.resolvedFileContextForTest(withImports(''));
+        final file = await resolvedContext.resolvedFileContextForTest(
+          withImports(''),
+        );
         unit = (await file.getResolvedUnit())!;
       });
 
@@ -74,10 +76,7 @@ void main() {
           getImportedInterfaceElement(unit, propsName);
 
       test('with system props', () async {
-        expect(
-          hasSxAndSomeSystemProps(getProps('BoxProps')),
-          isTrue,
-        );
+        expect(hasSxAndSomeSystemProps(getProps('BoxProps')), isTrue);
         expect(hasSxAndSomeSystemProps(getProps('GridProps')), isTrue);
         expect(hasSxAndSomeSystemProps(getProps('StackProps')), isTrue);
         expect(hasSxAndSomeSystemProps(getProps('TypographyProps')), isTrue);
@@ -217,10 +216,11 @@ void main() {
         );
       });
 
-      test('with an entry that has the same key as a migrated system prop',
-          () async {
-        await testSuggestor(
-          input: withImports('''
+      test(
+        'with an entry that has the same key as a migrated system prop',
+        () async {
+          await testSuggestor(
+            input: withImports('''
               content() => 
                   (Box()
                     ..sx = {
@@ -229,10 +229,10 @@ void main() {
                     ..mt = 2
                   )();
           '''),
-          // This will result in duplicate keys in the map, but they're in the
-          // correct order to preserve the original behavior, and will result in
-          // a hint that there are duplicate entries.
-          expectedOutput: withImports('''
+            // This will result in duplicate keys in the map, but they're in the
+            // correct order to preserve the original behavior, and will result in
+            // a hint that there are duplicate entries.
+            expectedOutput: withImports('''
               content() => 
                   (Box()
                     ..sx = { 
@@ -241,8 +241,9 @@ void main() {
                     }
                   )();
           '''),
-        );
-      });
+          );
+        },
+      );
     });
 
     group('merges with forwarded sx prop using spread:', () {
@@ -393,10 +394,11 @@ void main() {
       });
 
       // Regression test
-      test('even when there are other unrelated calls in the cascade',
-          () async {
-        await testSuggestor(
-          input: withImports('''
+      test(
+        'even when there are other unrelated calls in the cascade',
+        () async {
+          await testSuggestor(
+            input: withImports('''
               content(BoxProps props) =>
                   (Box()
                     ..addProps(props)
@@ -404,7 +406,7 @@ void main() {
                     ..mt = 2
                   )();
           '''),
-          expectedOutput: withImports('''
+            expectedOutput: withImports('''
               content(BoxProps props) =>
                   (Box()
                     ..addProps(props)
@@ -412,8 +414,9 @@ void main() {
                     ..sx = {'mt': 2, ...?props.sx,}
                   )();
           '''),
-        );
-      });
+          );
+        },
+      );
     });
 
     group('adds FIXME comment when forwarding is ambiguous:', () {
@@ -663,27 +666,31 @@ void main() {
       );
     });
 
-    test('does not migrate components without deprecated system props',
-        () async {
-      await testSuggestor(
-        input: withImports('''
+    test(
+      'does not migrate components without deprecated system props',
+      () async {
+        await testSuggestor(
+          input: withImports('''
             content() => 
                 (Box()
                   ..id = 'test'
                   ..className = 'test-class'
                 )();
         '''),
-      );
-    });
+        );
+      },
+    );
 
-    test('does not migrate deprecated props with the same name as system props',
-        () async {
-      await testSuggestor(
-        input: withImports('''
+    test(
+      'does not migrate deprecated props with the same name as system props',
+      () async {
+        await testSuggestor(
+          input: withImports('''
             content() => (TextField()..color = '')();
         '''),
-      );
-    });
+        );
+      },
+    );
 
     test('does not flag unrelated cascades with FIXMEs', () async {
       await testSuggestor(
@@ -699,11 +706,12 @@ void main() {
       );
     });
 
-    group('adds a fixme when there are forwarded props after system props and',
-        () {
-      test('an existing sx map literal', () async {
-        await testSuggestor(
-          input: withImports('''
+    group(
+      'adds a fixme when there are forwarded props after system props and',
+      () {
+        test('an existing sx map literal', () async {
+          await testSuggestor(
+            input: withImports('''
               content(BoxProps props) =>
                   (Box()
                     ..mt = 2
@@ -711,7 +719,7 @@ void main() {
                     ..sx = {'border': '1px solid black'}
                   )();
           '''),
-          expectedOutput: withImports('''
+            expectedOutput: withImports('''
               content(BoxProps props) =>
                   (Box()
                     ..addProps(props)
@@ -722,12 +730,12 @@ void main() {
                     }
                   )();
           '''),
-        );
-      });
+          );
+        });
 
-      test('an existing sx value', () async {
-        await testSuggestor(
-          input: withImports('''
+        test('an existing sx value', () async {
+          await testSuggestor(
+            input: withImports('''
               content(BoxProps props) =>
                   (Box()
                     ..mt = 2
@@ -736,7 +744,7 @@ void main() {
                   )();
               Map getSx() => {'color': 'red'};
           '''),
-          expectedOutput: withImports('''
+            expectedOutput: withImports('''
               content(BoxProps props) =>
                   (Box()
                     ..addProps(props)
@@ -748,19 +756,19 @@ void main() {
                   )();
               Map getSx() => {'color': 'red'};
           '''),
-        );
-      });
+          );
+        });
 
-      test('no existing sx', () async {
-        await testSuggestor(
-          input: withImports('''
+        test('no existing sx', () async {
+          await testSuggestor(
+            input: withImports('''
               content(BoxProps props) =>
                   (Box()
                     ..mt = 2
                     ..addProps(props)
                   )();
           '''),
-          expectedOutput: withImports('''
+            expectedOutput: withImports('''
               content(BoxProps props) =>
                   (Box()
                     ..addProps(props)
@@ -771,15 +779,17 @@ void main() {
                     }
                   )();
           '''),
-        );
-      });
-    });
+          );
+        });
+      },
+    );
 
     group('insertion location:', () {
-      test('inserts after prop forwarding to avoid being overwritten',
-          () async {
-        await testSuggestor(
-          input: withImports('''
+      test(
+        'inserts after prop forwarding to avoid being overwritten',
+        () async {
+          await testSuggestor(
+            input: withImports('''
               content(BoxProps props) =>
                   (Box()
                     ..mt = 2
@@ -787,7 +797,7 @@ void main() {
                     ..id = 'test'
                   )();
           '''),
-          expectedOutput: withImports('''
+            expectedOutput: withImports('''
               content(BoxProps props) =>
                   (Box()
                     ..addProps(props)
@@ -796,13 +806,15 @@ void main() {
                     ..id = 'test'
                   )();
           '''),
-        );
-      });
+          );
+        },
+      );
 
-      test('inserts at location of last system prop when no prop forwarding',
-          () async {
-        await testSuggestor(
-          input: withImports('''
+      test(
+        'inserts at location of last system prop when no prop forwarding',
+        () async {
+          await testSuggestor(
+            input: withImports('''
               content() => 
                   (Box()
                     ..id = 'first'
@@ -812,7 +824,7 @@ void main() {
                     ..onClick = (_) {}
                   )();
           '''),
-          expectedOutput: withImports('''
+            expectedOutput: withImports('''
               content() => 
                   (Box()
                     ..id = 'first'
@@ -821,13 +833,15 @@ void main() {
                     ..onClick = (_) {}
                   )();
           '''),
-        );
-      });
+          );
+        },
+      );
 
-      test('inserts after latest of (forwarding or last system prop)',
-          () async {
-        await testSuggestor(
-          input: withImports('''
+      test(
+        'inserts after latest of (forwarding or last system prop)',
+        () async {
+          await testSuggestor(
+            input: withImports('''
               content(BoxProps props) =>
                   (Box()
                     ..mt = 2
@@ -835,7 +849,7 @@ void main() {
                     ..p = 3
                   )();
           '''),
-          expectedOutput: withImports('''
+            expectedOutput: withImports('''
               content(BoxProps props) =>
                   (Box()
                     ..addProps(props)
@@ -844,8 +858,9 @@ void main() {
                     ..sx = {'mt': 2, 'p': 3, ...?props.sx,}
                   )();
           '''),
-        );
-      });
+          );
+        },
+      );
 
       test('inserts after all forwarding calls when multiple exist', () async {
         await testSuggestor(
@@ -914,17 +929,18 @@ void main() {
         );
       });
 
-      test('uses multiline for long content (>= 20 chars with 2+ elements)',
-          () async {
-        await testSuggestor(
-          input: withImports('''
+      test(
+        'uses multiline for long content (>= 20 chars with 2+ elements)',
+        () async {
+          await testSuggestor(
+            input: withImports('''
               content() => 
                   (Box()
                     ..mt = 2
                     ..bgcolor = 'verylongcolor.main'
                   )();
           '''),
-          expectedOutput: withImports('''
+            expectedOutput: withImports('''
               content() => 
                   (Box()
                     ..sx = {
@@ -933,8 +949,9 @@ void main() {
                     }
                   )();
           '''),
-        );
-      });
+          );
+        },
+      );
     });
 
     group('preserves comments before system props:', () {
@@ -1058,10 +1075,11 @@ void main() {
         );
       });
 
-      test('comments before system props mixed with non-system props',
-          () async {
-        await testSuggestor(
-          input: withImports('''
+      test(
+        'comments before system props mixed with non-system props',
+        () async {
+          await testSuggestor(
+            input: withImports('''
               content() => 
                   (Box()
                     ..id = 'test'
@@ -1072,7 +1090,7 @@ void main() {
                     ..p = 3
                   )();
           '''),
-          expectedOutput: withImports('''
+            expectedOutput: withImports('''
               content() => 
                   (Box()
                     ..id = 'test'
@@ -1085,8 +1103,9 @@ void main() {
                     }
                   )();
           '''),
-        );
-      });
+          );
+        },
+      );
 
       test('comment before system prop with forwarding', () async {
         await testSuggestor(
@@ -1215,13 +1234,9 @@ void main() {
 }
 
 String getStubMuiLibrarySource({required String filenameWithoutExtension}) {
-  final systemPropComponentsSource = [
-    'Box',
-    'Grid',
-    'Stack',
-    'Typography',
-  ].map((componentName) {
-    return '''
+  final systemPropComponentsSource = ['Box', 'Grid', 'Stack', 'Typography']
+      .map((componentName) {
+        return '''
       UiFactory<${componentName}Props> $componentName = uiFunction((_) {}, _\$${componentName}Config);
       
       @Props(keyNamespace: '')
@@ -1232,7 +1247,8 @@ String getStubMuiLibrarySource({required String filenameWithoutExtension}) {
         ${systemPropNames.map((propName) => "  @Deprecated('Use sx.') dynamic ${propName};").join('\n')}
       }
   ''';
-  }).join('\n\n');
+      })
+      .join('\n\n');
 
   return '''
       //@dart=2.19
@@ -1265,8 +1281,11 @@ InterfaceElement getInterfaceElement(ResolvedUnitResult result, String name) =>
         .singleWhere((e) => e.name == name);
 
 InterfaceElement getImportedInterfaceElement(
-        ResolvedUnitResult result, String name) =>
+  ResolvedUnitResult result,
+  String name,
+) =>
     result.libraryElement.importedLibraries
-        .map((l) => l.exportNamespace.get(name))
-        .whereNotNull()
-        .single as InterfaceElement;
+            .map((l) => l.exportNamespace.get(name))
+            .whereNotNull()
+            .single
+        as InterfaceElement;

--- a/test/react16_suggestors/comment_remover_test.dart
+++ b/test/react16_suggestors/comment_remover_test.dart
@@ -18,17 +18,20 @@ import 'package:test/test.dart';
 
 import '../util.dart';
 
-const manualCheckedStyleMapString = '// [x] Check this box upon manual '
+const manualCheckedStyleMapString =
+    '// [x] Check this box upon manual '
     'validation that this style map uses a valid value for the keys that are '
     'numbers.';
 
-const manualCheckedRefString = '// [x] Check this box upon manual validation of'
+const manualCheckedRefString =
+    '// [x] Check this box upon manual validation of'
     ' this ref and its typing. $willBeRemovedCommentSuffix';
 
 main() {
   group('CommentRemover', () {
-    final testSuggestor =
-        getSuggestorTester(CommentRemover('Check this box', 'complete'));
+    final testSuggestor = getSuggestorTester(
+      CommentRemover('Check this box', 'complete'),
+    );
 
     test('does not update an empty file', () async {
       await testSuggestor(expectedPatchCount: 0, input: '');
@@ -50,7 +53,8 @@ main() {
         test('', () async {
           await testSuggestor(
             expectedPatchCount: 1,
-            input: '''
+            input:
+                '''
           class Test extends UiComponent {
             var aTest = Foo()
             $manualCheckedStyleMapString $willBeRemovedCommentSuffix
@@ -69,7 +73,8 @@ main() {
         test('nested under a function', () async {
           await testSuggestor(
             expectedPatchCount: 1,
-            input: '''
+            input:
+                '''
           class test extends UiComponent {
             dynamic function() {
               return Foo()
@@ -93,7 +98,8 @@ main() {
       test('updates when there is a multiline comment', () async {
         await testSuggestor(
           expectedPatchCount: 1,
-          input: '''
+          input:
+              '''
           class Test extends UiComponent {
             var aTest = Foo()
              $manualCheckedStyleMapString
@@ -111,12 +117,12 @@ main() {
         );
       });
 
-      test(
-          'updates when there is a multiline comment and a comment string is'
+      test('updates when there is a multiline comment and a comment string is'
           ' split', () async {
         await testSuggestor(
           expectedPatchCount: 1,
-          input: '''
+          input:
+              '''
           class Test extends UiComponent {
             var aTest = Foo()
              // [x] Check this box upon manual validation that this style map is
@@ -136,7 +142,8 @@ main() {
 
         await testSuggestor(
           expectedPatchCount: 1,
-          input: '''
+          input:
+              '''
           class Test extends UiComponent {
             var aTest = Foo()
              // [x] Check this box upon manual validation that this style map is
@@ -157,7 +164,8 @@ main() {
 
         await testSuggestor(
           expectedPatchCount: 1,
-          input: '''
+          input:
+              '''
           class Test extends UiComponent {
             var aTest = Foo()
              // [x] Check this box upon manual validation that this style map
@@ -179,7 +187,8 @@ main() {
       test('does not remove comments above', () async {
         await testSuggestor(
           expectedPatchCount: 1,
-          input: ''' 
+          input:
+              ''' 
           class Test extends UiComponent {
             var aTest = Foo()
              // A random comment that should not be removed.
@@ -202,7 +211,8 @@ main() {
       test('does not remove comments below', () async {
         await testSuggestor(
           expectedPatchCount: 1,
-          input: '''
+          input:
+              '''
           class Test extends UiComponent {
             var aTest = Foo()
              $manualCheckedStyleMapString
@@ -227,7 +237,8 @@ main() {
       test('updates when there is a basic comment', () async {
         await testSuggestor(
           expectedPatchCount: 1,
-          input: '''
+          input:
+              '''
             main() {
               var instance;
               $manualCheckedRefString
@@ -250,7 +261,8 @@ main() {
       test('updates when there is a multiline comment', () async {
         await testSuggestor(
           expectedPatchCount: 1,
-          input: '''
+          input:
+              '''
             main() {
               var instance;
               // [x] Check this box upon manual validation of

--- a/test/react16_suggestors/dependency_override_updater_test.dart
+++ b/test/react16_suggestors/dependency_override_updater_test.dart
@@ -19,7 +19,8 @@ import '../util.dart';
 
 main() {
   group('DependencyOverrideUpdater', () {
-    const defaultDependencies = '  test: 1.5.1\n'
+    const defaultDependencies =
+        '  test: 1.5.1\n'
         '  react: ^4.6.0\n'
         '  over_react: ^2.0.0\n';
     const defaultDevDependencies = '  dart_dev: ^2.0.1\n';
@@ -29,9 +30,13 @@ main() {
       'dev_dependencies': defaultDevDependencies,
     };
 
-    void testDependencyOverridesSectionByPosition(SuggestorTester tester,
-        Map inputSections, String expectedOverrideContent,
-        {String? additionalOverrides, bool testIdempotency = true}) {
+    void testDependencyOverridesSectionByPosition(
+      SuggestorTester tester,
+      Map inputSections,
+      String expectedOverrideContent, {
+      String? additionalOverrides,
+      bool testIdempotency = true,
+    }) {
       if (additionalOverrides != null) {
         expectedOverrideContent += additionalOverrides;
       }
@@ -41,7 +46,8 @@ main() {
           expectedPatchCount: 2,
           shouldDartfmtOutput: false,
           testIdempotency: testIdempotency,
-          input: ''
+          input:
+              ''
                   'dependencies:\n' +
               inputSections['dependencies'] +
               '\n'
@@ -51,7 +57,8 @@ main() {
                   'dependency_overrides:\n' +
               inputSections['dependency_overrides'] +
               '',
-          expectedOutput: ''
+          expectedOutput:
+              ''
                   'dependencies:\n' +
               expectedOutputSections['dependencies']! +
               '\n'
@@ -67,14 +74,16 @@ main() {
       test('and the dependency_overrides section is first', () async {
         // The extra line-break is not ideal, but the effort to make it be a
         // single break no matter the order of the sections is not worth it, IMO.
-        final lineBreaksAfterDepOverridesSection =
-            additionalOverrides == null ? '\n\n' : '\n';
+        final lineBreaksAfterDepOverridesSection = additionalOverrides == null
+            ? '\n\n'
+            : '\n';
 
         await tester(
           expectedPatchCount: 2,
           shouldDartfmtOutput: false,
           testIdempotency: testIdempotency,
-          input: ''
+          input:
+              ''
                   'dependency_overrides:\n' +
               inputSections['dependency_overrides'] +
               '\n'
@@ -84,7 +93,8 @@ main() {
                   'dev_dependencies:\n' +
               inputSections['dev_dependencies'] +
               '',
-          expectedOutput: ''
+          expectedOutput:
+              ''
                   'dependency_overrides:\n' +
               expectedOverrideContent +
               lineBreaksAfterDepOverridesSection +
@@ -100,14 +110,16 @@ main() {
       test('and the dependency_overrides section is in the middle', () async {
         // The extra line-break is not ideal, but the effort to make it be a
         // single break no matter the order of the sections is not worth it, IMO.
-        final lineBreaksAfterDepOverridesSection =
-            additionalOverrides == null ? '\n\n' : '\n';
+        final lineBreaksAfterDepOverridesSection = additionalOverrides == null
+            ? '\n\n'
+            : '\n';
 
         await tester(
           expectedPatchCount: 2,
           shouldDartfmtOutput: false,
           testIdempotency: testIdempotency,
-          input: ''
+          input:
+              ''
                   'dependencies:\n' +
               inputSections['dependencies'] +
               '\n'
@@ -117,7 +129,8 @@ main() {
                   'dev_dependencies:\n' +
               inputSections['dev_dependencies'] +
               '',
-          expectedOutput: ''
+          expectedOutput:
+              ''
                   'dependencies:\n' +
               expectedOutputSections['dependencies']! +
               '\n'
@@ -132,8 +145,10 @@ main() {
     }
 
     void commonOverrideUpdaterTests(
-        SuggestorTester tester, String expectedOverrideOutput,
-        {bool testIdempotency = true}) {
+      SuggestorTester tester,
+      String expectedOverrideOutput, {
+      bool testIdempotency = true,
+    }) {
       group('- common override updater tests -', () {
         group('adds the dependencies if', () {
           test('the pubspec is empty', () async {
@@ -142,7 +157,8 @@ main() {
               expectedPatchCount: 2,
               shouldDartfmtOutput: false,
               input: '',
-              expectedOutput: '\n'
+              expectedOutput:
+                  '\n'
                       'dependency_overrides:\n' +
                   expectedOverrideOutput +
                   '',
@@ -153,14 +169,16 @@ main() {
             await tester(
               expectedPatchCount: 2,
               shouldDartfmtOutput: false,
-              input: ''
+              input:
+                  ''
                   'dependencies:\n'
                   '  test: 1.5.1\n'
                   '\n'
                   'dev_dependencies:\n'
                   '  dart_dev: ^2.0.1\n'
                   '',
-              expectedOutput: ''
+              expectedOutput:
+                  ''
                       'dependencies:\n'
                       '  test: 1.5.1\n'
                       '\n'
@@ -178,7 +196,8 @@ main() {
               const inputSections = {
                 'dependencies': defaultDependencies,
                 'dev_dependencies': defaultDevDependencies,
-                'dependency_overrides': '  react:\n'
+                'dependency_overrides':
+                    '  react:\n'
                     '    git:\n'
                     '      url: git@github.com:cleandart/react-dart.git\n'
                     '      ref: 5.0.0-wip\n'
@@ -189,15 +208,19 @@ main() {
               };
 
               testDependencyOverridesSectionByPosition(
-                  tester, inputSections, expectedOverrideOutput,
-                  testIdempotency: testIdempotency);
+                tester,
+                inputSections,
+                expectedOverrideOutput,
+                testIdempotency: testIdempotency,
+              );
             });
 
             group('git (HTTPS)', () {
               const inputSections = {
                 'dependencies': defaultDependencies,
                 'dev_dependencies': defaultDevDependencies,
-                'dependency_overrides': '  react:\n'
+                'dependency_overrides':
+                    '  react:\n'
                     '    git:\n'
                     '      url: https://github.com/cleandart/react-dart.git\n'
                     '      ref: 5.0.0-wip\n'
@@ -208,23 +231,30 @@ main() {
               };
 
               testDependencyOverridesSectionByPosition(
-                  tester, inputSections, expectedOverrideOutput,
-                  testIdempotency: testIdempotency);
+                tester,
+                inputSections,
+                expectedOverrideOutput,
+                testIdempotency: testIdempotency,
+              );
             });
 
             group('path', () {
               const inputSections = {
                 'dependencies': defaultDependencies,
                 'dev_dependencies': defaultDevDependencies,
-                'dependency_overrides': '  react:\n'
+                'dependency_overrides':
+                    '  react:\n'
                     '    path: ../../anywhere\n'
                     '  over_react:\n'
                     '    path: ../../anywhere\n',
               };
 
               testDependencyOverridesSectionByPosition(
-                  tester, inputSections, expectedOverrideOutput,
-                  testIdempotency: testIdempotency);
+                tester,
+                inputSections,
+                expectedOverrideOutput,
+                testIdempotency: testIdempotency,
+              );
             });
           });
 
@@ -232,14 +262,16 @@ main() {
             await tester(
               expectedPatchCount: 2,
               shouldDartfmtOutput: false,
-              input: ''
+              input:
+                  ''
                       'dependencies:\n' +
                   defaultDependencies +
                   '\n'
                       'dev_dependencies:\n' +
                   defaultDevDependencies +
                   '',
-              expectedOutput: ''
+              expectedOutput:
+                  ''
                       'dependencies:\n' +
                   defaultDependencies +
                   '\n'
@@ -253,7 +285,8 @@ main() {
           });
 
           group('preserves existing, unrelated dependency overrides', () {
-            const unrelatedOverride = '  foo:\n'
+            const unrelatedOverride =
+                '  foo:\n'
                 '    git:\n'
                 '      url: git@github.com:Workiva/foo.git\n'
                 '      ref: 100.0.0\n';
@@ -264,65 +297,73 @@ main() {
             };
 
             testDependencyOverridesSectionByPosition(
-                tester, inputSections, expectedOverrideOutput,
-                additionalOverrides: unrelatedOverride,
-                testIdempotency: testIdempotency);
-          });
-
-          test('does not override sections after dependency_overrides',
-              () async {
-            await tester(
-              expectedPatchCount: 2,
-              shouldDartfmtOutput: false,
-              testIdempotency: false,
-              input: ''
-                  'dependencies:\n'
-                  '  test: 1.5.1\n'
-                  '  react: ^4.6.0\n'
-                  '  over_react: ^2.0.0\n'
-                  '\n'
-                  'dev_dependencies:\n'
-                  '  dart_dev: ^2.0.1\n'
-                  '\n'
-                  'dependency_overrides:\n'
-                  '  foo:\n'
-                  '    git:\n'
-                  '      url: git@github.com:Workiva/foo.git\n'
-                  '      ref: 100.0.0\n'
-                  '\n'
-                  'executables:\n'
-                  '  dart2_upgrade:\n'
-                  '  react_16_upgrade:\n'
-                  '',
-              expectedOutput: ''
-                      'dependencies:\n'
-                      '  test: 1.5.1\n'
-                      '  react: ^4.6.0\n'
-                      '  over_react: ^2.0.0\n'
-                      '\n'
-                      'dev_dependencies:\n'
-                      '  dart_dev: ^2.0.1\n'
-                      '\n'
-                      'dependency_overrides:\n' +
-                  expectedOverrideOutput +
-                  '  foo:\n'
-                      '    git:\n'
-                      '      url: git@github.com:Workiva/foo.git\n'
-                      '      ref: 100.0.0\n'
-                      '\n'
-                      'executables:\n'
-                      '  dart2_upgrade:\n'
-                      '  react_16_upgrade:\n'
-                      '',
+              tester,
+              inputSections,
+              expectedOverrideOutput,
+              additionalOverrides: unrelatedOverride,
+              testIdempotency: testIdempotency,
             );
           });
+
+          test(
+            'does not override sections after dependency_overrides',
+            () async {
+              await tester(
+                expectedPatchCount: 2,
+                shouldDartfmtOutput: false,
+                testIdempotency: false,
+                input:
+                    ''
+                    'dependencies:\n'
+                    '  test: 1.5.1\n'
+                    '  react: ^4.6.0\n'
+                    '  over_react: ^2.0.0\n'
+                    '\n'
+                    'dev_dependencies:\n'
+                    '  dart_dev: ^2.0.1\n'
+                    '\n'
+                    'dependency_overrides:\n'
+                    '  foo:\n'
+                    '    git:\n'
+                    '      url: git@github.com:Workiva/foo.git\n'
+                    '      ref: 100.0.0\n'
+                    '\n'
+                    'executables:\n'
+                    '  dart2_upgrade:\n'
+                    '  react_16_upgrade:\n'
+                    '',
+                expectedOutput:
+                    ''
+                        'dependencies:\n'
+                        '  test: 1.5.1\n'
+                        '  react: ^4.6.0\n'
+                        '  over_react: ^2.0.0\n'
+                        '\n'
+                        'dev_dependencies:\n'
+                        '  dart_dev: ^2.0.1\n'
+                        '\n'
+                        'dependency_overrides:\n' +
+                    expectedOverrideOutput +
+                    '  foo:\n'
+                        '    git:\n'
+                        '      url: git@github.com:Workiva/foo.git\n'
+                        '      ref: 100.0.0\n'
+                        '\n'
+                        'executables:\n'
+                        '  dart2_upgrade:\n'
+                        '  react_16_upgrade:\n'
+                        '',
+              );
+            },
+          );
 
           test('does not fail if there is no trailing new line.', () async {
             await tester(
               expectedPatchCount: 2,
               shouldDartfmtOutput: false,
               testIdempotency: false,
-              input: ''
+              input:
+                  ''
                   'dependencies:\n'
                   '  test: 1.5.1\n'
                   '  react: ^4.6.0\n'
@@ -330,7 +371,8 @@ main() {
                   '\n'
                   'dev_dependencies:\n'
                   '  dart_dev: ^2.0.1\n',
-              expectedOutput: ''
+              expectedOutput:
+                  ''
                       'dependencies:\n'
                       '  test: 1.5.1\n'
                       '  react: ^4.6.0\n'
@@ -349,17 +391,25 @@ main() {
     }
 
     group('with a SimpleOverrideConfig', () {
-      final defaultReactConfig =
-          SimpleOverrideConfig(name: 'react', version: '^5.0.0-alpha');
-      final defaultOverReactConfig =
-          SimpleOverrideConfig(name: 'over_react', version: '^3.0.0-alpha');
+      final defaultReactConfig = SimpleOverrideConfig(
+        name: 'react',
+        version: '^5.0.0-alpha',
+      );
+      final defaultOverReactConfig = SimpleOverrideConfig(
+        name: 'over_react',
+        version: '^3.0.0-alpha',
+      );
 
-      const expectedOverrides = '  react: ^5.0.0-alpha\n'
+      const expectedOverrides =
+          '  react: ^5.0.0-alpha\n'
           '  over_react: ^3.0.0-alpha\n';
 
-      final testSuggestor = getSuggestorTester(DependencyOverrideUpdater(
+      final testSuggestor = getSuggestorTester(
+        DependencyOverrideUpdater(
           reactOverrideConfig: defaultReactConfig,
-          overReactOverrideConfig: defaultOverReactConfig));
+          overReactOverrideConfig: defaultOverReactConfig,
+        ),
+      );
 
       commonOverrideUpdaterTests(testSuggestor, expectedOverrides);
     });
@@ -377,22 +427,30 @@ main() {
 ''';
 
         final defaultReactConfig = GitOverrideConfig(
-            name: 'react',
-            url: 'https://github.com/cleandart/react-dart.git',
-            ref: '6.0.0-wip');
+          name: 'react',
+          url: 'https://github.com/cleandart/react-dart.git',
+          ref: '6.0.0-wip',
+        );
         final defaultOverReactConfig = GitOverrideConfig(
-            name: 'over_react',
-            url: 'https://github.com/Workiva/over_react.git',
-            ref: 'release_over_react_4.0.0');
+          name: 'over_react',
+          url: 'https://github.com/Workiva/over_react.git',
+          ref: 'release_over_react_4.0.0',
+        );
 
-        final testSuggestor = getSuggestorTester(DependencyOverrideUpdater(
+        final testSuggestor = getSuggestorTester(
+          DependencyOverrideUpdater(
             reactOverrideConfig: defaultReactConfig,
-            overReactOverrideConfig: defaultOverReactConfig));
+            overReactOverrideConfig: defaultOverReactConfig,
+          ),
+        );
 
         // turning idempotency tests off for this because it would just add a new line the second run,
         // which caused failures for insignificant white space
-        commonOverrideUpdaterTests(testSuggestor, expectedOverrides,
-            testIdempotency: false);
+        commonOverrideUpdaterTests(
+          testSuggestor,
+          expectedOverrides,
+          testIdempotency: false,
+        );
       });
 
       group('with no ref', () {
@@ -405,19 +463,28 @@ main() {
 ''';
 
         final defaultReactConfig = GitOverrideConfig(
-            name: 'react', url: 'https://github.com/cleandart/react-dart.git');
+          name: 'react',
+          url: 'https://github.com/cleandart/react-dart.git',
+        );
         final defaultOverReactConfig = GitOverrideConfig(
-            name: 'over_react',
-            url: 'https://github.com/Workiva/over_react.git');
+          name: 'over_react',
+          url: 'https://github.com/Workiva/over_react.git',
+        );
 
-        final testSuggestor = getSuggestorTester(DependencyOverrideUpdater(
+        final testSuggestor = getSuggestorTester(
+          DependencyOverrideUpdater(
             reactOverrideConfig: defaultReactConfig,
-            overReactOverrideConfig: defaultOverReactConfig));
+            overReactOverrideConfig: defaultOverReactConfig,
+          ),
+        );
 
         // turning idempotency tests off for this because it would just add a new line the second run,
         // which caused failures for insignificant white space
-        commonOverrideUpdaterTests(testSuggestor, expectedOverrides,
-            testIdempotency: false);
+        commonOverrideUpdaterTests(
+          testSuggestor,
+          expectedOverrides,
+          testIdempotency: false,
+        );
       });
     });
   });

--- a/test/react16_suggestors/pubspec_react_updater_test.dart
+++ b/test/react16_suggestors/pubspec_react_updater_test.dart
@@ -33,59 +33,67 @@ main() {
   group('PubspecReactUpdater', () {
     /// Suggestor used to test the default configurations.
     final testSuggestor = getSuggestorTester(
-        PubspecReactUpdater(parseVersionRange(reactVersionRange)));
+      PubspecReactUpdater(parseVersionRange(reactVersionRange)),
+    );
 
     /// Suggestor to test when the codemod should not add the dependency if
     /// it does not encounter it.
-    final doNotAddDependencies = getSuggestorTester(PubspecReactUpdater(
+    final doNotAddDependencies = getSuggestorTester(
+      PubspecReactUpdater(
         parseVersionRange(reactVersionRange),
-        shouldAddDependencies: false));
+        shouldAddDependencies: false,
+      ),
+    );
 
     group('when there are no special cases', () {
       sharedPubspecTest(
-          testSuggestor: testSuggestor,
-          getExpectedOutput: getExpectedOutput,
-          startingRange: parseVersionRange('>=4.6.1 <4.9.0'),
-          isDevDependency: false,
-          dependency: 'react',
-          midVersionRange: '^$midVersionMin');
+        testSuggestor: testSuggestor,
+        getExpectedOutput: getExpectedOutput,
+        startingRange: parseVersionRange('>=4.6.1 <4.9.0'),
+        isDevDependency: false,
+        dependency: 'react',
+        midVersionRange: '^$midVersionMin',
+      );
 
       group('and the new version is a pre-release version', () {
         sharedPubspecTest(
-            testSuggestor: getSuggestorTester(PubspecReactUpdater(
-                parseVersionRange(reactVersionRangeForTesting))),
-            getExpectedOutput: getExpectedPreReleaseOutput,
-            startingRange: parseVersionRange('>=4.6.1 <4.9.0'),
-            isDevDependency: false,
-            midVersionRange: '^5.5.3',
-            shouldUpdateMidRange: false,
-            dependency: 'react');
+          testSuggestor: getSuggestorTester(
+            PubspecReactUpdater(parseVersionRange(reactVersionRangeForTesting)),
+          ),
+          getExpectedOutput: getExpectedPreReleaseOutput,
+          startingRange: parseVersionRange('>=4.6.1 <4.9.0'),
+          isDevDependency: false,
+          midVersionRange: '^5.5.3',
+          shouldUpdateMidRange: false,
+          dependency: 'react',
+        );
       });
     });
 
     group('when the codemod should not add dependencies', () {
       sharedPubspecTest(
-          testSuggestor: doNotAddDependencies,
-          getExpectedOutput: getExpectedOutput,
-          startingRange: parseVersionRange('>=4.6.1 <4.9.0'),
-          isDevDependency: false,
-          dependency: 'react',
-          midVersionRange: '^$midVersionMin',
-          shouldAddDependencies: false);
+        testSuggestor: doNotAddDependencies,
+        getExpectedOutput: getExpectedOutput,
+        startingRange: parseVersionRange('>=4.6.1 <4.9.0'),
+        isDevDependency: false,
+        dependency: 'react',
+        midVersionRange: '^$midVersionMin',
+        shouldAddDependencies: false,
+      );
     });
 
-    group(
-        'when the codemod should not update because the version range is '
+    group('when the codemod should not update because the version range is '
         'acceptable', () {
       sharedPubspecTest(
-          testSuggestor: testSuggestor,
-          getExpectedOutput: getExpectedOutput,
-          startingRange: parseVersionRange('^5.0.0'),
-          isDevDependency: false,
-          dependency: 'react',
-          shouldUpdate: false,
-          shouldUpdateMidRange: false,
-          midVersionRange: '^5.5.3');
+        testSuggestor: testSuggestor,
+        getExpectedOutput: getExpectedOutput,
+        startingRange: parseVersionRange('^5.0.0'),
+        isDevDependency: false,
+        dependency: 'react',
+        shouldUpdate: false,
+        shouldUpdateMidRange: false,
+        midVersionRange: '^5.5.3',
+      );
     });
 
     test('does not lower the lower bound', () async {
@@ -93,14 +101,16 @@ main() {
         expectedPatchCount: 1,
         shouldDartfmtOutput: false,
         validateContents: validatePubspecYaml,
-        input: ''
+        input:
+            ''
             'name: nothing\n'
             'version: 0.0.0\n'
             'dependencies:\n'
             '  react: ">=4.8.0 <5.0.0"\n'
             '  test: 1.5.1\n'
             '',
-        expectedOutput: ''
+        expectedOutput:
+            ''
             'name: nothing\n'
             'version: 0.0.0\n'
             'dependencies:\n'
@@ -116,7 +126,8 @@ main() {
           expectedPatchCount: 0,
           shouldDartfmtOutput: false,
           validateContents: validatePubspecYaml,
-          input: ''
+          input:
+              ''
               'dependency_overrides:\n'
               '  react:\n'
               '    git:\n'
@@ -130,7 +141,8 @@ main() {
           expectedPatchCount: 0,
           shouldDartfmtOutput: false,
           validateContents: validatePubspecYaml,
-          input: ''
+          input:
+              ''
               'dependency_overrides:\n'
               '  react:\n'
               '    path: ../\n',
@@ -144,8 +156,8 @@ String getExpectedOutput({bool useMidVersionMin = false, String? hostedUrl}) {
   if (useMidVersionMin) {
     final expected =
         VersionConstraint.parse('^5.0.0').allows(Version.parse(midVersionMin))
-            ? '^$midVersionMin'
-            : '">=$midVersionMin <6.0.0"';
+        ? '^$midVersionMin'
+        : '">=$midVersionMin <6.0.0"';
 
     return ''
         'dependencies:\n'
@@ -161,8 +173,10 @@ String getExpectedOutput({bool useMidVersionMin = false, String? hostedUrl}) {
       '';
 }
 
-String getExpectedPreReleaseOutput(
-    {bool useMidVersionMin = false, String? hostedUrl}) {
+String getExpectedPreReleaseOutput({
+  bool useMidVersionMin = false,
+  String? hostedUrl,
+}) {
   return ''
       'dependencies:\n'
       '  react: ^5.0.0-alpha\n'

--- a/test/react16_suggestors/react_dom_render_migrator_test.dart
+++ b/test/react16_suggestors/react_dom_render_migrator_test.dart
@@ -69,7 +69,8 @@ main() {
             var instance = react_dom.render(Foo()(), mountNode);
           }
         ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
           import 'package:over_react/over_react.dart';
           import 'package:react/react_dom.dart' as react_dom;
 
@@ -84,11 +85,12 @@ main() {
       );
     });
 
-    test('simple usage already wrapped with ErrorBoundary that has props',
-        () async {
-      await testSuggestor(
-        expectedPatchCount: 0,
-        input: '''
+    test(
+      'simple usage already wrapped with ErrorBoundary that has props',
+      () async {
+        await testSuggestor(
+          expectedPatchCount: 0,
+          input: '''
           import 'package:over_react/over_react.dart';
           import 'package:react/react_dom.dart' as react_dom;
 
@@ -97,8 +99,9 @@ main() {
             react_dom.render((ErrorBoundary()..prop = true)(foo), mountNode);
           }
         ''',
-      );
-    });
+        );
+      },
+    );
 
     test('simple usage assignment to existing variable', () async {
       await testSuggestor(
@@ -112,7 +115,8 @@ main() {
             instance = react_dom.render(Foo()(), mountNode);
           }
         ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
           import 'package:over_react/over_react.dart';
           import 'package:react/react_dom.dart' as react_dom;
 
@@ -138,7 +142,8 @@ main() {
             var instance = getDartComponent(react_dom.render(Foo()(), mountNode));
           }
         ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
           import 'package:over_react/over_react.dart';
           import 'package:react/react_dom.dart' as react_dom;
 
@@ -161,7 +166,8 @@ main() {
             return react_dom.render(Foo()(), mountNode);
           }
         ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
           import 'package:over_react/over_react.dart';
           import 'package:react/react_dom.dart' as react_dom;
 
@@ -186,7 +192,8 @@ main() {
             )(), mountNode);
           }
         ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
           import 'package:over_react/over_react.dart';
           import 'package:react/react_dom.dart' as react_dom;
 
@@ -216,7 +223,8 @@ main() {
             )(), mountNode);
           }
         ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
           import 'package:over_react/over_react.dart';
           import 'package:react/react_dom.dart' as react_dom;
 
@@ -242,7 +250,8 @@ main() {
             void render() => react_dom.render((Foo()..ref = ((ref) => fooRef = ref))(), mountNode);
           }
         ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
           import 'package:over_react/over_react.dart';
           import 'package:react/react_dom.dart' as react_dom;
 
@@ -265,7 +274,8 @@ main() {
             render() => react_dom.render((Foo()..ref = ((ref) => fooRef = ref))(), mountNode);
           }
         ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
           import 'package:over_react/over_react.dart';
           import 'package:react/react_dom.dart' as react_dom;
 
@@ -290,7 +300,8 @@ main() {
             )(), mountNode);
           }
         ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
           import 'package:over_react/over_react.dart';
           import 'package:react/react_dom.dart' as react_dom;
 
@@ -322,7 +333,8 @@ main() {
             instance4 = react_dom.render(foo, mountNode);
           }
         ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
           import 'package:over_react/over_react.dart';
           import 'package:react/react_dom.dart' as react_dom;
 
@@ -348,7 +360,8 @@ main() {
     test('simple usage with validated ref', () async {
       await testSuggestor(
         expectedPatchCount: 0,
-        input: '''
+        input:
+            '''
           import 'package:over_react/over_react.dart';
           import 'package:react/react_dom.dart' as react_dom;
 
@@ -366,7 +379,8 @@ main() {
     test('simple usage with unvalidated ref', () async {
       await testSuggestor(
         expectedPatchCount: 0,
-        input: '''
+        input:
+            '''
           import 'package:over_react/over_react.dart';
           import 'package:react/react_dom.dart' as react_dom;
 
@@ -518,35 +532,45 @@ main() {
       );
     });
 
-    test('no react_dom.dart import but usage has namespace in a `part of` file',
-        () async {
-      await testSuggestor(expectedPatchCount: 2, input: '''
+    test(
+      'no react_dom.dart import but usage has namespace in a `part of` file',
+      () async {
+        await testSuggestor(
+          expectedPatchCount: 2,
+          input: '''
           part of 'a_file.dart';
 
           main() {
             react_dom.render(Foo()(), mountNode);
           }
-        ''', expectedOutput: '''
+        ''',
+          expectedOutput: '''
           part of 'a_file.dart';
 
           main() {
             react_dom.render(ErrorBoundary()(Foo()()), mountNode);
           }
-        ''');
-    });
+        ''',
+        );
+      },
+    );
 
     test('no react_dom.dart import but usage has namespace', () async {
-      await testSuggestor(expectedPatchCount: 3, input: '''
+      await testSuggestor(
+        expectedPatchCount: 3,
+        input: '''
           main() {
             react_dom.render(Foo()(), mountNode);
           }
-        ''', expectedOutput: '''
+        ''',
+        expectedOutput: '''
           import 'package:over_react/over_react.dart';
 
           main() {
             react_dom.render(ErrorBoundary()(Foo()()), mountNode);
           }
-        ''');
+        ''',
+      );
     });
 
     test('no import of over_react but is wrapped with ErrorBoundary', () async {
@@ -571,30 +595,34 @@ main() {
     });
 
     // These tests strings are split by web_skin_dart to work around issues with dependency_validator.
-    test('doesnt add over_react if it imports web_skin_dart/ui_core instead',
-        () async {
-      await testSuggestor(
-        expectedPatchCount: 0,
-        input: '''
+    test(
+      'doesnt add over_react if it imports web_skin_dart/ui_core instead',
+      () async {
+        await testSuggestor(
+          expectedPatchCount: 0,
+          input:
+              '''
           import 'package:'''
-            '''web_skin_dart/ui_core.dart';
+              '''web_skin_dart/ui_core.dart';
           import 'package:react/react_dom.dart';
 
           main() {
             render(ErrorBoundary()(Foo()()), mountNode);
           }
         ''',
-        expectedOutput: '''
+          expectedOutput:
+              '''
           import 'package:'''
-            '''web_skin_dart/ui_core.dart';
+              '''web_skin_dart/ui_core.dart';
           import 'package:react/react_dom.dart';
 
           main() {
             render(ErrorBoundary()(Foo()()), mountNode);
           }
         ''',
-      );
-    });
+        );
+      },
+    );
   });
 }
 

--- a/test/react16_suggestors/react_style_maps_updater_test.dart
+++ b/test/react16_suggestors/react_style_maps_updater_test.dart
@@ -66,11 +66,12 @@ main() {
         );
       });
 
-      test('is a single value within a style map using double quotes',
-          () async {
-        await testSuggestor(
-          expectedPatchCount: 1,
-          input: '''
+      test(
+        'is a single value within a style map using double quotes',
+        () async {
+          await testSuggestor(
+            expectedPatchCount: 1,
+            input: '''
             main() {
               Foo()
               ..id = 'number1'
@@ -79,7 +80,7 @@ main() {
               };
             }
           ''',
-          expectedOutput: '''
+            expectedOutput: '''
             main() {
               Foo()
               ..id = 'number1'
@@ -88,8 +89,9 @@ main() {
               };
             }
           ''',
-        );
-      });
+          );
+        },
+      );
 
       test('is a single value within an inline style map', () async {
         await testSuggestor(
@@ -180,7 +182,8 @@ main() {
               };
             }
           ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
             main() {
               Foo()
               ${manualVariableCheckComment(keysOfModdedValues: ['width'])}
@@ -209,12 +212,11 @@ main() {
               };
             }
           ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
             main() {
               Foo()
-              ${manualVariableCheckComment(keysOfModdedValues: [
-                'width',
-              ])}
+              ${manualVariableCheckComment(keysOfModdedValues: ['width'])}
               ..style = {
                 'width': isWide ?? isNotWide,
                 'height': '40%',
@@ -240,12 +242,11 @@ main() {
               };
             }
           ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
             main() {
               Foo()
-              ${manualVariableCheckComment(keysOfModdedValues: [
-                'width',
-              ])}
+              ${manualVariableCheckComment(keysOfModdedValues: ['width'])}
               ..style = {
                 'width': width / 10,
                 'height': '40%',
@@ -339,18 +340,16 @@ main() {
         );
       });
 
-      test('is an interpolated string not ending in a known CSS unit',
-          () async {
-        await testSuggestor(
-          expectedPatchCount: 0,
-          input: '''
+      test(
+        'is an interpolated string not ending in a known CSS unit',
+        () async {
+          await testSuggestor(
+            expectedPatchCount: 0,
+            input:
+                '''
             main() {
               Foo()
-                ${getCheckboxComment(keysOfModdedValues: [
-                'width',
-                'height',
-                'fontSize'
-              ])}
+                ${getCheckboxComment(keysOfModdedValues: ['width', 'height', 'fontSize'])}
                 ..style = {
                   'width': '\$width',
                   'height': '\${getHeight()}foo',
@@ -358,8 +357,9 @@ main() {
                 };
             }
           ''',
-        );
-      });
+          );
+        },
+      );
 
       test('is on an instance creation expression', () async {
         await testSuggestor(
@@ -380,14 +380,11 @@ main() {
       test('is an expression that has already been updated', () async {
         await testSuggestor(
           expectedPatchCount: 0,
-          input: '''
+          input:
+              '''
             main() {
               Foo()
-              ${getCheckboxComment(keysOfModdedValues: [
-                'width',
-                'fontSize',
-                'margin'
-              ])}
+              ${getCheckboxComment(keysOfModdedValues: ['width', 'fontSize', 'margin'])}
               ..style = {
                 'width': isWide ? 40 : 20,
                 'height': '40%',
@@ -396,14 +393,11 @@ main() {
               };
             }
           ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
             main() {
               Foo()
-              ${getCheckboxComment(keysOfModdedValues: [
-                'width',
-                'fontSize',
-                'margin'
-              ])}
+              ${getCheckboxComment(keysOfModdedValues: ['width', 'fontSize', 'margin'])}
               ..style = {
                 'width': isWide ? 40 : 20,
                 'height': '40%',
@@ -430,7 +424,8 @@ main() {
               ..style = getStyleMap();
             }
           ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
             main() {
               Map getStyleMap() {
                 return {
@@ -517,7 +512,8 @@ main() {
               };
             }
           ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
             main() {
               Foo()
               ${manualVariableCheckComment(keysOfModdedValues: ['width'])}
@@ -538,7 +534,8 @@ main() {
               ..style = foo.bar;
             }
           ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
             main() {
               Foo()
               ${manualVariableCheckComment()}
@@ -549,18 +546,20 @@ main() {
       });
     });
 
-    test('adds a validate variable comment when the map value is a variable',
-        () async {
-      await testSuggestor(
-        expectedPatchCount: 1,
-        input: '''
+    test(
+      'adds a validate variable comment when the map value is a variable',
+      () async {
+        await testSuggestor(
+          expectedPatchCount: 1,
+          input: '''
             main() {
               var bar = {'width': '40'};
               Foo()
               ..style = bar;
             }
         ''',
-        expectedOutput: '''
+          expectedOutput:
+              '''
           main() {
             var bar = {'width': '40'};
             Foo()
@@ -568,14 +567,16 @@ main() {
             ..style = bar;
           }
         ''',
-      );
-    });
+        );
+      },
+    );
 
-    test('adds a validate variable comment when the key value is a variable',
-        () async {
-      await testSuggestor(
-        expectedPatchCount: 1,
-        input: '''
+    test(
+      'adds a validate variable comment when the key value is a variable',
+      () async {
+        await testSuggestor(
+          expectedPatchCount: 1,
+          input: '''
             main() {
               Foo()
               ..style = {
@@ -583,7 +584,8 @@ main() {
               };
             }
         ''',
-        expectedOutput: '''
+          expectedOutput:
+              '''
           main() {
             Foo()
             ${manualVariableCheckComment(keysOfModdedValues: ['width'])}
@@ -592,13 +594,15 @@ main() {
             };
           }
         ''',
-      );
-    });
+        );
+      },
+    );
 
     test('does not add a second validate comment when unchecked', () async {
       await testSuggestor(
         expectedPatchCount: 0,
-        input: '''
+        input:
+            '''
             main() {
               Foo()
               ${getCheckboxComment(keysOfModdedValues: ['width'])}
@@ -613,12 +617,11 @@ main() {
     test('does not add a second validate comment when checked', () async {
       await testSuggestor(
         expectedPatchCount: 0,
-        input: '''
+        input:
+            '''
             main() {
               Foo()
-              ${getCheckboxComment(keysOfModdedValues: [
-              'width'
-            ], checked: true)}
+              ${getCheckboxComment(keysOfModdedValues: ['width'], checked: true)}
               ..style = {
                 'width': '40px',
               };
@@ -668,11 +671,12 @@ main() {
       );
     });
 
-    test('does not run on DOM style property assignments in various forms',
-        () async {
-      await testSuggestor(
-        expectedPatchCount: 0,
-        input: '''
+    test(
+      'does not run on DOM style property assignments in various forms',
+      () async {
+        await testSuggestor(
+          expectedPatchCount: 0,
+          input: '''
             main() {
               style.width = '400';
               style..width = '400';
@@ -681,8 +685,9 @@ main() {
               DivElement().style..width = '400';
             }
           ''',
-      );
-    });
+        );
+      },
+    );
 
     test('works for custom props maps containing styles', () async {
       await testSuggestor(
@@ -713,12 +718,11 @@ main() {
     test('does not run twice', () async {
       await testSuggestor(
         expectedPatchCount: 0,
-        input: '''
+        input:
+            '''
             main() {
               Foo()
-              ${manualVariableCheckComment(keysOfModdedValues: [
-              'width'
-            ], isChecked: true)}
+              ${manualVariableCheckComment(keysOfModdedValues: ['width'], isChecked: true)}
               ..style = {
                 'width': isWide ?? 40,
                 'height': '40%',
@@ -727,12 +731,11 @@ main() {
               };
             }
           ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
             main() {
               Foo()
-              ${manualVariableCheckComment(keysOfModdedValues: [
-              'width'
-            ], isChecked: true)}
+              ${manualVariableCheckComment(keysOfModdedValues: ['width'], isChecked: true)}
               ..style = {
                 'width': isWide ?? 40,
                 'height': '40%',
@@ -754,8 +757,10 @@ String getCheckboxComment({
     $styleMapComment
     //$willBeRemovedCommentSuffix''';
 
-String manualVariableCheckComment(
-        {List<String> keysOfModdedValues = const [], isChecked = false}) =>
+String manualVariableCheckComment({
+  List<String> keysOfModdedValues = const [],
+  isChecked = false,
+}) =>
     '''// ${isChecked ? '[x]' : '[ ]'} Check this box upon manual validation that this style map is receiving a value that is valid ${keysOfModdedValues.isNotEmpty ? 'for the following keys: ${keysOfModdedValues.join(', ')}.' : 'for the keys that are simple string variables.'}
     $styleMapComment
     //$willBeRemovedCommentSuffix''';

--- a/test/resolved_file_context.dart
+++ b/test/resolved_file_context.dart
@@ -54,8 +54,12 @@ class SharedAnalysisContext {
   /// null-safety analysis errors. Those are suppressed via [defaultIsExpectedError]
   /// so suggestor tests can still exercise pre-null-safe code patterns.
   static final overReact = SharedAnalysisContext(
-      p.join(findPackageRootFor(p.current), 'test/test_fixtures/over_react_project'),
-      defaultIsExpectedError: _isLegacyNullSafetyError);
+    p.join(
+      findPackageRootFor(p.current),
+      'test/test_fixtures/over_react_project',
+    ),
+    defaultIsExpectedError: _isLegacyNullSafetyError,
+  );
 
   static bool _isLegacyNullSafetyError(AnalysisError error) {
     const legacyCodes = {
@@ -72,24 +76,29 @@ class SharedAnalysisContext {
 
   /// A context root located at `test/test_fixtures/over_react_null_safe_project`
   /// that depends on the `over_react` package and a null-safe Dart version.
-  static final overReactNullSafe = SharedAnalysisContext(p.join(
+  static final overReactNullSafe = SharedAnalysisContext(
+    p.join(
       findPackageRootFor(p.current),
-      'test/test_fixtures/over_react_null_safe_project'));
+      'test/test_fixtures/over_react_null_safe_project',
+    ),
+  );
 
   /// A context root located at `test/test_fixtures/over_react_project`
   /// that depends on the internal `web_skin_dart` package (as well as `over_react`).
   static final wsd = SharedAnalysisContext(
-      p.join(findPackageRootFor(p.current), 'test/test_fixtures/wsd_project'),
-      defaultIsExpectedError: _isLegacyNullSafetyError,
-      customPubGetErrorMessage:
-          'If this fails to resolve in GitHub Actions, make sure your test or'
-          ' test group is tagged with "wsd" so that it\'s only run in Skynet.');
+    p.join(findPackageRootFor(p.current), 'test/test_fixtures/wsd_project'),
+    defaultIsExpectedError: _isLegacyNullSafetyError,
+    customPubGetErrorMessage:
+        'If this fails to resolve in GitHub Actions, make sure your test or'
+        ' test group is tagged with "wsd" so that it\'s only run in Skynet.',
+  );
 
   /// A context root located at `test/test_fixtures/rmui_project`
   /// that depends on the `react_material_ui` package (as well as `over_react`).
   static final rmui = SharedAnalysisContext(
-      p.join(findPackageRootFor(p.current), 'test/test_fixtures/rmui_project'),
-      defaultIsExpectedError: _isLegacyNullSafetyError);
+    p.join(findPackageRootFor(p.current), 'test/test_fixtures/rmui_project'),
+    defaultIsExpectedError: _isLegacyNullSafetyError,
+  );
 
   /// The path to the package root in which test files will be created
   /// and resolved.
@@ -116,8 +125,11 @@ class SharedAnalysisContext {
   // analysis results (meaning faster test runs).
   final _testFileSubpath = 'lib/dynamic_test_files/${Uuid().v4()}';
 
-  SharedAnalysisContext(this._path,
-      {this.customPubGetErrorMessage, this.defaultIsExpectedError}) {
+  SharedAnalysisContext(
+    this._path, {
+    this.customPubGetErrorMessage,
+    this.defaultIsExpectedError,
+  }) {
     if (!p.isAbsolute(_path)) {
       throw ArgumentError.value(_path, 'projectRoot', 'must be absolute');
     }
@@ -128,28 +140,26 @@ class SharedAnalysisContext {
   final _initMemo = AsyncMemoizer();
 
   Future<void> _initIfNeeded() => _initMemo.runOnce(() async {
-        // Note that if tests are run concurrently, then concurrent pub gets will be run.
-        // This is hard to avoid (trying to avoid it using a filesystem lock in
-        // macOS/Linux doesn't work due to advisory lock behavior), but intermittently
-        // causes issues, so message referencing exit code 66 and workaround below.
-        try {
-          await runPubGetIfNeeded(_path);
-        } catch (e, st) {
-          var message = [
-            // ignore: no_adjacent_strings_in_list
-            'If the exit code is 66, the issue is likely concurrent `pub get`s on'
-                ' this directory from concurrent test entrypoints.'
-                ' Regardless of the exit code, if in CI, try running `pub get`'
-                ' in this directory before running any tests.',
-            if (customPubGetErrorMessage != null) customPubGetErrorMessage,
-          ].join(' ');
-          throw Exception('$message\nOriginal exception: $e$st');
-        }
+    // Note that if tests are run concurrently, then concurrent pub gets will be run.
+    // This is hard to avoid (trying to avoid it using a filesystem lock in
+    // macOS/Linux doesn't work due to advisory lock behavior), but intermittently
+    // causes issues, so message referencing exit code 66 and workaround below.
+    try {
+      await runPubGetIfNeeded(_path);
+    } catch (e, st) {
+      var message = [
+        // ignore: no_adjacent_strings_in_list
+        'If the exit code is 66, the issue is likely concurrent `pub get`s on'
+            ' this directory from concurrent test entrypoints.'
+            ' Regardless of the exit code, if in CI, try running `pub get`'
+            ' in this directory before running any tests.',
+        if (customPubGetErrorMessage != null) customPubGetErrorMessage,
+      ].join(' ');
+      throw Exception('$message\nOriginal exception: $e$st');
+    }
 
-        collection = AnalysisContextCollection(
-          includedPaths: [_path],
-        );
-      });
+    collection = AnalysisContextCollection(includedPaths: [_path]);
+  });
 
   /// Warms up the AnalysisContextCollection by running `pub get` (if needed) and
   /// initializing [collection] if that hasn't been done yet, and getting the
@@ -228,47 +238,55 @@ class SharedAnalysisContext {
         final testName = Invoker.current!.liveTest.test.name;
         sourceText =
             lineComment('Created within test with name:\n> $testName') +
-                '\n' +
-                sourceText;
+            '\n' +
+            sourceText;
       } catch (_) {}
     }
 
     final path = p.join(_path, _testFileSubpath, filename);
     final file = File(path);
     if (file.existsSync()) {
-      throw StateError('File already exists: ${filename}.'
-          ' Cannot use an existing file, since there is no public API'
-          ' to update a file within a AnalysisContextCollection.'
-          ' Make sure you\'re using a unique filename each time.'
-          ' This error can also occur if there are concurrent test runs'
-          ' and `_testFileSubpath` is not namespaced.');
+      throw StateError(
+        'File already exists: ${filename}.'
+        ' Cannot use an existing file, since there is no public API'
+        ' to update a file within a AnalysisContextCollection.'
+        ' Make sure you\'re using a unique filename each time.'
+        ' This error can also occur if there are concurrent test runs'
+        ' and `_testFileSubpath` is not namespaced.',
+      );
     }
     file.parent.createSync(recursive: true);
     file.writeAsStringSync(sourceText);
 
-    final context = collection.contexts
-        .singleWhere((c) => c.contextRoot.root.path == _path);
+    final context = collection.contexts.singleWhere(
+      (c) => c.contextRoot.root.path == _path,
+    );
 
     if (throwOnAnalysisErrors && !preResolveLibrary) {
       throw ArgumentError(
-          'If throwOnAnalysisErrors is true, preResolveFile must be false');
+        'If throwOnAnalysisErrors is true, preResolveFile must be false',
+      );
     }
     if (isExpectedError != null && !throwOnAnalysisErrors) {
       throw ArgumentError(
-          'If isExpectedError is provided, throwOnAnalysisErrors must be true');
+        'If isExpectedError is provided, throwOnAnalysisErrors must be true',
+      );
     }
     if (preResolveLibrary) {
       final result = await _printAboutFirstFile(
-          () => context.currentSession.getResolvedLibrary(path));
+        () => context.currentSession.getResolvedLibrary(path),
+      );
       if (throwOnAnalysisErrors) {
         final mergedIsExpectedError =
             (defaultIsExpectedError == null && isExpectedError == null)
-                ? null
-                : (AnalysisError error) =>
-                    (defaultIsExpectedError?.call(error) ?? false) ||
-                    (isExpectedError?.call(error) ?? false);
-        checkResolvedResultForErrors(result,
-            isExpectedError: mergedIsExpectedError);
+            ? null
+            : (AnalysisError error) =>
+                  (defaultIsExpectedError?.call(error) ?? false) ||
+                  (isExpectedError?.call(error) ?? false);
+        checkResolvedResultForErrors(
+          result,
+          isExpectedError: mergedIsExpectedError,
+        );
       }
     }
 
@@ -299,8 +317,10 @@ class SharedAnalysisContext {
 
     if (shouldPrint) {
       final contextName = p.basename(_path);
-      print('Resolving a file for the first time in context "${contextName}";'
-          ' this will take a few seconds...');
+      print(
+        'Resolving a file for the first time in context "${contextName}";'
+        ' this will take a few seconds...',
+      );
     }
     final result = await callback();
     if (shouldPrint) {
@@ -326,7 +346,8 @@ void checkResolvedResultForErrors(
 }) {
   isExpectedError ??= (_) => false;
 
-  const sharedMessage = 'If analysis errors are expected for this test, either:'
+  const sharedMessage =
+      'If analysis errors are expected for this test, either:'
       '\n1. specify `isExpectedError` with a function that returns true'
       ' only for your expected error'
       '\n2. use an `ignore:` comment to silence them'
@@ -335,32 +356,35 @@ void checkResolvedResultForErrors(
       ' to verify that only the expected errors are present.';
 
   if (result is! ResolvedLibraryResult) {
-    throw ArgumentError([
-      'Error resolving file; result was ${result}.',
-      sharedMessage
-    ].join(' '));
+    throw ArgumentError(
+      ['Error resolving file; result was ${result}.', sharedMessage].join(' '),
+    );
   }
 
   final unexpectedErrors = result.units
       .expand((unit) => unit.errors)
-      .where((AnalysisError error) =>
-          error.severity == Severity.error ||
-          const {
-            'unused_element',
-            'unused_local_variable',
-          }.contains(error.errorCode.name.toLowerCase()))
+      .where(
+        (AnalysisError error) =>
+            error.severity == Severity.error ||
+            const {
+              'unused_element',
+              'unused_local_variable',
+            }.contains(error.errorCode.name.toLowerCase()),
+      )
       // We need a non-null-assertion here due to https://github.com/dart-lang/sdk/issues/40790
       .where((error) => !isExpectedError!(error))
       .toList();
   if (unexpectedErrors.isNotEmpty) {
-    throw ArgumentError([
-      // ignore: no_adjacent_strings_in_list
-      'File had analysis errors or unused element hints,'
-          ' which likely indicate that the test file is set up improperly,'
-          ' potentially resulting in false positives in your test.',
-      sharedMessage,
-      'Errors:\n${prettyPrintErrors(unexpectedErrors)}.'
-    ].join(' '));
+    throw ArgumentError(
+      [
+        // ignore: no_adjacent_strings_in_list
+        'File had analysis errors or unused element hints,'
+            ' which likely indicate that the test file is set up improperly,'
+            ' potentially resulting in false positives in your test.',
+        sharedMessage,
+        'Errors:\n${prettyPrintErrors(unexpectedErrors)}.',
+      ].join(' '),
+    );
   }
 }
 
@@ -395,18 +419,21 @@ extension ParseHelpers on SharedAnalysisContext {
     CompilationUnit unit;
     // Wrap the expression in parens to ensure this is interpreted as an expression
     // for ambiguous cases (e.g, a map literal that could be interpreted as an empty block).
-    final source = '''
+    final source =
+        '''
       $imports
       void wrapperFunction() {
         ($expression);
       }
       $otherSource
     ''';
-    final fileContext = await resolvedFileContextForTest(source,
-        // We don't want to get the resolved unit if `isResolve = false`,
-        // since it may fail.
-        preResolveLibrary: false,
-        throwOnAnalysisErrors: false);
+    final fileContext = await resolvedFileContextForTest(
+      source,
+      // We don't want to get the resolved unit if `isResolve = false`,
+      // since it may fail.
+      preResolveLibrary: false,
+      throwOnAnalysisErrors: false,
+    );
     if (isResolved) {
       final result = await fileContext.getResolvedUnit();
       unit = result!.unit;

--- a/test/rmui_bundle_updater_suggestors/dart_script_updater_test.dart
+++ b/test/rmui_bundle_updater_suggestors/dart_script_updater_test.dart
@@ -21,10 +21,12 @@ import '../util.dart';
 
 void main() {
   group('DartScriptAdder', () {
-    final testSuggestor = getSuggestorTester(aggregate([
-      DartScriptUpdater(rmuiBundleDev, rmuiBundleDevUpdated),
-      DartScriptUpdater(rmuiBundleProd, rmuiBundleProdUpdated),
-    ]));
+    final testSuggestor = getSuggestorTester(
+      aggregate([
+        DartScriptUpdater(rmuiBundleDev, rmuiBundleDevUpdated),
+        DartScriptUpdater(rmuiBundleProd, rmuiBundleProdUpdated),
+      ]),
+    );
 
     test('empty file', () async {
       await testSuggestor(expectedPatchCount: 0, input: '');
@@ -42,13 +44,15 @@ void main() {
     test('dev bundle', () async {
       await testSuggestor(
         expectedPatchCount: 4,
-        input: '''
+        input:
+            '''
               List<String> _reactHtmlHeaders = const [
                 '<script src="$rmuiBundleDev"></script>',
                 '<link rel="preload" href="$rmuiBundleDev" as="script">',
               ];
             ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
               List<String> _reactHtmlHeaders = const [
                 '<script src="$rmuiBundleDevUpdated" type="module"></script>',
                 '<link rel="preload" href="$rmuiBundleDevUpdated" crossorigin="" as="script">',
@@ -60,13 +64,15 @@ void main() {
     test('prod bundle', () async {
       await testSuggestor(
         expectedPatchCount: 4,
-        input: '''
+        input:
+            '''
               List<String> _reactHtmlHeaders = const [
                 '<script src="$rmuiBundleProd"></script>',
                 '<link rel="preload" href="$rmuiBundleProd" as="script">',
               ];
             ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
               List<String> _reactHtmlHeaders = const [
                 '<script src="$rmuiBundleProdUpdated" type="module"></script>',
                 '<link rel="preload" href="$rmuiBundleProdUpdated" crossorigin="" as="script">',
@@ -79,14 +85,16 @@ void main() {
       await testSuggestor(
         expectedPatchCount: 0,
         shouldDartfmtOutput: false,
-        input: '''
+        input:
+            '''
             List<String> _reactHtmlHeaders = const [
               '<script src="$rmuiBundleDevUpdated" type="module"></script>',
               '<link rel="preload" href="$rmuiBundleDevUpdated" crossorigin="" as="script">',
               '<script src="$rmuiBundleProdUpdated" type="module"></script>',
               '<link rel="preload" href="$rmuiBundleProdUpdated" crossorigin="" as="script">',
             ];\n''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
             List<String> _reactHtmlHeaders = const [
               '<script src="$rmuiBundleDevUpdated" type="module"></script>',
               '<link rel="preload" href="$rmuiBundleDevUpdated" crossorigin="" as="script">',
@@ -99,13 +107,15 @@ void main() {
     test('with indentation', () async {
       await testSuggestor(
         expectedPatchCount: 4,
-        input: '''
+        input:
+            '''
                 List<String> _reactHtmlHeaders = const [
                 '  <script src="$rmuiBundleDev"></script>',
                 '  <link rel="preload" href="$rmuiBundleDev" as="script">',
               ];
             ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
               List<String> _reactHtmlHeaders = const [
                 '  <script src="$rmuiBundleDevUpdated" type="module"></script>',
                 '  <link rel="preload" href="$rmuiBundleDevUpdated" crossorigin="" as="script">',
@@ -118,7 +128,8 @@ void main() {
       await testSuggestor(
         expectedPatchCount: 4,
         shouldDartfmtOutput: false,
-        input: '''
+        input:
+            '''
           List<String> _reactHtmlHeaders = const [
             '<!DOCTYPE html>',
             '<html>',
@@ -157,7 +168,8 @@ void main() {
             '  </body>',
             '</html>',
           ];''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
           List<String> _reactHtmlHeaders = const [
             '<!DOCTYPE html>',
             '<html>',
@@ -203,7 +215,8 @@ void main() {
       await testSuggestor(
         expectedPatchCount: 8,
         shouldDartfmtOutput: false,
-        input: '''
+        input:
+            '''
           List<String> _reactHtmlHeaders = const [
             '<script type="module" src="$rmuiBundleProd"></script>',
             '<link crossorigin="" rel="preload" href="$rmuiBundleProd" as="script">',
@@ -214,7 +227,8 @@ void main() {
             '<script src="$rmuiBundleProdUpdated"></script>',
             '<link rel="preload" href="$rmuiBundleProdUpdated" as="script">',
           ];''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
           List<String> _reactHtmlHeaders = const [
             '<script type="module" src="$rmuiBundleProdUpdated"></script>',
             '<link crossorigin="" rel="preload" href="$rmuiBundleProdUpdated" as="script">',
@@ -232,14 +246,16 @@ void main() {
       await testSuggestor(
         expectedPatchCount: 8,
         shouldDartfmtOutput: false,
-        input: '''
+        input:
+            '''
           List<String> _reactHtmlHeaders = const [
             '<script src="$rmuiBundleDev" type="js/slk-f.sdkf"></script>',
             '<link rel="preload" href="$rmuiBundleDev" crossorigin="asdfsafdsf" as="script">',
             '<script src="$rmuiBundleProd" type="js/slkfsdkf"></script>',
             '<link rel="preload" href="$rmuiBundleProd" crossorigin="sadfsa/asdf" as="script">',
           ];''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
           List<String> _reactHtmlHeaders = const [
             '<script src="$rmuiBundleDevUpdated" type="module"></script>',
             '<link rel="preload" href="$rmuiBundleDevUpdated" crossorigin="" as="script">',
@@ -252,13 +268,15 @@ void main() {
     test('just script tags', () async {
       await testSuggestor(
         expectedPatchCount: 4,
-        input: '''
+        input:
+            '''
               List<String> _reactHtmlHeaders = const [
                 '<script src="$rmuiBundleDev"></script>',
                 '<script src="$rmuiBundleProd"></script>',
               ];
             ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
               List<String> _reactHtmlHeaders = const [
                 '<script src="$rmuiBundleDevUpdated" type="module"></script>',
                 '<script src="$rmuiBundleProdUpdated" type="module"></script>',
@@ -270,13 +288,15 @@ void main() {
     test('just link tags', () async {
       await testSuggestor(
         expectedPatchCount: 4,
-        input: '''
+        input:
+            '''
               List<String> _reactHtmlHeaders = const [
                 '<link rel="preload" href="$rmuiBundleDev" as="script">',
                 '<link rel="preload" href="$rmuiBundleProd" as="script">',
               ];
             ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
               List<String> _reactHtmlHeaders = const [
                 '<link rel="preload" href="$rmuiBundleDevUpdated" crossorigin="" as="script">',
                 '<link rel="preload" href="$rmuiBundleProdUpdated" crossorigin="" as="script">',
@@ -288,7 +308,8 @@ void main() {
     test('string const', () async {
       await testSuggestor(
         expectedPatchCount: 2,
-        input: '''
+        input:
+            '''
           const expectedWithReact = \'\'\'
             <!DOCTYPE html>
             <html>
@@ -307,7 +328,8 @@ void main() {
             </html>
           \'\'\';
         ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
           const expectedWithReact = \'\'\'
             <!DOCTYPE html>
             <html>
@@ -331,19 +353,24 @@ void main() {
 
     test('updateAttributes arg', () async {
       final updateSuggestor = getSuggestorTester(
-        DartScriptUpdater(rmuiBundleDev, rmuiBundleDevUpdated,
-            updateAttributes: false),
+        DartScriptUpdater(
+          rmuiBundleDev,
+          rmuiBundleDevUpdated,
+          updateAttributes: false,
+        ),
       );
 
       await updateSuggestor(
         expectedPatchCount: 2,
-        input: '''
+        input:
+            '''
               List<String> _reactHtmlHeaders = const [
                 '<script src="$rmuiBundleDev"></script>',
                 '<link rel="preload" href="$rmuiBundleDev" as="script">',
               ];
             ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
               List<String> _reactHtmlHeaders = const [
                 '<script src="$rmuiBundleDevUpdated"></script>',
                 '<link rel="preload" href="$rmuiBundleDevUpdated" as="script">',
@@ -353,13 +380,15 @@ void main() {
     });
 
     group('remove constructor', () {
-      final removeTagSuggestor =
-          getSuggestorTester(DartScriptUpdater.remove(rmuiBundleDev));
+      final removeTagSuggestor = getSuggestorTester(
+        DartScriptUpdater.remove(rmuiBundleDev),
+      );
 
       test('list', () async {
         await removeTagSuggestor(
           expectedPatchCount: 3,
-          input: '''
+          input:
+              '''
               List<String> _reactHtmlHeaders = const [
                 '<script src="$rmuiBundleDev"></script>',
                 '<link rel="preload" href="$rmuiBundleDev" as="script">',
@@ -368,7 +397,8 @@ void main() {
                 '<link rel="preload" href="$rmuiBundleDevUpdated" crossorigin="" as="script">',
               ];
             ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
               List<String> _reactHtmlHeaders = const [
                 '<script src="$rmuiBundleDevUpdated" type="module"></script>',
                 '<link rel="preload" href="$rmuiBundleDevUpdated" crossorigin="" as="script">',
@@ -380,7 +410,8 @@ void main() {
       test('string const', () async {
         await removeTagSuggestor(
           expectedPatchCount: 1,
-          input: '''
+          input:
+              '''
           const expectedWithReact = \'\'\'
             <!DOCTYPE html>
             <html>

--- a/test/rmui_bundle_updater_suggestors/html_script_updater_test.dart
+++ b/test/rmui_bundle_updater_suggestors/html_script_updater_test.dart
@@ -21,10 +21,12 @@ import '../util.dart';
 
 void main() {
   group('HtmlScriptUpdater', () {
-    final testSuggestor = getSuggestorTester(aggregate([
-      HtmlScriptUpdater(rmuiBundleDev, rmuiBundleDevUpdated),
-      HtmlScriptUpdater(rmuiBundleProd, rmuiBundleProdUpdated),
-    ]));
+    final testSuggestor = getSuggestorTester(
+      aggregate([
+        HtmlScriptUpdater(rmuiBundleDev, rmuiBundleDevUpdated),
+        HtmlScriptUpdater(rmuiBundleProd, rmuiBundleProdUpdated),
+      ]),
+    );
 
     test('empty file', () async {
       await testSuggestor(expectedPatchCount: 0, input: '');
@@ -34,7 +36,8 @@ void main() {
       await testSuggestor(
         expectedPatchCount: 0,
         shouldDartfmtOutput: false,
-        input: ''
+        input:
+            ''
             '<script src="packages/react_testing_library/js/react-testing-library.js"></script>\n'
             '',
       );
@@ -44,11 +47,13 @@ void main() {
       await testSuggestor(
         expectedPatchCount: 4,
         shouldDartfmtOutput: false,
-        input: ''
+        input:
+            ''
             '<script src="$rmuiBundleDev"></script>\n'
             '<link rel="preload" href="$rmuiBundleDev" as="script">\n'
             '',
-        expectedOutput: ''
+        expectedOutput:
+            ''
             '<script src="$rmuiBundleDevUpdated" type="module"></script>\n'
             '<link rel="preload" href="$rmuiBundleDevUpdated" crossorigin="" as="script">\n'
             '',
@@ -59,11 +64,13 @@ void main() {
       await testSuggestor(
         expectedPatchCount: 4,
         shouldDartfmtOutput: false,
-        input: ''
+        input:
+            ''
             '<script src="$rmuiBundleProd"></script>\n'
             '<link rel="preload" href="$rmuiBundleProd" as="script">\n'
             '',
-        expectedOutput: ''
+        expectedOutput:
+            ''
             '<script src="$rmuiBundleProdUpdated" type="module"></script>\n'
             '<link rel="preload" href="$rmuiBundleProdUpdated" crossorigin="" as="script">\n'
             '',
@@ -74,13 +81,15 @@ void main() {
       await testSuggestor(
         expectedPatchCount: 0,
         shouldDartfmtOutput: false,
-        input: ''
+        input:
+            ''
             '<script src="$rmuiBundleDevUpdated" type="module"></script>\n'
             '<link rel="preload" href="$rmuiBundleDevUpdated" crossorigin="" as="script">\n'
             '<script src="$rmuiBundleProdUpdated" type="module"></script>\n'
             '<link rel="preload" href="$rmuiBundleProdUpdated" crossorigin="" as="script">\n'
             '',
-        expectedOutput: ''
+        expectedOutput:
+            ''
             '<script src="$rmuiBundleDevUpdated" type="module"></script>\n'
             '<link rel="preload" href="$rmuiBundleDevUpdated" crossorigin="" as="script">\n'
             '<script src="$rmuiBundleProdUpdated" type="module"></script>\n'
@@ -93,11 +102,13 @@ void main() {
       await testSuggestor(
         expectedPatchCount: 4,
         shouldDartfmtOutput: false,
-        input: ''
+        input:
+            ''
             '  <script src="$rmuiBundleDev"></script>\n'
             '  <link rel="preload" href="$rmuiBundleDev" as="script">\n'
             '',
-        expectedOutput: ''
+        expectedOutput:
+            ''
             '  <script src="$rmuiBundleDevUpdated" type="module"></script>\n'
             '  <link rel="preload" href="$rmuiBundleDevUpdated" crossorigin="" as="script">\n'
             '',
@@ -108,7 +119,8 @@ void main() {
       await testSuggestor(
         expectedPatchCount: 4,
         shouldDartfmtOutput: false,
-        input: ''
+        input:
+            ''
             '<!DOCTYPE html>\n'
             '<html>\n'
             '  <head>\n'
@@ -147,7 +159,8 @@ void main() {
             '  </body>\n'
             '</html>\n'
             '',
-        expectedOutput: ''
+        expectedOutput:
+            ''
             '<!DOCTYPE html>\n'
             '<html>\n'
             '  <head>\n'
@@ -193,7 +206,8 @@ void main() {
       await testSuggestor(
         expectedPatchCount: 8,
         shouldDartfmtOutput: false,
-        input: ''
+        input:
+            ''
             '<script type="module" src="$rmuiBundleProd"></script>\n'
             '<link crossorigin="" rel="preload" href="$rmuiBundleProd" as="script">\n'
             '<script src="$rmuiBundleDev" type="module" ></script>\n'
@@ -203,7 +217,8 @@ void main() {
             '<script src="$rmuiBundleProdUpdated"></script>\n'
             '<link rel="preload" href="$rmuiBundleProdUpdated" as="script">\n'
             '',
-        expectedOutput: ''
+        expectedOutput:
+            ''
             '<script type="module" src="$rmuiBundleProdUpdated"></script>\n'
             '<link crossorigin="" rel="preload" href="$rmuiBundleProdUpdated" as="script">\n'
             '<script src="$rmuiBundleDevUpdated" type="module" ></script>\n'
@@ -220,13 +235,15 @@ void main() {
       await testSuggestor(
         expectedPatchCount: 8,
         shouldDartfmtOutput: false,
-        input: ''
+        input:
+            ''
             '<script src="$rmuiBundleDev" type="js/slk-f.sdkf"></script>\n'
             '<link rel="preload" href="$rmuiBundleDev" crossorigin="sadfsafdsa" as="script">\n'
             '<script src="$rmuiBundleProd" type="js/slkfsdkf"></script>\n'
             '<link rel="preload" href="$rmuiBundleProd" crossorigin="saf/asdf/sa" as="script">\n'
             '',
-        expectedOutput: ''
+        expectedOutput:
+            ''
             '<script src="$rmuiBundleDevUpdated" type="module"></script>\n'
             '<link rel="preload" href="$rmuiBundleDevUpdated" crossorigin="" as="script">\n'
             '<script src="$rmuiBundleProdUpdated" type="module"></script>\n'
@@ -239,11 +256,13 @@ void main() {
       await testSuggestor(
         expectedPatchCount: 4,
         shouldDartfmtOutput: false,
-        input: ''
+        input:
+            ''
             '<script src="/directory/$rmuiBundleDev"></script>\n'
             '<script src="$rmuiBundleProd"></script>\n'
             '',
-        expectedOutput: ''
+        expectedOutput:
+            ''
             '<script src="/directory/$rmuiBundleDevUpdated" type="module"></script>\n'
             '<script src="$rmuiBundleProdUpdated" type="module"></script>\n'
             '',
@@ -254,11 +273,13 @@ void main() {
       await testSuggestor(
         expectedPatchCount: 4,
         shouldDartfmtOutput: false,
-        input: ''
+        input:
+            ''
             '<link rel="preload" href="$rmuiBundleDev" as="script">\n'
             '<link rel="preload" href="$rmuiBundleProd" as="script">\n'
             '',
-        expectedOutput: ''
+        expectedOutput:
+            ''
             '<link rel="preload" href="$rmuiBundleDevUpdated" crossorigin="" as="script">\n'
             '<link rel="preload" href="$rmuiBundleProdUpdated" crossorigin="" as="script">\n'
             '',
@@ -266,12 +287,14 @@ void main() {
     });
 
     test('removeTag arg', () async {
-      final removeTagSuggestor =
-          getSuggestorTester(HtmlScriptUpdater.remove(rmuiBundleDev));
+      final removeTagSuggestor = getSuggestorTester(
+        HtmlScriptUpdater.remove(rmuiBundleDev),
+      );
 
       await removeTagSuggestor(
         shouldDartfmtOutput: false,
-        input: ''
+        input:
+            ''
             '<script src="$rmuiBundleDev"></script>\n'
             '  <script src="$rmuiBundleDev"></script>\n'
             '<script src="/something_else/$rmuiBundleDev"></script>\n'
@@ -282,7 +305,8 @@ void main() {
             '<script src="${rmuiBundleDevUpdated}abc" type="module"></script>\n'
             '<link rel="preload" href="$rmuiBundleDev" crossorigin="" as="script">\n'
             '',
-        expectedOutput: ''
+        expectedOutput:
+            ''
             '<link rel="preload" href="${rmuiBundleDev}abc" as="script">\n'
             '<script src="$rmuiBundleDevUpdated" type="module"></script>\n'
             '<script src="${rmuiBundleDevUpdated}abc" type="module"></script>\n'

--- a/test/rmui_preparation_suggestors/dart_script_adder_test.dart
+++ b/test/rmui_preparation_suggestors/dart_script_adder_test.dart
@@ -25,10 +25,12 @@ void main() {
     // Test both suggestors together to:
     // 1. verify for all cases that the wrong bundle type isn't added
     // 2. verify they work well together, since they'll never really be run individually
-    final testSuggestor = getSuggestorTester(aggregate([
-      DartScriptAdder(rmuiBundleProd, true),
-      DartScriptAdder(rmuiBundleDev, false)
-    ]));
+    final testSuggestor = getSuggestorTester(
+      aggregate([
+        DartScriptAdder(rmuiBundleProd, true),
+        DartScriptAdder(rmuiBundleDev, false),
+      ]),
+    );
 
     test('empty file', () async {
       await testSuggestor(expectedPatchCount: 0, input: '');
@@ -76,12 +78,14 @@ void _dartScriptAdderTests(
     test('', () async {
       await testSuggestor(
         expectedPatchCount: 1,
-        input: '''
+        input:
+            '''
               List<String> _reactHtmlHeaders = const [
                 '${scriptStrings.join('\',\n\'')}'
               ];
             ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
               List<String> _reactHtmlHeaders = const [
                 '${scriptStrings.join('\',\n\'')}'
                 ,\n\'${expectedAddedScript.scriptTag(pathPrefix: pathPrefix)}\'
@@ -93,13 +97,15 @@ void _dartScriptAdderTests(
     test('when there is already a comma after the preceding string', () async {
       await testSuggestor(
         expectedPatchCount: 1,
-        input: '''
+        input:
+            '''
             List<String> _reactHtmlHeaders = const [
               '${scriptStrings.join('\',\n\'')}',
               '<script src="packages/react_testing_library/js/react-testing-library.js"></script>',
             ];
           ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
             List<String> _reactHtmlHeaders = const [
               '${scriptStrings.join('\',\n\'')}',
               '${expectedAddedScript.scriptTag(pathPrefix: pathPrefix)}',
@@ -112,7 +118,8 @@ void _dartScriptAdderTests(
     test('when the added script already exists in the list', () async {
       await testSuggestor(
         expectedPatchCount: 0,
-        input: '''
+        input:
+            '''
             List<String> _reactHtmlHeaders = const [
               '${scriptStrings.join('\',\n\'')}',
               '${expectedAddedScript.scriptTag(pathPrefix: pathPrefix)}',
@@ -122,21 +129,26 @@ void _dartScriptAdderTests(
     });
 
     test('with a different script added', () async {
-      final someOtherScript =
-          ScriptToAdd(path: 'packages/something_else/something-else.js');
-      final anotherTestSuggestor = getSuggestorTester(aggregate([
-        DartScriptAdder(someOtherScript, false),
-        DartScriptAdder(someOtherScript, true),
-      ]));
+      final someOtherScript = ScriptToAdd(
+        path: 'packages/something_else/something-else.js',
+      );
+      final anotherTestSuggestor = getSuggestorTester(
+        aggregate([
+          DartScriptAdder(someOtherScript, false),
+          DartScriptAdder(someOtherScript, true),
+        ]),
+      );
 
       await anotherTestSuggestor(
         expectedPatchCount: 1,
-        input: '''
+        input:
+            '''
             List<String> _reactHtmlHeaders = const [
               '${scriptStrings.join('\',\n\'')}',
             ];
           ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
             List<String> _reactHtmlHeaders = const [
               '${scriptStrings.join('\',\n\'')}',
               '${someOtherScript.scriptTag(pathPrefix: pathPrefix)}',
@@ -168,7 +180,8 @@ void _dartScriptAdderTests(
     test('nested in other logic', () async {
       await testSuggestor(
         expectedPatchCount: 1,
-        input: '''
+        input:
+            '''
             import 'package:dart_dev/dart_dev.dart' show config, TestRunnerConfig, Environment;
             
             main(List<String> args) async {
@@ -191,7 +204,8 @@ void _dartScriptAdderTests(
               ];
             }
           ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
             import 'package:dart_dev/dart_dev.dart' show config, TestRunnerConfig, Environment;
             
             main(List<String> args) async {
@@ -223,12 +237,14 @@ void _dartScriptAdderTests(
     test('', () async {
       await testSuggestor(
         expectedPatchCount: 1,
-        input: '''
+        input:
+            '''
               const expectedTemplateHeaders = \'\'\'
                 ${scriptStrings.join('\n                ')}
               \'\'\';
             ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
               const expectedTemplateHeaders = \'\'\'
                 ${scriptStrings.join('\n                ')}
                 ${expectedAddedScript.scriptTag(pathPrefix: pathPrefix)}
@@ -240,7 +256,8 @@ void _dartScriptAdderTests(
     test('with a large string', () async {
       await testSuggestor(
         expectedPatchCount: 1,
-        input: '''
+        input:
+            '''
             const expectedTemplateHeaders = \'\'\'
               <!DOCTYPE html>
               <html>
@@ -258,7 +275,8 @@ void _dartScriptAdderTests(
               </html>
               \'\'\';
           ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
             const expectedTemplateHeaders = \'\'\'
               <!DOCTYPE html>
               <html>
@@ -281,21 +299,26 @@ void _dartScriptAdderTests(
     });
 
     test('with a different script added', () async {
-      final someOtherScript =
-          ScriptToAdd(path: 'packages/something_else/something-else.js');
-      final anotherTestSuggestor = getSuggestorTester(aggregate([
-        DartScriptAdder(someOtherScript, false),
-        DartScriptAdder(someOtherScript, true),
-      ]));
+      final someOtherScript = ScriptToAdd(
+        path: 'packages/something_else/something-else.js',
+      );
+      final anotherTestSuggestor = getSuggestorTester(
+        aggregate([
+          DartScriptAdder(someOtherScript, false),
+          DartScriptAdder(someOtherScript, true),
+        ]),
+      );
 
       await anotherTestSuggestor(
         expectedPatchCount: 1,
-        input: '''
+        input:
+            '''
             const expectedTemplateHeaders = \'\'\'
               ${scriptStrings.join('\n              ')}
             \'\'\';
           ''',
-        expectedOutput: '''
+        expectedOutput:
+            '''
             const expectedTemplateHeaders = \'\'\'
               ${scriptStrings.join('\n              ')}
               ${someOtherScript.scriptTag(pathPrefix: pathPrefix)}
@@ -307,7 +330,8 @@ void _dartScriptAdderTests(
     test('when the script already exists', () async {
       await testSuggestor(
         expectedPatchCount: 0,
-        input: '''
+        input:
+            '''
             const expectedTemplateHeaders = \'\'\'
               ${scriptStrings.join('\n              ')}
               ${expectedAddedScript.scriptTag(pathPrefix: pathPrefix)}

--- a/test/rmui_preparation_suggestors/html_script_adder_test.dart
+++ b/test/rmui_preparation_suggestors/html_script_adder_test.dart
@@ -55,10 +55,12 @@ void main() {
     // Test both suggestors together to:
     // 1. verify for all cases that the wrong bundle type isn't added
     // 2. verify they work well together, since they'll never really be run individually
-    final testSuggestor = getSuggestorTester(aggregate([
-      HtmlScriptAdder(rmuiBundleProd, true),
-      HtmlScriptAdder(rmuiBundleDev, false)
-    ]));
+    final testSuggestor = getSuggestorTester(
+      aggregate([
+        HtmlScriptAdder(rmuiBundleProd, true),
+        HtmlScriptAdder(rmuiBundleDev, false),
+      ]),
+    );
 
     test('empty file', () async {
       await testSuggestor(expectedPatchCount: 0, input: '');
@@ -68,7 +70,8 @@ void main() {
       await testSuggestor(
         expectedPatchCount: 0,
         shouldDartfmtOutput: false,
-        input: ''
+        input:
+            ''
             '<script src="packages/react_testing_library/js/react-testing-library.js"></script>\n'
             '',
       );
@@ -107,10 +110,12 @@ void _htmlScriptAdderTests(
     await testSuggestor(
       expectedPatchCount: 1,
       shouldDartfmtOutput: false,
-      input: ''
+      input:
+          ''
           '${scriptStrings.join('\n')}'
           '',
-      expectedOutput: ''
+      expectedOutput:
+          ''
           '${scriptStrings.join('\n')}\n'
           '${expectedAddedScript.scriptTag(pathPrefix: pathPrefix)}\n'
           '',
@@ -121,10 +126,12 @@ void _htmlScriptAdderTests(
     await testSuggestor(
       expectedPatchCount: 1,
       shouldDartfmtOutput: false,
-      input: ''
+      input:
+          ''
           '  ${scriptStrings.join('\n  ')}'
           '',
-      expectedOutput: ''
+      expectedOutput:
+          ''
           '  ${scriptStrings.join('\n  ')}\n'
           '  ${expectedAddedScript.scriptTag(pathPrefix: pathPrefix)}\n'
           '',
@@ -135,7 +142,8 @@ void _htmlScriptAdderTests(
     await testSuggestor(
       expectedPatchCount: 1,
       shouldDartfmtOutput: false,
-      input: ''
+      input:
+          ''
           '<!DOCTYPE html>\n'
           '<html>\n'
           '  <head>\n'
@@ -151,7 +159,8 @@ void _htmlScriptAdderTests(
           '  <body></body>\n'
           '</html>\n'
           '',
-      expectedOutput: ''
+      expectedOutput:
+          ''
           '<!DOCTYPE html>\n'
           '<html>\n'
           '  <head>\n'
@@ -172,20 +181,25 @@ void _htmlScriptAdderTests(
   });
 
   test('with a different script added', () async {
-    final someOtherScript =
-        ScriptToAdd(path: 'packages/something_else/something-else.js');
-    final anotherTestSuggestor = getSuggestorTester(aggregate([
-      HtmlScriptAdder(someOtherScript, true),
-      HtmlScriptAdder(someOtherScript, false),
-    ]));
+    final someOtherScript = ScriptToAdd(
+      path: 'packages/something_else/something-else.js',
+    );
+    final anotherTestSuggestor = getSuggestorTester(
+      aggregate([
+        HtmlScriptAdder(someOtherScript, true),
+        HtmlScriptAdder(someOtherScript, false),
+      ]),
+    );
 
     await anotherTestSuggestor(
       expectedPatchCount: 1,
       shouldDartfmtOutput: false,
-      input: ''
+      input:
+          ''
           '    ${scriptStrings.join('\n    ')}'
           '',
-      expectedOutput: ''
+      expectedOutput:
+          ''
           '    ${scriptStrings.join('\n    ')}\n'
           '    ${someOtherScript.scriptTag(pathPrefix: pathPrefix)}\n'
           '',
@@ -196,7 +210,8 @@ void _htmlScriptAdderTests(
     await testSuggestor(
       expectedPatchCount: 0,
       shouldDartfmtOutput: false,
-      input: ''
+      input:
+          ''
           '    ${expectedAddedScript.scriptTag(pathPrefix: pathPrefix)}\n'
           '    ${scriptStrings.join('\n    ')}\n'
           '',

--- a/test/rmui_preparation_suggestors/theme_provider_adder_test.dart
+++ b/test/rmui_preparation_suggestors/theme_provider_adder_test.dart
@@ -199,7 +199,8 @@ main() {
               return react_dom.render((Foo()..color = 'red')(), mountNode);
             }
           ''',
-            expectedOutput: '''
+            expectedOutput:
+                '''
             import 'package:over_react/over_react.dart';
             import 'package:react/react_dom.dart' as react_dom;
             import 'package:react_material_ui/styles/theme_provider.dart';
@@ -221,7 +222,8 @@ main() {
   
             main() => react_dom.render((Foo()..color = 'red')(), mountNode);
           ''',
-            expectedOutput: '''
+            expectedOutput:
+                '''
             import 'package:over_react/over_react.dart';
             import 'package:react/react_dom.dart' as react_dom;
             import 'package:react_material_ui/styles/theme_provider.dart';
@@ -268,7 +270,8 @@ main() {
                 var instance = getDartComponent(react_dom.render(Foo()(), mountNode));
               }
             ''',
-            expectedOutput: '''
+            expectedOutput:
+                '''
               import 'package:over_react/over_react.dart';
               import 'package:react/react_dom.dart' as react_dom;
               import 'package:react_material_ui/styles/theme_provider.dart';
@@ -317,7 +320,8 @@ main() {
                 var instance = react_dom.render(Foo()(), mountNode);
               }
             ''',
-            expectedOutput: '''
+            expectedOutput:
+                '''
               import 'package:over_react/over_react.dart';
               import 'package:react/react_dom.dart' as react_dom;
               import 'package:react_material_ui/styles/theme_provider.dart';
@@ -342,7 +346,8 @@ main() {
                 instance = react_dom.render(Foo()(), mountNode);
               }
             ''',
-            expectedOutput: '''
+            expectedOutput:
+                '''
               import 'package:over_react/over_react.dart';
               import 'package:react/react_dom.dart' as react_dom;
               import 'package:react_material_ui/styles/theme_provider.dart';
@@ -434,11 +439,12 @@ main() {
       );
     });
 
-    test('when the ThemeProvider import already exists with double quotes',
-        () async {
-      await testSuggestor(
-        expectedPatchCount: 2,
-        input: '''
+    test(
+      'when the ThemeProvider import already exists with double quotes',
+      () async {
+        await testSuggestor(
+          expectedPatchCount: 2,
+          input: '''
           import 'dart:html';
           
           import 'package:react/react_dom.dart' as react_dom;
@@ -448,7 +454,7 @@ main() {
             react_dom.render(Foo()(), mountNode);
           }
         ''',
-        expectedOutput: '''
+          expectedOutput: '''
           import 'dart:html';
         
           import 'package:react/react_dom.dart' as react_dom;
@@ -458,8 +464,9 @@ main() {
             react_dom.render((ThemeProvider()..theme = wkTheme)(Foo()()), mountNode);
           }
         ''',
-      );
-    });
+        );
+      },
+    );
 
     test('render usage with ErrorBoundary', () async {
       await testSuggestor(
@@ -540,26 +547,28 @@ main() {
       );
     });
 
-    test('no react_dom.dart import but usage has namespace in a `part of` file',
-        () async {
-      await testSuggestor(
-        expectedPatchCount: 2,
-        input: '''
+    test(
+      'no react_dom.dart import but usage has namespace in a `part of` file',
+      () async {
+        await testSuggestor(
+          expectedPatchCount: 2,
+          input: '''
           part of 'a_file.dart';
 
           main() {
             react_dom.render(Foo()(), mountNode);
           }
         ''',
-        expectedOutput: '''
+          expectedOutput: '''
           part of 'a_file.dart';
 
           main() {
             react_dom.render((ThemeProvider()..theme = wkTheme)(Foo()()), mountNode);
           }
         ''',
-      );
-    });
+        );
+      },
+    );
 
     group('render usage already wrapped in ThemeProvider', () {
       test('', () async {
@@ -640,8 +649,10 @@ main() {
 
     group('render usage in a test directory', () {
       test('', () async {
-        await getSuggestorTester(ThemeProviderAdder('wkTheme'),
-            inputUrl: 'test/input')(
+        await getSuggestorTester(
+          ThemeProviderAdder('wkTheme'),
+          inputUrl: 'test/input',
+        )(
           expectedPatchCount: 0,
           input: '''
             import 'dart:html';
@@ -656,8 +667,10 @@ main() {
       });
 
       test('nested', () async {
-        await getSuggestorTester(ThemeProviderAdder('wkTheme'),
-            inputUrl: 'subpackages/a_package/test/input')(
+        await getSuggestorTester(
+          ThemeProviderAdder('wkTheme'),
+          inputUrl: 'subpackages/a_package/test/input',
+        )(
           expectedPatchCount: 0,
           input: '''
             import 'dart:html';
@@ -672,8 +685,10 @@ main() {
       });
 
       test('in lib', () async {
-        await getSuggestorTester(ThemeProviderAdder('wkTheme'),
-            inputUrl: 'lib/a_dir/test/input')(
+        await getSuggestorTester(
+          ThemeProviderAdder('wkTheme'),
+          inputUrl: 'lib/a_dir/test/input',
+        )(
           expectedPatchCount: 3,
           input: '''
             import 'dart:html';

--- a/test/shared_pubspec_tests.dart
+++ b/test/shared_pubspec_tests.dart
@@ -47,7 +47,7 @@ import 'util.dart';
 /// min. Used in conjunction with `shouldUpdateMidRange`.
 void sharedPubspecTest({
   required Function({bool useMidVersionMin, String? hostedUrl})
-      getExpectedOutput,
+  getExpectedOutput,
   required SuggestorTester testSuggestor,
   required String dependency,
   required VersionRange startingRange,
@@ -66,11 +66,13 @@ void sharedPubspecTest({
       expectedPatchCount: 0,
       shouldDartfmtOutput: false,
       validateContents: validatePubspecYaml,
-      input: ''
+      input:
+          ''
           'name: nothing\n'
           'version: 0.0.0\n'
           '',
-      expectedOutput: ''
+      expectedOutput:
+          ''
           'name: nothing\n'
           'version: 0.0.0\n'
           '',
@@ -82,12 +84,14 @@ void sharedPubspecTest({
       expectedPatchCount: 0,
       shouldDartfmtOutput: false,
       validateContents: validatePubspecYaml,
-      input: ''
+      input:
+          ''
           'name: nothing\n'
           'version: 0.0.0\n'
           '${getExpectedOutput(hostedUrl: hostedUrl)}'
           '',
-      expectedOutput: ''
+      expectedOutput:
+          ''
           'name: nothing\n'
           'version: 0.0.0\n'
           '${getExpectedOutput(hostedUrl: hostedUrl)}'
@@ -100,13 +104,15 @@ void sharedPubspecTest({
       expectedPatchCount: 0,
       shouldDartfmtOutput: false,
       validateContents: validatePubspecYaml,
-      input: ''
+      input:
+          ''
           'name: nothing\n'
           'version: 0.0.0\n'
           '$key:\n'
           '${getDependencyDeclaration(dependency, 'any', hostedUrl)}'
           '',
-      expectedOutput: ''
+      expectedOutput:
+          ''
           'name: nothing\n'
           'version: 0.0.0\n'
           '$key:\n'
@@ -115,28 +121,30 @@ void sharedPubspecTest({
     );
   });
 
-  test(
-      '${shouldAddDependencies ? 'adds the' : 'does not add the'} dependency '
+  test('${shouldAddDependencies ? 'adds the' : 'does not add the'} dependency '
       'if missing', () async {
     await testSuggestor(
       expectedPatchCount: shouldAddDependencies ? 1 : 0,
       shouldDartfmtOutput: false,
       validateContents: validatePubspecYaml,
-      input: ''
+      input:
+          ''
           '$key:\n'
           '  test: 1.5.1\n'
           '',
-      expectedOutput: ''
+      expectedOutput:
+          ''
           '${shouldAddDependencies ? getExpectedOutput(hostedUrl: hostedUrl) : ''
-              '$key:\n'
-              '  test: 1.5.1\n'}'
+                    '$key:\n'
+                    '  test: 1.5.1\n'}'
           '',
     );
   });
 
   if (shouldAddDependencies) {
     group('adds the dependency, if missing, in correct alphabetical order', () {
-      final expectedAddedDep = (hostedUrl == null
+      final expectedAddedDep =
+          (hostedUrl == null
                   ? getDependencyRegExp(dependency)
                   : getHostedDependencyRegExp(dependency))
               .firstMatch(getExpectedOutput(hostedUrl: hostedUrl))
@@ -148,11 +156,13 @@ void sharedPubspecTest({
           expectedPatchCount: 1,
           shouldDartfmtOutput: false,
           validateContents: validatePubspecYaml,
-          input: ''
+          input:
+              ''
               '$key:\n'
               '  z: 1.5.1\n'
               '',
-          expectedOutput: ''
+          expectedOutput:
+              ''
               '$key:\n'
               '  $expectedAddedDep\n'
               '  z: 1.5.1\n'
@@ -165,12 +175,14 @@ void sharedPubspecTest({
           expectedPatchCount: 1,
           shouldDartfmtOutput: false,
           validateContents: validatePubspecYaml,
-          input: ''
+          input:
+              ''
               '$key:\n'
               '  a: 1.5.1\n'
               '  c: 1.5.1\n'
               '',
-          expectedOutput: ''
+          expectedOutput:
+              ''
               '$key:\n'
               '  a: 1.5.1\n'
               '  c: 1.5.1\n'
@@ -184,13 +196,15 @@ void sharedPubspecTest({
           expectedPatchCount: 1,
           shouldDartfmtOutput: false,
           validateContents: validatePubspecYaml,
-          input: ''
+          input:
+              ''
               '$key:\n'
               '  a: 1.5.1\n'
               '  b: 1.5.1\n'
               '  x: 1.5.1\n'
               '',
-          expectedOutput: ''
+          expectedOutput:
+              ''
               '$key:\n'
               '  a: 1.5.1\n'
               '  b: 1.5.1\n'
@@ -208,7 +222,8 @@ void sharedPubspecTest({
         expectedPatchCount: patchCount,
         shouldDartfmtOutput: false,
         validateContents: validatePubspecYaml,
-        input: ''
+        input:
+            ''
             '$key:\n'
             '${getDependencyDeclaration(dependency, '^${startingRange.min}', hostedUrl)}'
             '  test: 1.5.1\n'
@@ -216,41 +231,44 @@ void sharedPubspecTest({
         expectedOutput: shouldUpdate
             ? getExpectedOutput(hostedUrl: hostedUrl)
             : ''
-                '$key:\n'
-                '${getDependencyDeclaration(dependency, '^${startingRange.min}', hostedUrl)}'
-                '  test: 1.5.1\n'
-                '',
+                  '$key:\n'
+                  '${getDependencyDeclaration(dependency, '^${startingRange.min}', hostedUrl)}'
+                  '  test: 1.5.1\n'
+                  '',
       );
     });
 
     test(
-        '${shouldUpdateMidRange ? '' : 'except'} when the version is within the expected range',
-        () async {
-      await testSuggestor(
-        expectedPatchCount: shouldUpdateMidRange ? 1 : 0,
-        shouldDartfmtOutput: false,
-        validateContents: validatePubspecYaml,
-        input: ''
-            '$key:\n'
-            '${getDependencyDeclaration(dependency, midVersionRange, hostedUrl)}'
-            '  test: 1.5.1\n'
-            '',
-        expectedOutput: shouldUpdateMidRange
-            ? getExpectedOutput(useMidVersionMin: true, hostedUrl: hostedUrl)
-            : ''
-                '$key:\n'
-                '${getDependencyDeclaration(dependency, midVersionRange, hostedUrl)}'
-                '  test: 1.5.1\n'
-                '',
-      );
-    });
+      '${shouldUpdateMidRange ? '' : 'except'} when the version is within the expected range',
+      () async {
+        await testSuggestor(
+          expectedPatchCount: shouldUpdateMidRange ? 1 : 0,
+          shouldDartfmtOutput: false,
+          validateContents: validatePubspecYaml,
+          input:
+              ''
+              '$key:\n'
+              '${getDependencyDeclaration(dependency, midVersionRange, hostedUrl)}'
+              '  test: 1.5.1\n'
+              '',
+          expectedOutput: shouldUpdateMidRange
+              ? getExpectedOutput(useMidVersionMin: true, hostedUrl: hostedUrl)
+              : ''
+                    '$key:\n'
+                    '${getDependencyDeclaration(dependency, midVersionRange, hostedUrl)}'
+                    '  test: 1.5.1\n'
+                    '',
+        );
+      },
+    );
 
     test('with single quotes', () async {
       await testSuggestor(
         expectedPatchCount: patchCount,
         shouldDartfmtOutput: false,
         validateContents: validatePubspecYaml,
-        input: ''
+        input:
+            ''
             '$key:\n'
             '${getDependencyDeclaration(dependency, '\'^${startingRange.min}\'', hostedUrl)}'
             '  test: 1.5.1\n'
@@ -258,10 +276,10 @@ void sharedPubspecTest({
         expectedOutput: shouldUpdate
             ? getExpectedOutput(hostedUrl: hostedUrl)
             : ''
-                '$key:\n'
-                '${getDependencyDeclaration(dependency, '\'^${startingRange.min}\'', hostedUrl)}'
-                '  test: 1.5.1\n'
-                '',
+                  '$key:\n'
+                  '${getDependencyDeclaration(dependency, '\'^${startingRange.min}\'', hostedUrl)}'
+                  '  test: 1.5.1\n'
+                  '',
       );
     });
 
@@ -270,7 +288,8 @@ void sharedPubspecTest({
         expectedPatchCount: patchCount,
         shouldDartfmtOutput: false,
         validateContents: validatePubspecYaml,
-        input: ''
+        input:
+            ''
             '$key:\n'
             '${getDependencyDeclaration(dependency, '"^${startingRange.min}"', hostedUrl)}'
             '  test: 1.5.1\n'
@@ -278,10 +297,10 @@ void sharedPubspecTest({
         expectedOutput: shouldUpdate
             ? getExpectedOutput(hostedUrl: hostedUrl)
             : ''
-                '$key:\n'
-                '${getDependencyDeclaration(dependency, '"^${startingRange.min}"', hostedUrl)}'
-                '  test: 1.5.1\n'
-                '',
+                  '$key:\n'
+                  '${getDependencyDeclaration(dependency, '"^${startingRange.min}"', hostedUrl)}'
+                  '  test: 1.5.1\n'
+                  '',
       );
     });
   });
@@ -292,7 +311,8 @@ void sharedPubspecTest({
         expectedPatchCount: patchCount,
         shouldDartfmtOutput: false,
         validateContents: validatePubspecYaml,
-        input: ''
+        input:
+            ''
             '$key:\n'
             '${getDependencyDeclaration(dependency, '\'$startingRange\'', hostedUrl)}'
             '  test: 1.5.1\n'
@@ -300,10 +320,10 @@ void sharedPubspecTest({
         expectedOutput: shouldUpdate
             ? getExpectedOutput(hostedUrl: hostedUrl)
             : ''
-                '$key:\n'
-                '${getDependencyDeclaration(dependency, '\'$startingRange\'', hostedUrl)}'
-                '  test: 1.5.1\n'
-                '',
+                  '$key:\n'
+                  '${getDependencyDeclaration(dependency, '\'$startingRange\'', hostedUrl)}'
+                  '  test: 1.5.1\n'
+                  '',
       );
     });
 
@@ -312,7 +332,8 @@ void sharedPubspecTest({
         expectedPatchCount: patchCount,
         shouldDartfmtOutput: false,
         validateContents: validatePubspecYaml,
-        input: ''
+        input:
+            ''
             '$key:\n'
             '${getDependencyDeclaration(dependency, '"$startingRange"', hostedUrl)}'
             '  test: 1.5.1\n'
@@ -320,10 +341,10 @@ void sharedPubspecTest({
         expectedOutput: shouldUpdate
             ? getExpectedOutput(hostedUrl: hostedUrl)
             : ''
-                '$key:\n'
-                '${getDependencyDeclaration(dependency, '"$startingRange"', hostedUrl)}'
-                '  test: 1.5.1\n'
-                '',
+                  '$key:\n'
+                  '${getDependencyDeclaration(dependency, '"$startingRange"', hostedUrl)}'
+                  '  test: 1.5.1\n'
+                  '',
       );
     });
   });
@@ -334,7 +355,8 @@ void sharedPubspecTest({
         expectedPatchCount: patchCount,
         shouldDartfmtOutput: false,
         validateContents: validatePubspecYaml,
-        input: ''
+        input:
+            ''
             '$key:\n'
             '${getDependencyDeclaration(dependency, '">=${startingRange.min}"', hostedUrl)}'
             '  test: 1.5.1\n'
@@ -342,10 +364,10 @@ void sharedPubspecTest({
         expectedOutput: shouldUpdate
             ? getExpectedOutput(hostedUrl: hostedUrl)
             : ''
-                '$key:\n'
-                '${getDependencyDeclaration(dependency, '">=${startingRange.min}"', hostedUrl)}'
-                '  test: 1.5.1\n'
-                '',
+                  '$key:\n'
+                  '${getDependencyDeclaration(dependency, '">=${startingRange.min}"', hostedUrl)}'
+                  '  test: 1.5.1\n'
+                  '',
       );
     });
 
@@ -354,7 +376,8 @@ void sharedPubspecTest({
         expectedPatchCount: patchCount,
         shouldDartfmtOutput: false,
         validateContents: validatePubspecYaml,
-        input: ''
+        input:
+            ''
             '$key:\n'
             '${getDependencyDeclaration(dependency, '\'>=${startingRange.min}\'', hostedUrl)}'
             '  test: 1.5.1\n'
@@ -362,10 +385,10 @@ void sharedPubspecTest({
         expectedOutput: shouldUpdate
             ? getExpectedOutput(hostedUrl: hostedUrl)
             : ''
-                '$key:\n'
-                '${getDependencyDeclaration(dependency, '\'>=${startingRange.min}\'', hostedUrl)}'
-                '  test: 1.5.1\n'
-                '',
+                  '$key:\n'
+                  '${getDependencyDeclaration(dependency, '\'>=${startingRange.min}\'', hostedUrl)}'
+                  '  test: 1.5.1\n'
+                  '',
       );
     });
 
@@ -374,7 +397,8 @@ void sharedPubspecTest({
         expectedPatchCount: patchCount,
         shouldDartfmtOutput: false,
         validateContents: validatePubspecYaml,
-        input: ''
+        input:
+            ''
             '$key:\n'
             '${getDependencyDeclaration(dependency, '">=${startingRange.min}"', hostedUrl)}'
             '  test: 1.5.1\n'
@@ -382,17 +406,20 @@ void sharedPubspecTest({
         expectedOutput: shouldUpdate
             ? getExpectedOutput(hostedUrl: hostedUrl)
             : ''
-                '$key:\n'
-                '${getDependencyDeclaration(dependency, '">=${startingRange.min}"', hostedUrl)}'
-                '  test: 1.5.1\n'
-                '',
+                  '$key:\n'
+                  '${getDependencyDeclaration(dependency, '">=${startingRange.min}"', hostedUrl)}'
+                  '  test: 1.5.1\n'
+                  '',
       );
     });
   });
 }
 
-String getDependencyDeclaration(String dependency, String? version,
-    [String? hostedUrl]) {
+String getDependencyDeclaration(
+  String dependency,
+  String? version, [
+  String? hostedUrl,
+]) {
   if (hostedUrl != null) {
     return '  $dependency:\n'
         '    hosted:\n'

--- a/test/unify_package_rename_suggestors/import_renamer_test.dart
+++ b/test/unify_package_rename_suggestors/import_renamer_test.dart
@@ -51,7 +51,8 @@ void main() {
           
               content() => Dom.div()();
           ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
               import 'package:over_react/over_react.dart';
               import 'package:'''
               '''unify_ui/abc.dart';
@@ -75,7 +76,8 @@ void main() {
           
               content() => Dom.div()();
           ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
               import 'package:'''
               '''unify_ui/styles/styled.dart' as mui;
               import 'package:'''
@@ -87,10 +89,10 @@ void main() {
       });
 
       test(
-          'for special cases when the new file path is different from the old one',
-          () async {
-        await testSuggestor(
-          input: '''
+        'for special cases when the new file path is different from the old one',
+        () async {
+          await testSuggestor(
+            input: '''
               import 'package:react_material_ui/react_material_ui.dart';
               import 'package:over_react/over_react.dart';
               import 'package:web_skin_dart/ui_components.dart';
@@ -102,24 +104,26 @@ void main() {
           
               content() => Dom.div()();
           ''',
-          expectedOutput: '''
+            expectedOutput:
+                '''
               import 'package:over_react/over_react.dart';
               import 'package:'''
-              '''unify_ui/components/list.dart';
+                '''unify_ui/components/list.dart';
               import 'package:'''
-              '''unify_ui/components/usage_must_be_approved_by_unify_team_for_legal_reasons/data_grid_premium.dart';
+                '''unify_ui/components/usage_must_be_approved_by_unify_team_for_legal_reasons/data_grid_premium.dart';
               import 'package:'''
-              '''unify_ui/styles/styled.dart';
+                '''unify_ui/styles/styled.dart';
               import 'package:'''
-              '''unify_ui/styles/styled.dart';
+                '''unify_ui/styles/styled.dart';
               import 'package:'''
-              '''unify_ui/unify_ui.dart';
+                '''unify_ui/unify_ui.dart';
               import 'package:web_skin_dart/ui_components.dart';
           
               content() => Dom.div()();
           ''',
-        );
-      });
+          );
+        },
+      );
 
       test('with namespaces', () async {
         await testSuggestor(
@@ -136,7 +140,8 @@ void main() {
           
               content() => Dom.div()();
           ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
               library lib;
               
               import 'package:over_react/over_react.dart' as mui;
@@ -169,7 +174,8 @@ void main() {
           
               content() => Dom.div()();
           ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
               import 'package:'''
               '''unify_ui/components/alert.dart' as something_else show Alert;
               import 'package:'''
@@ -188,7 +194,8 @@ void main() {
 
       test('unless the imports are already updated to the new name', () async {
         await testSuggestor(
-          input: '''
+          input:
+              '''
               library lib;
           
               import 'package:'''
@@ -215,7 +222,8 @@ void main() {
           ),
         );
         await testSuggestor(
-          input: '''
+          input:
+              '''
               import 'package:over_react/over_react.dart';
               import 'package:'''
               '''old/old.dart' as o;
@@ -224,7 +232,8 @@ void main() {
           
               content() => Dom.div()();
           ''',
-          expectedOutput: '''
+          expectedOutput:
+              '''
               import 'package:'''
               '''new/components/badge.dart';
               import 'package:'''

--- a/test/util.dart
+++ b/test/util.dart
@@ -34,8 +34,9 @@ final formatter = DartFormatter();
 // tests since it is pretty much entirely input >> output.
 // https://github.com/dart-lang/dart_style/blob/master/test/utils.dart#L55
 void testSuggestorsDir(Map<String, Suggestor> suggestorMap, String testDir) {
-  final testFiles =
-      Directory(testDir).listSync(followLinks: false, recursive: true);
+  final testFiles = Directory(
+    testDir,
+  ).listSync(followLinks: false, recursive: true);
   testFiles.sort((a, b) => a.path.compareTo(b.path));
 
   for (var testFile in testFiles) {
@@ -56,8 +57,9 @@ void _testSuggestor(Map<String, Suggestor> suggestorMap, String testFilePath) {
     // Let the test specify whether to format expected and actual output
     // before comparing them.
     var dartfmtOutputAll = false;
-    suggestorName =
-        suggestorName.replaceAllMapped(_dartfmtOutputPattern, (match) {
+    suggestorName = suggestorName.replaceAllMapped(_dartfmtOutputPattern, (
+      match,
+    ) {
       dartfmtOutputAll = true;
       return '';
     });
@@ -95,8 +97,9 @@ void _testSuggestor(Map<String, Suggestor> suggestorMap, String testFilePath) {
       // Let the test specify whether to format expected and actual output
       // before comparing them.
       var shouldDartfmtOutput = dartfmtOutputAll;
-      description =
-          description.replaceAllMapped(_dartfmtOutputPattern, (match) {
+      description = description.replaceAllMapped(_dartfmtOutputPattern, (
+        match,
+      ) {
         shouldDartfmtOutput = true;
         return '';
       });
@@ -115,8 +118,9 @@ void _testSuggestor(Map<String, Suggestor> suggestorMap, String testFilePath) {
       });
 
       description = description.trim();
-      description =
-          description.isEmpty ? 'line ${i + 1}' : 'line ${i + 1}: $description';
+      description = description.isEmpty
+          ? 'line ${i + 1}'
+          : 'line ${i + 1}: $description';
 
       var input = '';
       while (!lines[i].startsWith('<<<')) {
@@ -151,16 +155,17 @@ void _testSuggestor(Map<String, Suggestor> suggestorMap, String testFilePath) {
   });
 }
 
-typedef SuggestorTester = Future<void> Function({
-  required String input,
-  String? expectedOutput,
-  int? expectedPatchCount,
-  bool shouldDartfmtOutput,
-  bool testIdempotency,
-  SharedAnalysisContext? resolvedContext,
-  IsExpectedError? isExpectedError,
-  void Function(String contents)? validateContents,
-});
+typedef SuggestorTester =
+    Future<void> Function({
+      required String input,
+      String? expectedOutput,
+      int? expectedPatchCount,
+      bool shouldDartfmtOutput,
+      bool testIdempotency,
+      SharedAnalysisContext? resolvedContext,
+      IsExpectedError? isExpectedError,
+      void Function(String contents)? validateContents,
+    });
 
 const defaultSuggestorTesterInputUrl = 'lib/src/input';
 
@@ -180,19 +185,18 @@ SuggestorTester getSuggestorTester(
     SharedAnalysisContext? resolvedContext,
     IsExpectedError? isExpectedError,
     void Function(String contents)? validateContents,
-  }) =>
-      testSuggestor(
-        suggestor: suggestor,
-        input: input,
-        expectedOutput: expectedOutput,
-        expectedPatchCount: expectedPatchCount,
-        shouldDartfmtOutput: shouldDartfmtOutput,
-        testIdempotency: testIdempotency,
-        resolvedContext: resolvedContext ?? defaultResolvedContext,
-        isExpectedError: isExpectedError,
-        validateContents: validateContents,
-        inputUrl: inputUrl,
-      );
+  }) => testSuggestor(
+    suggestor: suggestor,
+    input: input,
+    expectedOutput: expectedOutput,
+    expectedPatchCount: expectedPatchCount,
+    shouldDartfmtOutput: shouldDartfmtOutput,
+    testIdempotency: testIdempotency,
+    resolvedContext: resolvedContext ?? defaultResolvedContext,
+    isExpectedError: isExpectedError,
+    validateContents: validateContents,
+    inputUrl: inputUrl,
+  );
 }
 
 String _formatWithBetterFailureOutput(String input, {required String uri}) {
@@ -222,28 +226,35 @@ Future<void> testSuggestor({
 
   if (isExpectedError != null && resolvedContext == null) {
     throw ArgumentError(
-        'resolvedContext must be non-null to specify isExpectedError');
+      'resolvedContext must be non-null to specify isExpectedError',
+    );
   }
 
   Future<FileContext> getFileContext({
     required String contents,
     required String path,
-  }) =>
-      resolvedContext != null
-          ? resolvedContext.resolvedFileContextForTest(contents,
-              filename: path,
-              includeTestDescription: false,
-              isExpectedError: isExpectedError)
-          : fileContextForTest(path, contents);
+  }) => resolvedContext != null
+      ? resolvedContext.resolvedFileContextForTest(
+          contents,
+          filename: path,
+          includeTestDescription: false,
+          isExpectedError: isExpectedError,
+        )
+      : fileContextForTest(path, contents);
 
   if (validateContents != null) {
-    expect(() => validateContents(input), returnsNormally,
-        reason: 'input is invalid');
+    expect(
+      () => validateContents(input),
+      returnsNormally,
+      reason: 'input is invalid',
+    );
   }
 
   if (shouldDartfmtOutput) {
-    expectedOutput =
-        _formatWithBetterFailureOutput(expectedOutput, uri: 'expectedOutput');
+    expectedOutput = _formatWithBetterFailureOutput(
+      expectedOutput,
+      uri: 'expectedOutput',
+    );
   }
 
   String modifiedInput;
@@ -251,44 +262,64 @@ Future<void> testSuggestor({
     final context = await getFileContext(contents: input, path: inputUrl);
     final patches = await suggestor(context).toList();
     if (expectedPatchCount != null && patches.length != expectedPatchCount) {
-      fail('Incorrect number of patches generated '
-          '(expected: $expectedPatchCount, actual: ${patches.length})\n'
-          'Patches:\n$patches');
+      fail(
+        'Incorrect number of patches generated '
+        '(expected: $expectedPatchCount, actual: ${patches.length})\n'
+        'Patches:\n$patches',
+      );
     }
     try {
       modifiedInput =
           applyPatches(context.sourceFile, patches).trimRight() + '\n';
     } catch (_) {
-      print('Patches:\n${patches.map((p) {
-        return '<Patch: from ${p.startOffset} to ${p.endOffset} with text "${p.updatedText}">';
-      }).join('\n')}\n');
+      print(
+        'Patches:\n${patches.map((p) {
+          return '<Patch: from ${p.startOffset} to ${p.endOffset} with text "${p.updatedText}">';
+        }).join('\n')}\n',
+      );
       rethrow;
     }
     if (validateContents != null) {
-      expect(() => validateContents(modifiedInput), returnsNormally,
-          reason: 'output is invalid');
+      expect(
+        () => validateContents(modifiedInput),
+        returnsNormally,
+        reason: 'output is invalid',
+      );
     }
     if (shouldDartfmtOutput) {
-      modifiedInput = _formatWithBetterFailureOutput(modifiedInput,
-          uri: '$inputUrl.modifiedInput');
+      modifiedInput = _formatWithBetterFailureOutput(
+        modifiedInput,
+        uri: '$inputUrl.modifiedInput',
+      );
     }
-    expect(modifiedInput, expectedOutput,
-        reason: 'Original input:\n---------------\n$input');
+    expect(
+      modifiedInput,
+      expectedOutput,
+      reason: 'Original input:\n---------------\n$input',
+    );
   }
 
   if (testIdempotency) {
-    final context =
-        await getFileContext(contents: input, path: '$inputUrl.modifiedInput');
+    final context = await getFileContext(
+      contents: input,
+      path: '$inputUrl.modifiedInput',
+    );
     final patches = await suggestor(context).toList();
     var doubleModifiedInput =
         applyPatches(context.sourceFile, patches).trimRight() + '\n';
     if (shouldDartfmtOutput) {
-      doubleModifiedInput = _formatWithBetterFailureOutput(doubleModifiedInput,
-          uri: '$inputUrl.doubleModifiedInput');
+      doubleModifiedInput = _formatWithBetterFailureOutput(
+        doubleModifiedInput,
+        uri: '$inputUrl.doubleModifiedInput',
+      );
     }
-    expect(doubleModifiedInput, expectedOutput,
-        reason: 'Should be idempotent, but changed in the second run.\n\n'
-            'Original input:\n---------------\n$input');
+    expect(
+      doubleModifiedInput,
+      expectedOutput,
+      reason:
+          'Should be idempotent, but changed in the second run.\n\n'
+          'Original input:\n---------------\n$input',
+    );
   }
 }
 
@@ -300,29 +331,42 @@ void validatePubspecYaml(String yaml) {
   final yamlDoc = loadYamlDocument(yaml);
 
   expect(yamlDoc.contents, isA<YamlMap>());
-  final extraTopLevelKeys =
-      (yamlDoc.contents as YamlMap).keys.toSet().difference(const {
-    'name',
-    'version',
-    'author',
-    'executables',
-    'description',
-    'dependencies',
-    'dev_dependencies',
-    'dependency_overrides',
-  });
-  expect(extraTopLevelKeys, isEmpty,
-      reason: 'unexpected top-level keys in pubspec.yaml;'
-          ' could the dependencies be missing indentation?');
+  final extraTopLevelKeys = (yamlDoc.contents as YamlMap).keys
+      .toSet()
+      .difference(const {
+        'name',
+        'version',
+        'author',
+        'executables',
+        'description',
+        'dependencies',
+        'dev_dependencies',
+        'dependency_overrides',
+      });
+  expect(
+    extraTopLevelKeys,
+    isEmpty,
+    reason:
+        'unexpected top-level keys in pubspec.yaml;'
+        ' could the dependencies be missing indentation?',
+  );
 }
 
-Func1<T, A> boundExpectAsync1<T, A>(T Function(A) callback,
-        {int count = 1, int max = 0, String? id, String? reason}) =>
-    expectAsync1(callback, count: count, max: max, id: id, reason: reason);
+Func1<T, A> boundExpectAsync1<T, A>(
+  T Function(A) callback, {
+  int count = 1,
+  int max = 0,
+  String? id,
+  String? reason,
+}) => expectAsync1(callback, count: count, max: max, id: id, reason: reason);
 
-Func2<T, A, B> boundExpectAsync2<T, A, B>(T Function(A, B) callback,
-        {int count = 1, int max = 0, String? id, String? reason}) =>
-    expectAsync2(callback, count: count, max: max, id: id, reason: reason);
+Func2<T, A, B> boundExpectAsync2<T, A, B>(
+  T Function(A, B) callback, {
+  int count = 1,
+  int max = 0,
+  String? id,
+  String? reason,
+}) => expectAsync2(callback, count: count, max: max, id: id, reason: reason);
 
 extension PatchMatchers on TypeMatcher<Patch> {
   Matcher havingText(dynamic matcher) =>
@@ -332,9 +376,13 @@ extension PatchMatchers on TypeMatcher<Patch> {
 Matcher hasPatchText(dynamic matcher) => isA<Patch>().havingText(matcher);
 
 Matcher isMuiMigrationFixmeCommentPatch({String withMessage = ''}) =>
-    hasPatchText(matches(
-      RegExp(r'// FIXME\(mui_migration\) - .+ - ' + RegExp.escape(withMessage)),
-    ));
+    hasPatchText(
+      matches(
+        RegExp(
+          r'// FIXME\(mui_migration\) - .+ - ' + RegExp.escape(withMessage),
+        ),
+      ),
+    );
 
 extension ObjectMatchers on TypeMatcher<Object> {
   Matcher havingToStringValue(dynamic matcher) =>

--- a/test/util/args_test.dart
+++ b/test/util/args_test.dart
@@ -27,14 +27,14 @@ void main() {
         '2',
         '--other-flag',
         ...getArgsToRemove(),
-        'positional'
+        'positional',
       ];
       final expectedArgs = [
         '--other-option-1=1',
         '--other-option-2',
         '2',
         '--other-flag',
-        'positional'
+        'positional',
       ];
       expect(removeArgs(args), expectedArgs);
     }
@@ -59,16 +59,24 @@ void main() {
 
         test('when there are multiple matching options of the same name', () {
           sharedTest(
-            getArgsToRemove: () =>
-                ['--test-option', 'value1', '--test-option', 'value2'],
+            getArgsToRemove: () => [
+              '--test-option',
+              'value1',
+              '--test-option',
+              'value2',
+            ],
             removeArgs: (args) => removeOptionArgs(args, ['test-option']),
           );
         });
 
         test('when multiple names are specified', () {
           sharedTest(
-            getArgsToRemove: () =>
-                ['--test-option-1', 'value', '--test-option-2', 'value'],
+            getArgsToRemove: () => [
+              '--test-option-1',
+              'value',
+              '--test-option-2',
+              'value',
+            ],
             removeArgs: (args) =>
                 removeOptionArgs(args, ['test-option-1', 'test-option-2']),
           );

--- a/test/util/class_suggestor_test.dart
+++ b/test/util/class_suggestor_test.dart
@@ -61,21 +61,22 @@ void main() {
       final suggestor = Simple();
       final context = await fileContextForTest('lib.dart', 'library lib;');
       expect(
-          suggestor(context),
-          emitsInOrder([
-            isA<Patch>()
-                .having((p) => p.startOffset, 'startOffset', 0)
-                .having((p) => p.endOffset, 'endOffset', 1)
-                .having((p) => p.updatedText, 'updatedText', 'foo1')
-                .having((p) => p.isInsertionPatch, 'isInsertionPatch', isFalse),
-            equals(Patch('foo1', 0, 1)),
-            isA<Patch>()
-                .having((p) => p.startOffset, 'startOffset', 1)
-                .having((p) => p.endOffset, 'endOffset', 1)
-                .having((p) => p.updatedText, 'updatedText', 'foo2')
-                .having((p) => p.isInsertionPatch, 'isInsertionPatch', isTrue),
-            emitsDone,
-          ]));
+        suggestor(context),
+        emitsInOrder([
+          isA<Patch>()
+              .having((p) => p.startOffset, 'startOffset', 0)
+              .having((p) => p.endOffset, 'endOffset', 1)
+              .having((p) => p.updatedText, 'updatedText', 'foo1')
+              .having((p) => p.isInsertionPatch, 'isInsertionPatch', isFalse),
+          equals(Patch('foo1', 0, 1)),
+          isA<Patch>()
+              .having((p) => p.startOffset, 'startOffset', 1)
+              .having((p) => p.endOffset, 'endOffset', 1)
+              .having((p) => p.updatedText, 'updatedText', 'foo2')
+              .having((p) => p.isInsertionPatch, 'isInsertionPatch', isTrue),
+          emitsDone,
+        ]),
+      );
     });
 
     test('should be able to be run multiple times', () async {
@@ -83,7 +84,7 @@ void main() {
       final expectedPatches = [
         Patch('foo1', 0, 1),
         Patch('foo1', 0, 1),
-        Patch('foo2', 1, 1)
+        Patch('foo2', 1, 1),
       ];
 
       final contextA = await fileContextForTest('a.dart', 'library a;');
@@ -95,8 +96,7 @@ void main() {
       expect(patchesB, expectedPatches);
     });
 
-    test(
-        'should scope patch generation such that it is not broken by '
+    test('should scope patch generation such that it is not broken by '
         'listening to streams out-of-order', () async {
       final suggestor = LibNameDoubler();
 
@@ -114,11 +114,12 @@ void main() {
       expect(await patchesC.toList(), [Patch('cc', 0, 1)]);
     });
 
-    test('should sort insertion patches when sortParenInsertionPatches is true',
-        () async {
-      final suggestor = SortParens(true);
-      final context = await fileContextForTest('lib.dart', 'foo()');
-      expect(
+    test(
+      'should sort insertion patches when sortParenInsertionPatches is true',
+      () async {
+        final suggestor = SortParens(true);
+        final context = await fileContextForTest('lib.dart', 'foo()');
+        expect(
           suggestor(context),
           emitsInOrder([
             Patch('(', 0, 0),
@@ -128,15 +129,17 @@ void main() {
             Patch(')', 3, 3),
             Patch(')', 3, 3),
             emitsDone,
-          ]));
-    });
+          ]),
+        );
+      },
+    );
 
     test(
-        'should not sort insertion patches when sortParenInsertionPatches is false',
-        () async {
-      final suggestor = SortParens(false);
-      final context = await fileContextForTest('lib.dart', 'foo()');
-      expect(
+      'should not sort insertion patches when sortParenInsertionPatches is false',
+      () async {
+        final suggestor = SortParens(false);
+        final context = await fileContextForTest('lib.dart', 'foo()');
+        expect(
           suggestor(context),
           emitsInOrder([
             Patch('(', 0, 0),
@@ -146,7 +149,9 @@ void main() {
             Patch('..baz', 3, 3),
             Patch(')', 3, 3),
             emitsDone,
-          ]));
-    });
+          ]),
+        );
+      },
+    );
   });
 }

--- a/test/util/component_usage_migrator_test.dart
+++ b/test/util/component_usage_migrator_test.dart
@@ -39,11 +39,14 @@ main() {
 
         for (final usage in unresolvedUsages) {
           final migrator = GenericMigrator(
-              migrateUsage: boundExpectAsync2((_, __) {},
-                  count: 0,
-                  reason:
-                      'migrator should not be called for any of these usages;'
-                      ' it should throw first'));
+            migrateUsage: boundExpectAsync2(
+              (_, __) {},
+              count: 0,
+              reason:
+                  'migrator should not be called for any of these usages;'
+                  ' it should throw first',
+            ),
+          );
 
           final context = await sharedContext.resolvedFileContextForTest(
             // We're intentionally not importing over_react here since we don't
@@ -57,19 +60,23 @@ main() {
           );
           await expectLater(
             () async => await migrator(context).toList(),
-            throwsA(isA<Exception>().havingToStringValue(allOf(
-              contains('Builder static type could not be resolved'),
-              contains(usage),
-            ))),
+            throwsA(
+              isA<Exception>().havingToStringValue(
+                allOf(
+                  contains('Builder static type could not be resolved'),
+                  contains(usage),
+                ),
+              ),
+            ),
           );
         }
       });
 
       test(
-          'but not for resolved dynamic calls might look like unresolved usages',
-          () async {
-        // Valid dynamic calls that are resolved and just looks like usages
-        const source = /*language=dart*/ '''
+        'but not for resolved dynamic calls might look like unresolved usages',
+        () async {
+          // Valid dynamic calls that are resolved and just looks like usages
+          const source = /*language=dart*/ '''
             // Dynamic first and second invocation
             dynamic Foo1;
             usage1() => Foo1()();
@@ -87,25 +94,32 @@ main() {
             usage3_2() => builder3();
         ''';
 
-        final migrator = GenericMigrator(
-          migrateUsage: boundExpectAsync2((_, __) {},
-              count: 0, reason: 'these calls should not be detected as usages'),
-        );
-        // awaiting this is the best way to assert it does not throw, since
-        // returnsNormally doesn't work as intended with async functions.
-        await sharedContext.getPatches(migrator, source);
-      });
+          final migrator = GenericMigrator(
+            migrateUsage: boundExpectAsync2(
+              (_, __) {},
+              count: 0,
+              reason: 'these calls should not be detected as usages',
+            ),
+          );
+          // awaiting this is the best way to assert it does not throw, since
+          // returnsNormally doesn't work as intended with async functions.
+          await sharedContext.getPatches(migrator, source);
+        },
+      );
     });
 
     group('respects ignore comments, skipping shouldMigrateUsage when', () {
       group('a component usage is ignored', () {
         Future<List<FluentComponentUsage>> getShouldMigrateUsageCalls(
-            String source) async {
+          String source,
+        ) async {
           final calls = <FluentComponentUsage>[];
-          final migrator = GenericMigrator(shouldMigrateUsage: (_, usage) {
-            calls.add(usage);
-            return false;
-          });
+          final migrator = GenericMigrator(
+            shouldMigrateUsage: (_, usage) {
+              calls.add(usage);
+              return false;
+            },
+          );
           await sharedContext.getPatches(migrator, source);
           return calls;
         }
@@ -169,9 +183,10 @@ main() {
           ]);
         });
 
-        test('via a plain orcm_ignore_for_file comment somewhere in the file',
-            () async {
-          final source = withOverReactImport(/*language=dart*/ r'''
+        test(
+          'via a plain orcm_ignore_for_file comment somewhere in the file',
+          () async {
+            final source = withOverReactImport(/*language=dart*/ r'''
               // orcm_ignore_for_file
           
               usage() {
@@ -180,14 +195,15 @@ main() {
               }
           ''');
 
-          final calls = await getShouldMigrateUsageCalls(source);
-          expect(calls, isEmpty);
-        });
+            final calls = await getShouldMigrateUsageCalls(source);
+            expect(calls, isEmpty);
+          },
+        );
 
         test(
-            'via an orcm_ignore_for_file comment with args somewhere in the file',
-            () async {
-          final source = withOverReactImport(/*language=dart*/ r'''          
+          'via an orcm_ignore_for_file comment with args somewhere in the file',
+          () async {
+            final source = withOverReactImport(/*language=dart*/ r'''          
               // orcm_ignore_for_file: Foo
               // orcm_ignore_for_file: BarProps
               // orcm_ignore_for_file: Dom.div, Dom.span
@@ -219,12 +235,13 @@ main() {
               }
           ''');
 
-          final calls = await getShouldMigrateUsageCalls(source);
-          expect(calls.map((u) => u.builder.toSource()).toList(), [
-            'Qux()',
-            'Dom.a()',
-          ]);
-        });
+            final calls = await getShouldMigrateUsageCalls(source);
+            expect(calls.map((u) => u.builder.toSource()).toList(), [
+              'Qux()',
+              'Dom.a()',
+            ]);
+          },
+        );
       });
     });
 
@@ -380,10 +397,12 @@ main() {
         test('does not flag valid usages', () async {
           await testSuggestor(
             suggestor: GenericMigrator(
-              migrateUsage: boundExpectAsync2((_, __) {},
-                  // This suggestor gets run twice since idempotency is tested.
-                  count: 2,
-                  reason: 'should have run on the valid component usage'),
+              migrateUsage: boundExpectAsync2(
+                (_, __) {},
+                // This suggestor gets run twice since idempotency is tested.
+                count: 2,
+                reason: 'should have run on the valid component usage',
+              ),
             ),
             resolvedContext: sharedContext,
             input: withOverReactImport(/*language=dart*/ '''
@@ -507,9 +526,14 @@ main() {
       group('yieldInsertionPatch', () {
         test('yields a patch with the same start and end location', () async {
           await testSuggestor(
-            suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-              migrator.yieldInsertionPatch('/*insertion*/', usage.node.offset);
-            }),
+            suggestor: GenericMigrator(
+              migrateUsage: (migrator, usage) {
+                migrator.yieldInsertionPatch(
+                  '/*insertion*/',
+                  usage.node.offset,
+                );
+              },
+            ),
             resolvedContext: sharedContext,
             input: withOverReactImport(/*language=dart*/ '''
                 content() => Dom.div()();
@@ -523,21 +547,24 @@ main() {
 
       group('yieldPatchOverNode', () {
         test(
-            'yields a patch with the same start and end position as the given node',
-            () async {
-          await testSuggestor(
-            suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-              migrator.yieldPatchOverNode('newBuilder', usage.builder);
-            }),
-            resolvedContext: sharedContext,
-            input: withOverReactImport(/*language=dart*/ '''
+          'yields a patch with the same start and end position as the given node',
+          () async {
+            await testSuggestor(
+              suggestor: GenericMigrator(
+                migrateUsage: (migrator, usage) {
+                  migrator.yieldPatchOverNode('newBuilder', usage.builder);
+                },
+              ),
+              resolvedContext: sharedContext,
+              input: withOverReactImport(/*language=dart*/ '''
                 content() => Dom.div()();
             '''),
-            expectedOutput: withOverReactImport(/*language=dart*/ '''
+              expectedOutput: withOverReactImport(/*language=dart*/ '''
                 content() => newBuilder();
             '''),
-          );
-        });
+            );
+          },
+        );
       });
 
       group('yieldAddPropPatch', yieldAddPropPatchTests);
@@ -559,20 +586,29 @@ main() {
 
   group('handleCascadedPropsByName', () {
     test('runs the migrator for each prop with a matching name', () async {
-      final suggestor = GenericMigrator(migrateUsage: (migrator, usage) {
-        handleCascadedPropsByName(usage, {
-          'onClick': boundExpectAsync1((p) {
-            expect(p.name.name, 'onClick');
-          }),
-          'href': boundExpectAsync1((p) {
-            expect(p.name.name, 'href');
-          }),
-          'target': boundExpectAsync1((_) {},
-              count: 0, reason: 'should not call props that are not present'),
-        }, catchAll: boundExpectAsync1((p) {
-          expect(p.name.name, 'id');
-        }));
-      });
+      final suggestor = GenericMigrator(
+        migrateUsage: (migrator, usage) {
+          handleCascadedPropsByName(
+            usage,
+            {
+              'onClick': boundExpectAsync1((p) {
+                expect(p.name.name, 'onClick');
+              }),
+              'href': boundExpectAsync1((p) {
+                expect(p.name.name, 'href');
+              }),
+              'target': boundExpectAsync1(
+                (_) {},
+                count: 0,
+                reason: 'should not call props that are not present',
+              ),
+            },
+            catchAll: boundExpectAsync1((p) {
+              expect(p.name.name, 'id');
+            }),
+          );
+        },
+      );
       final source = withOverReactImport(/*language=dart*/ '''
           content() => (Dom.div()
             ..onClick = (_) {}
@@ -584,30 +620,37 @@ main() {
     });
 
     test('throws when a prop does not exist on the props class', () async {
-      final suggestor = GenericMigrator(migrateUsage: (migrator, usage) {
-        handleCascadedPropsByName(usage, {
-          'notARealProp': (_) {},
-        });
-      });
+      final suggestor = GenericMigrator(
+        migrateUsage: (migrator, usage) {
+          handleCascadedPropsByName(usage, {'notARealProp': (_) {}});
+        },
+      );
 
       final source = withOverReactImport('content() => Dom.div()();');
       expect(
-          () async => await sharedContext.getPatches(suggestor, source),
-          throwsA(isArgumentError.havingMessage(allOf(
-            contains("'migratorsByName' contains unknown prop name"),
-            contains("notARealProp"),
-          ))));
+        () async => await sharedContext.getPatches(suggestor, source),
+        throwsA(
+          isArgumentError.havingMessage(
+            allOf(
+              contains("'migratorsByName' contains unknown prop name"),
+              contains("notARealProp"),
+            ),
+          ),
+        ),
+      );
     });
   });
 
   group('getFirstPropByName', () {
     test('returns the first prop with a matching name', () async {
-      final suggestor = GenericMigrator(migrateUsage: (migrator, usage) {
-        final prop = getFirstPropWithName(usage, 'href');
-        expect(prop, isNotNull);
-        expect(prop!.name.name, 'href');
-        expect(prop.rightHandSide.toSource(), '"example.com/1"');
-      });
+      final suggestor = GenericMigrator(
+        migrateUsage: (migrator, usage) {
+          final prop = getFirstPropWithName(usage, 'href');
+          expect(prop, isNotNull);
+          expect(prop!.name.name, 'href');
+          expect(prop.rightHandSide.toSource(), '"example.com/1"');
+        },
+      );
       final source = withOverReactImport(/*language=dart*/ '''
           content() => (Dom.div()
             ..onClick = (_) {}
@@ -620,10 +663,12 @@ main() {
     });
 
     test('returns null when no prop matches the given name', () async {
-      final suggestor = GenericMigrator(migrateUsage: (migrator, usage) {
-        final prop = getFirstPropWithName(usage, 'href');
-        expect(prop, isNull);
-      });
+      final suggestor = GenericMigrator(
+        migrateUsage: (migrator, usage) {
+          final prop = getFirstPropWithName(usage, 'href');
+          expect(prop, isNull);
+        },
+      );
       final source = withOverReactImport(/*language=dart*/ '''
           content() => (Dom.div()
             ..onClick = (_) {}
@@ -634,17 +679,24 @@ main() {
     });
 
     test('throws when a prop does not exist on the props class', () async {
-      final suggestor = GenericMigrator(migrateUsage: (migrator, usage) {
-        getFirstPropWithName(usage, 'notARealProp');
-      });
+      final suggestor = GenericMigrator(
+        migrateUsage: (migrator, usage) {
+          getFirstPropWithName(usage, 'notARealProp');
+        },
+      );
 
       final source = withOverReactImport('content() => Dom.div()();');
       expect(
-          () async => await sharedContext.getPatches(suggestor, source),
-          throwsA(isArgumentError.havingMessage(allOf(
-            contains("not statically available"),
-            contains("notARealProp"),
-          ))));
+        () async => await sharedContext.getPatches(suggestor, source),
+        throwsA(
+          isArgumentError.havingMessage(
+            allOf(
+              contains("not statically available"),
+              contains("notARealProp"),
+            ),
+          ),
+        ),
+      );
     });
   });
 }
@@ -653,9 +705,11 @@ main() {
 void yieldAddPropPatchTests() {
   test('when the builder is not parenthesized', () async {
     await testSuggestor(
-      suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-        migrator.yieldAddPropPatch(usage, '..foo = "foo"');
-      }),
+      suggestor: GenericMigrator(
+        migrateUsage: (migrator, usage) {
+          migrator.yieldAddPropPatch(usage, '..foo = "foo"');
+        },
+      ),
       resolvedContext: sharedContext,
       input: withOverReactImport(/*language=dart*/ '''
           content() => Dom.div()();
@@ -667,31 +721,36 @@ void yieldAddPropPatchTests() {
   });
 
   test(
-      'when the builder is not parenthesized and yieldAddPropPatch is called more than once',
-      () async {
-    await testSuggestor(
-      suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-        migrator.yieldAddPropPatch(usage, '..foo = "foo"');
-        migrator.yieldAddPropPatch(usage, '..bar = "bar"');
-      }),
-      resolvedContext: sharedContext,
-      input: withOverReactImport(/*language=dart*/ '''
+    'when the builder is not parenthesized and yieldAddPropPatch is called more than once',
+    () async {
+      await testSuggestor(
+        suggestor: GenericMigrator(
+          migrateUsage: (migrator, usage) {
+            migrator.yieldAddPropPatch(usage, '..foo = "foo"');
+            migrator.yieldAddPropPatch(usage, '..bar = "bar"');
+          },
+        ),
+        resolvedContext: sharedContext,
+        input: withOverReactImport(/*language=dart*/ '''
           content() => Dom.div()();
       '''),
-      expectedOutput: withOverReactImport(/*language=dart*/ '''
+        expectedOutput: withOverReactImport(/*language=dart*/ '''
           content() => ((Dom.div()
             ..foo = "foo"
             ..bar = "bar"
           ))();
       '''),
-    );
-  });
+      );
+    },
+  );
 
   test('when the builder is parenthesized with no cascade', () async {
     await testSuggestor(
-      suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-        migrator.yieldAddPropPatch(usage, '..foo = "foo"');
-      }),
+      suggestor: GenericMigrator(
+        migrateUsage: (migrator, usage) {
+          migrator.yieldAddPropPatch(usage, '..foo = "foo"');
+        },
+      ),
       resolvedContext: sharedContext,
       input: withOverReactImport(/*language=dart*/ '''
           content() => (Dom.div())();
@@ -704,14 +763,18 @@ void yieldAddPropPatchTests() {
 
   test('when the builder has a single cascade on one line', () async {
     await testSuggestor(
-      suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-        final getLine = migrator.context.sourceFile.getLine;
-        expect(getLine(usage.cascadeSections.single.offset),
+      suggestor: GenericMigrator(
+        migrateUsage: (migrator, usage) {
+          final getLine = migrator.context.sourceFile.getLine;
+          expect(
+            getLine(usage.cascadeSections.single.offset),
             getLine(usage.builder.offset),
-            reason: 'cascade and builder should be on the same line');
+            reason: 'cascade and builder should be on the same line',
+          );
 
-        migrator.yieldAddPropPatch(usage, '..foo = "foo"');
-      }),
+          migrator.yieldAddPropPatch(usage, '..foo = "foo"');
+        },
+      ),
       resolvedContext: sharedContext,
       input: withOverReactImport(/*language=dart*/ '''
           content() => (Dom.div()..id = "some_id")();
@@ -727,14 +790,18 @@ void yieldAddPropPatchTests() {
 
   test('when the builder has a single cascade on a new line', () async {
     await testSuggestor(
-      suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-        final getLine = migrator.context.sourceFile.getLine;
-        expect(getLine(usage.cascadeSections.single.offset),
+      suggestor: GenericMigrator(
+        migrateUsage: (migrator, usage) {
+          final getLine = migrator.context.sourceFile.getLine;
+          expect(
+            getLine(usage.cascadeSections.single.offset),
             isNot(getLine(usage.builder.offset)),
-            reason: 'cascade and builder should not be on the same line');
+            reason: 'cascade and builder should not be on the same line',
+          );
 
-        migrator.yieldAddPropPatch(usage, '..foo = "foo"');
-      }),
+          migrator.yieldAddPropPatch(usage, '..foo = "foo"');
+        },
+      ),
       resolvedContext: sharedContext,
       input: withOverReactImport(/*language=dart*/ '''
           content() => (Dom.div()
@@ -754,9 +821,11 @@ void yieldAddPropPatchTests() {
 
   test('when the builder has multiple cascaded sections', () async {
     await testSuggestor(
-      suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-        migrator.yieldAddPropPatch(usage, '..foo = "foo"');
-      }),
+      suggestor: GenericMigrator(
+        migrateUsage: (migrator, usage) {
+          migrator.yieldAddPropPatch(usage, '..foo = "foo"');
+        },
+      ),
       resolvedContext: sharedContext,
       input: withOverReactImport(/*language=dart*/ '''
           content() => (Dom.div()
@@ -777,9 +846,11 @@ void yieldAddPropPatchTests() {
   group('automatically places a prop in the best location', () {
     test('when there are no special case props', () async {
       await testSuggestor(
-        suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-          migrator.yieldAddPropPatch(usage, '..foo = "foo"');
-        }),
+        suggestor: GenericMigrator(
+          migrateUsage: (migrator, usage) {
+            migrator.yieldAddPropPatch(usage, '..foo = "foo"');
+          },
+        ),
         resolvedContext: sharedContext,
         input: withOverReactImport(/*language=dart*/ '''
             content() => (Dom.div()
@@ -800,9 +871,11 @@ void yieldAddPropPatchTests() {
     group('when there are props that should remain last -', () {
       test('index assignment prop', () async {
         await testSuggestor(
-          suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-            migrator.yieldAddPropPatch(usage, '..foo = "foo"');
-          }),
+          suggestor: GenericMigrator(
+            migrateUsage: (migrator, usage) {
+              migrator.yieldAddPropPatch(usage, '..foo = "foo"');
+            },
+          ),
           resolvedContext: sharedContext,
           input: withOverReactImport(/*language=dart*/ '''
               content() => (Dom.div()
@@ -822,9 +895,11 @@ void yieldAddPropPatchTests() {
 
       test('method invocation prop', () async {
         await testSuggestor(
-          suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-            migrator.yieldAddPropPatch(usage, '..foo = "foo"');
-          }),
+          suggestor: GenericMigrator(
+            migrateUsage: (migrator, usage) {
+              migrator.yieldAddPropPatch(usage, '..foo = "foo"');
+            },
+          ),
           resolvedContext: sharedContext,
           input: withOverReactImport(/*language=dart*/ '''
               content() => (Dom.div()
@@ -844,9 +919,11 @@ void yieldAddPropPatchTests() {
 
       test('key prop', () async {
         await testSuggestor(
-          suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-            migrator.yieldAddPropPatch(usage, '..foo = "foo"');
-          }),
+          suggestor: GenericMigrator(
+            migrateUsage: (migrator, usage) {
+              migrator.yieldAddPropPatch(usage, '..foo = "foo"');
+            },
+          ),
           resolvedContext: sharedContext,
           input: withOverReactImport(/*language=dart*/ '''
               content() => (Dom.div()
@@ -866,9 +943,11 @@ void yieldAddPropPatchTests() {
 
       test('ref prop', () async {
         await testSuggestor(
-          suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-            migrator.yieldAddPropPatch(usage, '..foo = "foo"');
-          }),
+          suggestor: GenericMigrator(
+            migrateUsage: (migrator, usage) {
+              migrator.yieldAddPropPatch(usage, '..foo = "foo"');
+            },
+          ),
           resolvedContext: sharedContext,
           input: withOverReactImport(/*language=dart*/ '''
               final ref = createRef();
@@ -891,9 +970,11 @@ void yieldAddPropPatchTests() {
 
       test('but the prop is not last', () async {
         await testSuggestor(
-          suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-            migrator.yieldAddPropPatch(usage, '..foo = "foo"');
-          }),
+          suggestor: GenericMigrator(
+            migrateUsage: (migrator, usage) {
+              migrator.yieldAddPropPatch(usage, '..foo = "foo"');
+            },
+          ),
           resolvedContext: sharedContext,
           input: withOverReactImport(/*language=dart*/ '''
               content() => (Dom.div()
@@ -915,10 +996,15 @@ void yieldAddPropPatchTests() {
 
   test('when placement is NewPropPlacement.start', () async {
     await testSuggestor(
-      suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-        migrator.yieldAddPropPatch(usage, '..foo = "foo"',
-            placement: NewPropPlacement.start);
-      }),
+      suggestor: GenericMigrator(
+        migrateUsage: (migrator, usage) {
+          migrator.yieldAddPropPatch(
+            usage,
+            '..foo = "foo"',
+            placement: NewPropPlacement.start,
+          );
+        },
+      ),
       resolvedContext: sharedContext,
       input: withOverReactImport(/*language=dart*/ '''
           content() => (Dom.div()
@@ -938,10 +1024,15 @@ void yieldAddPropPatchTests() {
 
   test('when placement is NewPropPlacement.end', () async {
     await testSuggestor(
-      suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-        migrator.yieldAddPropPatch(usage, '..foo = "foo"',
-            placement: NewPropPlacement.end);
-      }),
+      suggestor: GenericMigrator(
+        migrateUsage: (migrator, usage) {
+          migrator.yieldAddPropPatch(
+            usage,
+            '..foo = "foo"',
+            placement: NewPropPlacement.end,
+          );
+        },
+      ),
       resolvedContext: sharedContext,
       input: withOverReactImport(/*language=dart*/ '''
           content() => (Dom.div()
@@ -966,9 +1057,11 @@ void yieldRemovePropPatchTests() {
   group('when the builder has more than one cascade section', () {
     test('and the first prop is removed', () async {
       await testSuggestor(
-        suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-          migrator.yieldRemovePropPatch(usage.cascadedProps.first);
-        }),
+        suggestor: GenericMigrator(
+          migrateUsage: (migrator, usage) {
+            migrator.yieldRemovePropPatch(usage.cascadedProps.first);
+          },
+        ),
         resolvedContext: sharedContext,
         input: withOverReactImport(/*language=dart*/ '''
             content() => (Dom.div()
@@ -988,9 +1081,11 @@ void yieldRemovePropPatchTests() {
 
     test('and a middle prop is removed', () async {
       await testSuggestor(
-        suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-          migrator.yieldRemovePropPatch(usage.cascadedProps.elementAt(1));
-        }),
+        suggestor: GenericMigrator(
+          migrateUsage: (migrator, usage) {
+            migrator.yieldRemovePropPatch(usage.cascadedProps.elementAt(1));
+          },
+        ),
         resolvedContext: sharedContext,
         input: withOverReactImport(/*language=dart*/ '''
             content() => (Dom.div()
@@ -1010,9 +1105,11 @@ void yieldRemovePropPatchTests() {
 
     test('and the last prop is removed', () async {
       await testSuggestor(
-        suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-          migrator.yieldRemovePropPatch(usage.cascadedProps.last);
-        }),
+        suggestor: GenericMigrator(
+          migrateUsage: (migrator, usage) {
+            migrator.yieldRemovePropPatch(usage.cascadedProps.last);
+          },
+        ),
         resolvedContext: sharedContext,
         input: withOverReactImport(/*language=dart*/ '''
             content() => (Dom.div()
@@ -1033,9 +1130,11 @@ void yieldRemovePropPatchTests() {
 
   test('when the builder has a single prop', () async {
     await testSuggestor(
-      suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-        migrator.yieldRemovePropPatch(usage.cascadedProps.single);
-      }),
+      suggestor: GenericMigrator(
+        migrateUsage: (migrator, usage) {
+          migrator.yieldRemovePropPatch(usage.cascadedProps.single);
+        },
+      ),
       resolvedContext: sharedContext,
       input: withOverReactImport(/*language=dart*/ '''
           content() => (Dom.div()
@@ -1052,17 +1151,21 @@ void yieldRemovePropPatchTests() {
 @isTestGroup
 void yieldBuilderMemberFixmePatchTests() {
   group(
-      'adds a FIXME comment to a cascaded member with a custom message,'
-      ' placing newlines properly so that the comment stays attached to the node after formatting',
-      () {
-    test('for the first cascade section', () async {
-      await testSuggestor(
-        suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-          migrator.yieldBuilderMemberFixmePatch(
-              usage.cascadedMembers.first, 'custom comment');
-        }),
-        resolvedContext: sharedContext,
-        input: withOverReactImport(/*language=dart*/ '''
+    'adds a FIXME comment to a cascaded member with a custom message,'
+    ' placing newlines properly so that the comment stays attached to the node after formatting',
+    () {
+      test('for the first cascade section', () async {
+        await testSuggestor(
+          suggestor: GenericMigrator(
+            migrateUsage: (migrator, usage) {
+              migrator.yieldBuilderMemberFixmePatch(
+                usage.cascadedMembers.first,
+                'custom comment',
+              );
+            },
+          ),
+          resolvedContext: sharedContext,
+          input: withOverReactImport(/*language=dart*/ '''
             content() {
               // Same line as builder
               (Dom.div()..id = '')();
@@ -1079,7 +1182,7 @@ void yieldBuilderMemberFixmePatchTests() {
               )();
             }
         '''),
-        expectedOutput: withOverReactImport(/*language=dart*/ '''
+          expectedOutput: withOverReactImport(/*language=dart*/ '''
             content() {
               // Same line as builder
               (Dom.div()
@@ -1103,17 +1206,21 @@ void yieldBuilderMemberFixmePatchTests() {
               )();
             }
         '''),
-      );
-    });
+        );
+      });
 
-    test('for other cascade sections', () async {
-      await testSuggestor(
-        suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-          migrator.yieldBuilderMemberFixmePatch(
-              usage.cascadedMembers.last, 'custom comment');
-        }),
-        resolvedContext: sharedContext,
-        input: withOverReactImport(/*language=dart*/ '''
+      test('for other cascade sections', () async {
+        await testSuggestor(
+          suggestor: GenericMigrator(
+            migrateUsage: (migrator, usage) {
+              migrator.yieldBuilderMemberFixmePatch(
+                usage.cascadedMembers.last,
+                'custom comment',
+              );
+            },
+          ),
+          resolvedContext: sharedContext,
+          input: withOverReactImport(/*language=dart*/ '''
             content() {
               (Dom.div()
                 ..id = ''
@@ -1121,7 +1228,7 @@ void yieldBuilderMemberFixmePatchTests() {
               )();
             }
         '''),
-        expectedOutput: withOverReactImport(/*language=dart*/ '''
+          expectedOutput: withOverReactImport(/*language=dart*/ '''
             content() {
               (Dom.div()
                 ..id = ''
@@ -1130,9 +1237,10 @@ void yieldBuilderMemberFixmePatchTests() {
               )();
             }
         '''),
-      );
-    });
-  });
+        );
+      });
+    },
+  );
 }
 
 /// The types of fix me comments that can be added to a particular prop.
@@ -1150,29 +1258,32 @@ const propFixmeMessage = <PropFixmeType, String>{
 };
 
 @isTestGroup
-void yieldPropFixmePatchTests(
-    {PropFixmeType fixmeType = PropFixmeType.custom}) {
+void yieldPropFixmePatchTests({
+  PropFixmeType fixmeType = PropFixmeType.custom,
+}) {
   final expectedMessage = propFixmeMessage[fixmeType] ?? 'custom comment';
 
   group(
-      'adds a FIXME comment to a cascaded prop with the prop name and a custom message,'
-      ' placing newlines properly so that the comment stays attached to the node after formatting',
-      () {
-    test('for the first prop', () async {
-      await testSuggestor(
-        suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-          final prop = usage.cascadedProps.first;
-          switch (fixmeType) {
-            case PropFixmeType.custom:
-              migrator.yieldPropFixmePatch(prop, expectedMessage);
-              break;
-            case PropFixmeType.manuallyMigrate:
-              migrator.yieldPropManualMigratePatch(prop);
-              break;
-          }
-        }),
-        resolvedContext: sharedContext,
-        input: withOverReactImport(/*language=dart*/ '''
+    'adds a FIXME comment to a cascaded prop with the prop name and a custom message,'
+    ' placing newlines properly so that the comment stays attached to the node after formatting',
+    () {
+      test('for the first prop', () async {
+        await testSuggestor(
+          suggestor: GenericMigrator(
+            migrateUsage: (migrator, usage) {
+              final prop = usage.cascadedProps.first;
+              switch (fixmeType) {
+                case PropFixmeType.custom:
+                  migrator.yieldPropFixmePatch(prop, expectedMessage);
+                  break;
+                case PropFixmeType.manuallyMigrate:
+                  migrator.yieldPropManualMigratePatch(prop);
+                  break;
+              }
+            },
+          ),
+          resolvedContext: sharedContext,
+          input: withOverReactImport(/*language=dart*/ '''
             content() {
               // Same line as builder
               (Dom.div()..id = '')();
@@ -1189,7 +1300,7 @@ void yieldPropFixmePatchTests(
               )();
             }
         '''),
-        expectedOutput: withOverReactImport('''
+          expectedOutput: withOverReactImport('''
             content() {
               // Same line as builder
               (Dom.div()
@@ -1213,24 +1324,26 @@ void yieldPropFixmePatchTests(
               )();
             }
         '''),
-      );
-    });
+        );
+      });
 
-    test('for other props', () async {
-      await testSuggestor(
-        suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-          final prop = usage.cascadedProps.last;
-          switch (fixmeType) {
-            case PropFixmeType.custom:
-              migrator.yieldPropFixmePatch(prop, expectedMessage);
-              break;
-            case PropFixmeType.manuallyMigrate:
-              migrator.yieldPropManualMigratePatch(prop);
-              break;
-          }
-        }),
-        resolvedContext: sharedContext,
-        input: withOverReactImport(/*language=dart*/ '''
+      test('for other props', () async {
+        await testSuggestor(
+          suggestor: GenericMigrator(
+            migrateUsage: (migrator, usage) {
+              final prop = usage.cascadedProps.last;
+              switch (fixmeType) {
+                case PropFixmeType.custom:
+                  migrator.yieldPropFixmePatch(prop, expectedMessage);
+                  break;
+                case PropFixmeType.manuallyMigrate:
+                  migrator.yieldPropManualMigratePatch(prop);
+                  break;
+              }
+            },
+          ),
+          resolvedContext: sharedContext,
+          input: withOverReactImport(/*language=dart*/ '''
             content() {
               (Dom.div()
                 ..id = ''
@@ -1238,7 +1351,7 @@ void yieldPropFixmePatchTests(
               )();
             }
         '''),
-        expectedOutput: withOverReactImport('''
+          expectedOutput: withOverReactImport('''
             content() {
               (Dom.div()
                 ..id = ''
@@ -1247,24 +1360,30 @@ void yieldPropFixmePatchTests(
               )();
             }
         '''),
-      );
-    });
-  });
+        );
+      });
+    },
+  );
 }
 
 @isTestGroup
 void yieldChildFixmePatchTests() {
   group(
-      'adds a FIXME comment to a cascaded member with a custom message,'
-      ' placing newlines properly so that the comment stays attached to the node after formatting',
-      () {
-    test('for the first child', () async {
-      await testSuggestor(
-        suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-          migrator.yieldChildFixmePatch(usage.children.first, 'custom comment');
-        }),
-        resolvedContext: sharedContext,
-        input: withOverReactImport(/*language=dart*/ '''
+    'adds a FIXME comment to a cascaded member with a custom message,'
+    ' placing newlines properly so that the comment stays attached to the node after formatting',
+    () {
+      test('for the first child', () async {
+        await testSuggestor(
+          suggestor: GenericMigrator(
+            migrateUsage: (migrator, usage) {
+              migrator.yieldChildFixmePatch(
+                usage.children.first,
+                'custom comment',
+              );
+            },
+          ),
+          resolvedContext: sharedContext,
+          input: withOverReactImport(/*language=dart*/ '''
             content() {
               // Same line as builder
               Dom.div()('child');
@@ -1288,7 +1407,7 @@ void yieldChildFixmePatchTests() {
               ]);
             }
         '''),
-        expectedOutput: withOverReactImport(/*language=dart*/ '''
+          expectedOutput: withOverReactImport(/*language=dart*/ '''
             content() {
               // Same line as builder
               Dom.div()(
@@ -1321,16 +1440,21 @@ void yieldChildFixmePatchTests() {
               ]);
             }
         '''),
-      );
-    });
+        );
+      });
 
-    test('for other children', () async {
-      await testSuggestor(
-        suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-          migrator.yieldChildFixmePatch(usage.children.last, 'custom comment');
-        }),
-        resolvedContext: sharedContext,
-        input: withOverReactImport(/*language=dart*/ '''
+      test('for other children', () async {
+        await testSuggestor(
+          suggestor: GenericMigrator(
+            migrateUsage: (migrator, usage) {
+              migrator.yieldChildFixmePatch(
+                usage.children.last,
+                'custom comment',
+              );
+            },
+          ),
+          resolvedContext: sharedContext,
+          input: withOverReactImport(/*language=dart*/ '''
             content() {
               // Same line as builder
               Dom.div()(1, 2);
@@ -1342,7 +1466,7 @@ void yieldChildFixmePatchTests() {
               );
             }
         '''),
-        expectedOutput: withOverReactImport(/*language=dart*/ '''
+          expectedOutput: withOverReactImport(/*language=dart*/ '''
             content() {
               // Same line as builder
               Dom.div()(
@@ -1358,17 +1482,20 @@ void yieldChildFixmePatchTests() {
               );
             }
         '''),
-      );
-    });
-  });
+        );
+      });
+    },
+  );
 }
 
 void yieldRemoveChildPatchTests() {
   test('when it is the only child', () async {
     await testSuggestor(
-      suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-        migrator.yieldRemoveChildPatch(usage.children.single.node);
-      }),
+      suggestor: GenericMigrator(
+        migrateUsage: (migrator, usage) {
+          migrator.yieldRemoveChildPatch(usage.children.single.node);
+        },
+      ),
       resolvedContext: sharedContext,
       input: withOverReactImport(/*language=dart*/ '''
           content() => [
@@ -1396,9 +1523,11 @@ void yieldRemoveChildPatchTests() {
   group('when there are multiple children', () {
     test('last child', () async {
       await testSuggestor(
-        suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-          migrator.yieldRemoveChildPatch(usage.children.last.node);
-        }),
+        suggestor: GenericMigrator(
+          migrateUsage: (migrator, usage) {
+            migrator.yieldRemoveChildPatch(usage.children.last.node);
+          },
+        ),
         resolvedContext: sharedContext,
         input: withOverReactImport(/*language=dart*/ '''
             content() => [
@@ -1431,9 +1560,11 @@ void yieldRemoveChildPatchTests() {
 
     test('first child', () async {
       await testSuggestor(
-        suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-          migrator.yieldRemoveChildPatch(usage.children.first.node);
-        }),
+        suggestor: GenericMigrator(
+          migrateUsage: (migrator, usage) {
+            migrator.yieldRemoveChildPatch(usage.children.first.node);
+          },
+        ),
         resolvedContext: sharedContext,
         input: withOverReactImport(/*language=dart*/ '''
             content() => [
@@ -1469,9 +1600,11 @@ void yieldRemoveChildPatchTests() {
 void yieldAddChildPatchTests() {
   test('when there are no existing children', () async {
     await testSuggestor(
-      suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-        migrator.yieldAddChildPatch(usage, 'Dom.div()(\'A child\')');
-      }),
+      suggestor: GenericMigrator(
+        migrateUsage: (migrator, usage) {
+          migrator.yieldAddChildPatch(usage, 'Dom.div()(\'A child\')');
+        },
+      ),
       resolvedContext: sharedContext,
       input: withOverReactImport(/*language=dart*/ '''
           content() => [
@@ -1495,9 +1628,11 @@ void yieldAddChildPatchTests() {
   group('when there are multiple children', () {
     test('and a string child is being added', () async {
       await testSuggestor(
-        suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-          migrator.yieldAddChildPatch(usage, "'A child'");
-        }),
+        suggestor: GenericMigrator(
+          migrateUsage: (migrator, usage) {
+            migrator.yieldAddChildPatch(usage, "'A child'");
+          },
+        ),
         resolvedContext: sharedContext,
         input: withOverReactImport(/*language=dart*/ '''
             content() => [
@@ -1534,9 +1669,11 @@ void yieldAddChildPatchTests() {
 
     test('and a basic component usage is being added', () async {
       await testSuggestor(
-        suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-          migrator.yieldAddChildPatch(usage, 'Dom.div()(\'A child\')');
-        }),
+        suggestor: GenericMigrator(
+          migrateUsage: (migrator, usage) {
+            migrator.yieldAddChildPatch(usage, 'Dom.div()(\'A child\')');
+          },
+        ),
         resolvedContext: sharedContext,
         input: withOverReactImport(/*language=dart*/ '''
             content() => [
@@ -1573,10 +1710,14 @@ void yieldAddChildPatchTests() {
 
     test('and a complicated component usage is being added', () async {
       await testSuggestor(
-        suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-          migrator.yieldAddChildPatch(usage,
-              '(Dom.div()..dom.href = content..style = {\'color\': \'blue\'})(\'A child\')');
-        }),
+        suggestor: GenericMigrator(
+          migrateUsage: (migrator, usage) {
+            migrator.yieldAddChildPatch(
+              usage,
+              '(Dom.div()..dom.href = content..style = {\'color\': \'blue\'})(\'A child\')',
+            );
+          },
+        ),
         resolvedContext: sharedContext,
         input: withOverReactImport(/*language=dart*/ '''
             content(dynamic content) => [
@@ -1616,12 +1757,18 @@ void yieldAddChildPatchTests() {
 void yieldPropPatchTests() {
   test('throws if neither arguments are specified', () async {
     await sharedContext.getPatches(
-      GenericMigrator(migrateUsage: boundExpectAsync2((migrator, usage) {
-        expect(
+      GenericMigrator(
+        migrateUsage: boundExpectAsync2((migrator, usage) {
+          expect(
             () => migrator.yieldPropPatch(usage.cascadedProps.first),
-            throwsA(isArgumentError
-                .havingToStringValue(contains('either newName or newRhs'))));
-      })),
+            throwsA(
+              isArgumentError.havingToStringValue(
+                contains('either newName or newRhs'),
+              ),
+            ),
+          );
+        }),
+      ),
       withOverReactImport(/*language=dart*/ '''
           content() => (Dom.div()..id = "some_id" )();
       '''),
@@ -1630,15 +1777,19 @@ void yieldPropPatchTests() {
 
   test('inserts content', () async {
     await testSuggestor(
-      suggestor: GenericMigrator(migrateUsage: (migrator, usage) {
-        final propAt = usage.cascadedProps.elementAt;
-        migrator.yieldPropPatch(propAt(0), newName: 'newName0');
-        migrator.yieldPropPatch(propAt(1), newRhs: 'newRhs1');
-        migrator.yieldPropPatch(propAt(2),
+      suggestor: GenericMigrator(
+        migrateUsage: (migrator, usage) {
+          final propAt = usage.cascadedProps.elementAt;
+          migrator.yieldPropPatch(propAt(0), newName: 'newName0');
+          migrator.yieldPropPatch(propAt(1), newRhs: 'newRhs1');
+          migrator.yieldPropPatch(
+            propAt(2),
             newName: 'newName2',
             newRhs: 'newRhs2',
-            additionalCascadeSection: '..additionalCascade');
-      }),
+            additionalCascadeSection: '..additionalCascade',
+          );
+        },
+      ),
       resolvedContext: sharedContext,
       input: withOverReactImport(/*language=dart*/ '''
           content() => (Dom.div()
@@ -1659,10 +1810,10 @@ void yieldPropPatchTests() {
   });
 }
 
-typedef OnMigrateUsage = void Function(
-    GenericMigrator migrator, FluentComponentUsage usage);
-typedef OnShouldMigrateUsage = bool Function(
-    GenericMigrator migrator, FluentComponentUsage usage);
+typedef OnMigrateUsage =
+    void Function(GenericMigrator migrator, FluentComponentUsage usage);
+typedef OnShouldMigrateUsage =
+    bool Function(GenericMigrator migrator, FluentComponentUsage usage);
 
 class GenericMigrator extends ComponentUsageMigrator {
   final OnMigrateUsage? _onMigrateUsage;
@@ -1671,8 +1822,8 @@ class GenericMigrator extends ComponentUsageMigrator {
   GenericMigrator({
     OnMigrateUsage? migrateUsage,
     OnShouldMigrateUsage? shouldMigrateUsage,
-  })  : _onMigrateUsage = migrateUsage,
-        _onShouldMigrateUsage = shouldMigrateUsage;
+  }) : _onMigrateUsage = migrateUsage,
+       _onShouldMigrateUsage = shouldMigrateUsage;
 
   @override
   bool shouldMigrateUsage(usage) =>

--- a/test/util/component_usage_test.dart
+++ b/test/util/component_usage_test.dart
@@ -33,109 +33,134 @@ void main() {
         });
 
         group(
-            'accurately detects and collects information on usages of OverReact components:',
-            () {
-          group('components with no cascades:', () {
-            buildersToTest.forEach((name, builderSource) {
-              test('$name', () async {
-                final source = '${builderSource.source}()';
+          'accurately detects and collects information on usages of OverReact components:',
+          () {
+            group('components with no cascades:', () {
+              buildersToTest.forEach((name, builderSource) {
+                test('$name', () async {
+                  final source = '${builderSource.source}()';
 
-                final expressionNode = await parseInvocation(source,
-                    imports: builderSource.imports, isResolved: isResolved);
+                  final expressionNode = await parseInvocation(
+                    source,
+                    imports: builderSource.imports,
+                    isResolved: isResolved,
+                  );
+                  final componentUsage = getComponentUsage(expressionNode);
+
+                  checkComponentUsage(componentUsage, builderSource, source);
+                });
+              });
+            });
+
+            group('components with cascades:', () {
+              buildersToTest.forEach((name, builderSource) {
+                test('$name', () async {
+                  var cascadeSource = '${builderSource.source}..id = \'123\'';
+                  var source = '($cascadeSource)()';
+
+                  var expressionNode = await parseInvocation(
+                    source,
+                    imports: builderSource.imports,
+                    isResolved: isResolved,
+                  );
+                  var componentUsage = getComponentUsage(expressionNode);
+
+                  checkComponentUsage(
+                    componentUsage,
+                    builderSource,
+                    source,
+                    cascadeSource,
+                  );
+                });
+              });
+            });
+
+            group('components with no cascade but extra parens:', () {
+              buildersToTest.forEach((name, builderSource) {
+                test('$name', () async {
+                  var source = '(${builderSource.source})()';
+
+                  var expressionNode = await parseInvocation(
+                    source,
+                    imports: builderSource.imports,
+                    isResolved: isResolved,
+                  );
+                  var componentUsage = getComponentUsage(expressionNode);
+
+                  checkComponentUsage(componentUsage, builderSource, source);
+                });
+              });
+            });
+
+            // The not-resolved test case for this test is slightly redundant with
+            // some of the cases in the next group, but the resolved case is important here.
+            test(
+              'when containing a blocked method name (unless unresolved)',
+              () async {
+                const testCase = BuilderTestCase(
+                  source: 'toBuilder()',
+                  imports: fooComponents,
+                  componentName: 'Foo',
+                  unresolvedComponentName: 'toBuilder',
+                  factoryName: 'toBuilder',
+                  propsName: 'FooProps',
+                  isDom: false,
+                  isSvg: false,
+                );
+                final source = '(${testCase.source})()';
+
+                final expressionNode = await parseInvocation(
+                  source,
+                  imports: testCase.imports,
+                  isResolved: isResolved,
+                );
                 final componentUsage = getComponentUsage(expressionNode);
 
-                checkComponentUsage(componentUsage, builderSource, source);
-              });
-            });
-          });
-
-          group('components with cascades:', () {
-            buildersToTest.forEach((name, builderSource) {
-              test('$name', () async {
-                var cascadeSource = '${builderSource.source}..id = \'123\'';
-                var source = '($cascadeSource)()';
-
-                var expressionNode = await parseInvocation(source,
-                    imports: builderSource.imports, isResolved: isResolved);
-                var componentUsage = getComponentUsage(expressionNode);
-
-                checkComponentUsage(
-                    componentUsage, builderSource, source, cascadeSource);
-              });
-            });
-          });
-
-          group('components with no cascade but extra parens:', () {
-            buildersToTest.forEach((name, builderSource) {
-              test('$name', () async {
-                var source = '(${builderSource.source})()';
-
-                var expressionNode = await parseInvocation(source,
-                    imports: builderSource.imports, isResolved: isResolved);
-                var componentUsage = getComponentUsage(expressionNode);
-
-                checkComponentUsage(componentUsage, builderSource, source);
-              });
-            });
-          });
-
-          // The not-resolved test case for this test is slightly redundant with
-          // some of the cases in the next group, but the resolved case is important here.
-          test('when containing a blocked method name (unless unresolved)',
-              () async {
-            const testCase = BuilderTestCase(
-              source: 'toBuilder()',
-              imports: fooComponents,
-              componentName: 'Foo',
-              unresolvedComponentName: 'toBuilder',
-              factoryName: 'toBuilder',
-              propsName: 'FooProps',
-              isDom: false,
-              isSvg: false,
+                if (isResolved) {
+                  checkComponentUsage(componentUsage, testCase, source);
+                } else {
+                  expect(
+                    componentUsage,
+                    isNull,
+                    reason:
+                        'should not be detected as a usage when not resolved',
+                  );
+                }
+              },
             );
-            final source = '(${testCase.source})()';
-
-            final expressionNode = await parseInvocation(source,
-                imports: testCase.imports, isResolved: isResolved);
-            final componentUsage = getComponentUsage(expressionNode);
-
-            if (isResolved) {
-              checkComponentUsage(componentUsage, testCase, source);
-            } else {
-              expect(componentUsage, isNull,
-                  reason:
-                      'should not be detected as a usage when not resolved');
-            }
-          });
-        });
+          },
+        );
 
         group(
-            'returns null for invocations that are not fluent interface usages:',
-            () {
-          const {
-            'Dom.h1()': 'not full invocation',
-            'Foo()': 'not full invocation',
-            'fooFactory()': 'not full invocation',
-            'foo()': 'not a valid builder',
-            'foo.bar()': 'not a valid builder',
-            'foo().bar()': 'not a valid builder',
-            'foo.bar.baz()': 'not a valid builder',
-            'foo()()': 'not a valid builder',
-            '_foo()()': 'not a valid builder',
-            'toBuilder()': 'blocked method name',
-            'toBuilder()()': 'blocked method name',
-            'foo.toBuilder()': 'blocked method name',
-            'foo().toBuilder()': 'blocked method name',
-            'foo.bar.toBuilder()': 'blocked method name',
-          }.forEach((source, reason) {
-            test('`$source`', () async {
-              final expressionNode =
-                  await parseInvocation(source, isResolved: isResolved);
-              var componentUsage = getComponentUsage(expressionNode);
-              expect(componentUsage, isNull, reason: '$source is $reason');
+          'returns null for invocations that are not fluent interface usages:',
+          () {
+            const {
+              'Dom.h1()': 'not full invocation',
+              'Foo()': 'not full invocation',
+              'fooFactory()': 'not full invocation',
+              'foo()': 'not a valid builder',
+              'foo.bar()': 'not a valid builder',
+              'foo().bar()': 'not a valid builder',
+              'foo.bar.baz()': 'not a valid builder',
+              'foo()()': 'not a valid builder',
+              '_foo()()': 'not a valid builder',
+              'toBuilder()': 'blocked method name',
+              'toBuilder()()': 'blocked method name',
+              'foo.toBuilder()': 'blocked method name',
+              'foo().toBuilder()': 'blocked method name',
+              'foo.bar.toBuilder()': 'blocked method name',
+            }.forEach((source, reason) {
+              test('`$source`', () async {
+                final expressionNode = await parseInvocation(
+                  source,
+                  isResolved: isResolved,
+                );
+                var componentUsage = getComponentUsage(expressionNode);
+                expect(componentUsage, isNull, reason: '$source is $reason');
+              });
             });
-          });
-        });
+          },
+        );
       }
 
       group('when the AST is resolved', () {
@@ -162,53 +187,60 @@ void main() {
           });
         });
 
-        group('when there are multiple children, and only one is a component',
-            () {
+        group(
+          'when there are multiple children, and only one is a component',
+          () {
+            buildersToTest.forEach((name, builderSource) {
+              test('and the child component uses a $name', () async {
+                var childSource = '${builderSource.source}()';
+                var source =
+                    'SomeOtherComponent()("other child 1", $childSource, "other child 2")';
+
+                final expressionNode = await parseInvocation(source);
+
+                expect(hasChildComponent(expressionNode.argumentList), isTrue);
+              });
+            });
+          },
+        );
+      });
+
+      group(
+        'even when the components have any number of extra wrapping parens',
+        () {
           buildersToTest.forEach((name, builderSource) {
             test('and the child component uses a $name', () async {
               var childSource = '${builderSource.source}()';
-              var source =
-                  'SomeOtherComponent()("other child 1", $childSource, "other child 2")';
+              var childSourceWithExtraParens = '((($childSource)))';
+              var source = 'SomeOtherComponent()($childSourceWithExtraParens)';
 
               final expressionNode = await parseInvocation(source);
 
               expect(hasChildComponent(expressionNode.argumentList), isTrue);
             });
           });
-        });
-      });
-
-      group('even when the components have any number of extra wrapping parens',
-          () {
-        buildersToTest.forEach((name, builderSource) {
-          test('and the child component uses a $name', () async {
-            var childSource = '${builderSource.source}()';
-            var childSourceWithExtraParens = '((($childSource)))';
-            var source = 'SomeOtherComponent()($childSourceWithExtraParens)';
-
-            final expressionNode = await parseInvocation(source);
-
-            expect(hasChildComponent(expressionNode.argumentList), isTrue);
-          });
-        });
-      });
-
-      test('returns false when there are only non-component arguments',
-          () async {
-        var source = 'SomeOtherComponent()(1, "non-component child", {})';
-        final expressionNode = await parseInvocation(source);
-
-        expect(hasChildComponent(expressionNode.argumentList), isFalse);
-      });
+        },
+      );
 
       test(
-          'returns false when there are nested components, but no top-level ones',
-          () async {
-        var source = 'SomeOtherComponent()([Foo()()])';
-        final expressionNode = await parseInvocation(source);
+        'returns false when there are only non-component arguments',
+        () async {
+          var source = 'SomeOtherComponent()(1, "non-component child", {})';
+          final expressionNode = await parseInvocation(source);
 
-        expect(hasChildComponent(expressionNode.argumentList), isFalse);
-      });
+          expect(hasChildComponent(expressionNode.argumentList), isFalse);
+        },
+      );
+
+      test(
+        'returns false when there are nested components, but no top-level ones',
+        () async {
+          var source = 'SomeOtherComponent()([Foo()()])';
+          final expressionNode = await parseInvocation(source);
+
+          expect(hasChildComponent(expressionNode.argumentList), isFalse);
+        },
+      );
     });
 
     group('identifyUsage', () {
@@ -220,26 +252,36 @@ void main() {
             late InvocationExpression expressionNode;
 
             setUpAll(() async {
-              expressionNode = await parseInvocation(source,
-                  imports: builderSource.imports, isResolved: true);
+              expressionNode = await parseInvocation(
+                source,
+                imports: builderSource.imports,
+                isResolved: true,
+              );
             });
 
             test('node is a $name which is already a component usage', () {
               final componentUsage = identifyUsage(expressionNode);
               checkComponentUsage(
-                  componentUsage, builderSource, source, cascadeSource);
+                componentUsage,
+                builderSource,
+                source,
+                cascadeSource,
+              );
             });
 
             group('node inside $name', () {
               test('is props cascade expression', () {
-                final cascadeExpression = getComponentUsage(expressionNode)
-                    ?.cascadeExpression
-                    ?.cascadeSections
-                    .firstOrNull;
+                final cascadeExpression = getComponentUsage(
+                  expressionNode,
+                )?.cascadeExpression?.cascadeSections.firstOrNull;
                 expect(cascadeExpression?.toSource(), '..id = \'123\'');
                 final componentUsage = identifyUsage(cascadeExpression);
                 checkComponentUsage(
-                    componentUsage, builderSource, source, cascadeSource);
+                  componentUsage,
+                  builderSource,
+                  source,
+                  cascadeSource,
+                );
               });
 
               test('is a child should return null', () {
@@ -266,47 +308,60 @@ void main() {
               );
 
               expect(
-                  expressionNode.argumentList.arguments.firstOrNull, isNotNull);
-              expect(expressionNode.argumentList.arguments.firstOrNull,
-                  isA<InvocationExpression>());
-              childExpression = expressionNode
-                  .argumentList.arguments.firstOrNull as InvocationExpression?;
+                expressionNode.argumentList.arguments.firstOrNull,
+                isNotNull,
+              );
+              expect(
+                expressionNode.argumentList.arguments.firstOrNull,
+                isA<InvocationExpression>(),
+              );
+              childExpression =
+                  expressionNode.argumentList.arguments.firstOrNull
+                      as InvocationExpression?;
               expect(childExpression?.toSource(), childSource);
             });
 
             test('and node is the parent component', () {
               final componentUsage = identifyUsage(expressionNode);
               checkComponentUsage(
-                  componentUsage,
-                  BuilderTestCase(
-                    source: 'Bar()',
-                    imports: '',
-                    componentName: 'Bar',
-                    unresolvedComponentName: 'Bar',
-                    factoryName: 'Bar',
-                    propsName: 'BarProps',
-                    isDom: false,
-                    isSvg: false,
-                  ),
-                  nestedSource);
+                componentUsage,
+                BuilderTestCase(
+                  source: 'Bar()',
+                  imports: '',
+                  componentName: 'Bar',
+                  unresolvedComponentName: 'Bar',
+                  factoryName: 'Bar',
+                  propsName: 'BarProps',
+                  isDom: false,
+                  isSvg: false,
+                ),
+                nestedSource,
+              );
             });
 
             test('and node is the child component', () {
               final componentUsage = identifyUsage(childExpression);
               checkComponentUsage(
-                  componentUsage, builderSource, childSource, cascadeSource);
+                componentUsage,
+                builderSource,
+                childSource,
+                cascadeSource,
+              );
             });
 
             group('and the node inside the child component', () {
               test('is props cascade expression', () {
-                final cascadeExpression = getComponentUsage(childExpression!)
-                    ?.cascadeExpression
-                    ?.cascadeSections
-                    .firstOrNull;
+                final cascadeExpression = getComponentUsage(
+                  childExpression!,
+                )?.cascadeExpression?.cascadeSections.firstOrNull;
                 expect(cascadeExpression?.toSource(), '..id = \'123\'');
                 final componentUsage = identifyUsage(cascadeExpression);
                 checkComponentUsage(
-                    componentUsage, builderSource, childSource, cascadeSource);
+                  componentUsage,
+                  builderSource,
+                  childSource,
+                  cascadeSource,
+                );
               });
 
               test('is a child should return null', () {
@@ -351,15 +406,17 @@ void main() {
         }
 
         test('and node is an invocation expression', () async {
-          final expressionNode =
-              await parseInvocation('Foo.foo(() => \'abc\')');
+          final expressionNode = await parseInvocation(
+            'Foo.foo(() => \'abc\')',
+          );
           final componentUsage = identifyUsage(expressionNode);
           expect(componentUsage, isNull);
         });
 
         test('and node is an argument of an invocation expression', () async {
-          final expressionNode =
-              await parseInvocation('Foo.foo(() => \'abc\')');
+          final expressionNode = await parseInvocation(
+            'Foo.foo(() => \'abc\')',
+          );
           final arg = expressionNode.argumentList.arguments.firstOrNull;
           expect(arg, isNotNull);
           final componentUsage = identifyUsage(arg);
@@ -384,8 +441,11 @@ void main() {
                 componentUsage?.factoryTopLevelVariableElement,
                 // Only resolved component factories will have `factoryTopLevelVariableElement`
                 name.contains('component factory')
-                    ? isA<TopLevelVariableElement>().having((f) => f.name,
-                        'name', equals(builderSource.componentName))
+                    ? isA<TopLevelVariableElement>().having(
+                        (f) => f.name,
+                        'name',
+                        equals(builderSource.componentName),
+                      )
                     : isNull,
               );
             });
@@ -393,9 +453,11 @@ void main() {
         });
 
         test('when the AST is not resolved', () async {
-          final usage = getComponentUsage(await parseInvocation(r'''
+          final usage = getComponentUsage(
+            await parseInvocation(r'''
                 Foo()()
-            '''))!;
+            '''),
+          )!;
 
           expect(usage.factoryTopLevelVariableElement, isNull);
         });
@@ -414,24 +476,30 @@ void main() {
 
               expect(
                 componentUsage.propsClassElement,
-                isA<InterfaceElement>()
-                    .having((c) => c.name, 'name', builderSource.propsName),
+                isA<InterfaceElement>().having(
+                  (c) => c.name,
+                  'name',
+                  builderSource.propsName,
+                ),
               );
               expect(
                 componentUsage.builderType,
                 isA<DartType>().having(
-                    (t) => t.getDisplayString(withNullability: false),
-                    'display name',
-                    builderSource.propsName),
+                  (t) => t.getDisplayString(withNullability: false),
+                  'display name',
+                  builderSource.propsName,
+                ),
               );
             });
           });
         });
 
         test('when the AST is not resolved', () async {
-          final usage = getComponentUsage(await parseInvocation(r'''
+          final usage = getComponentUsage(
+            await parseInvocation(r'''
                 Foo()()
-            '''))!;
+            '''),
+          )!;
 
           expect(usage.propsClassElement, isNull);
           expect(usage.builderType, isNull);
@@ -443,7 +511,8 @@ void main() {
           late FluentComponentUsage usage;
 
           setUpAll(() async {
-            usage = getComponentUsage(await parseInvocation('''
+            usage = getComponentUsage(
+              await parseInvocation('''
                 (Foo()
                   ..setter1 = null
                   ..getter1
@@ -464,92 +533,111 @@ void main() {
                   ..["indexRead2"]
                   ..methodInvocation2(null)
                 )()
-            ''', isResolved: isResolved))!;
+            ''', isResolved: isResolved),
+            )!;
           });
 
-          group('return the expected values for different types of cascades',
-              () {
-            test('cascadedSetters', () {
-              expect(usage.cascadedProps, [
-                isA<PropAssignment>().havingStringName('setter1'),
-                isA<PropAssignment>().havingStringName('prefixedSetter1'),
-                isA<PropAssignment>().havingStringName('setter2'),
-                isA<PropAssignment>().havingStringName('prefixedSetter2'),
-              ]);
-            });
+          group(
+            'return the expected values for different types of cascades',
+            () {
+              test('cascadedSetters', () {
+                expect(usage.cascadedProps, [
+                  isA<PropAssignment>().havingStringName('setter1'),
+                  isA<PropAssignment>().havingStringName('prefixedSetter1'),
+                  isA<PropAssignment>().havingStringName('setter2'),
+                  isA<PropAssignment>().havingStringName('prefixedSetter2'),
+                ]);
+              });
 
-            test('cascadedGetters', () {
-              expect(usage.cascadedGetters, [
-                isA<PropRead>().havingStringName('getter1'),
-                isA<PropRead>().havingStringName('prefixedGetter1'),
-                isA<PropRead>().havingStringName('getter2'),
-                isA<PropRead>().havingStringName('prefixedGetter2'),
-              ]);
-            });
+              test('cascadedGetters', () {
+                expect(usage.cascadedGetters, [
+                  isA<PropRead>().havingStringName('getter1'),
+                  isA<PropRead>().havingStringName('prefixedGetter1'),
+                  isA<PropRead>().havingStringName('getter2'),
+                  isA<PropRead>().havingStringName('prefixedGetter2'),
+                ]);
+              });
 
-            test('cascadedIndexAssignments', () {
-              expect(usage.cascadedIndexAssignments, [
-                isA<IndexPropAssignment>()
-                    .havingIndexValueSource('"indexAssignment1"'),
-                isA<IndexPropAssignment>()
-                    .havingIndexValueSource('"indexAssignment2"'),
-              ]);
-            });
+              test('cascadedIndexAssignments', () {
+                expect(usage.cascadedIndexAssignments, [
+                  isA<IndexPropAssignment>().havingIndexValueSource(
+                    '"indexAssignment1"',
+                  ),
+                  isA<IndexPropAssignment>().havingIndexValueSource(
+                    '"indexAssignment2"',
+                  ),
+                ]);
+              });
 
-            test('cascadedMethodInvocations', () {
-              expect(usage.cascadedMethodInvocations, [
-                isA<BuilderMethodInvocation>()
-                    .havingStringName('methodInvocation1'),
-                isA<BuilderMethodInvocation>()
-                    .havingStringName('methodInvocation2'),
-              ]);
-            });
-          });
+              test('cascadedMethodInvocations', () {
+                expect(usage.cascadedMethodInvocations, [
+                  isA<BuilderMethodInvocation>().havingStringName(
+                    'methodInvocation1',
+                  ),
+                  isA<BuilderMethodInvocation>().havingStringName(
+                    'methodInvocation2',
+                  ),
+                ]);
+              });
+            },
+          );
 
           test(
-              'cascadedMembers returns all values for different types of cascades,'
-              ' in the order they appeared in the original source', () {
-            expect(usage.cascadedMembers, [
-              // "1"s
-              isA<PropAssignment>().havingStringName('setter1'),
-              isA<PropRead>().havingStringName('getter1'),
-              isA<PropAssignment>().havingStringName('prefixedSetter1'),
-              isA<PropRead>().havingStringName('prefixedGetter1'),
-              isA<IndexPropAssignment>()
-                  .havingIndexValueSource('"indexAssignment1"'),
-              isA<BuilderMemberAccess>().havingSource('..["indexRead1"]'),
-              isA<BuilderMethodInvocation>()
-                  .havingStringName('methodInvocation1'),
-              // "2"s
-              isA<PropAssignment>().havingStringName('setter2'),
-              isA<PropRead>().havingStringName('getter2'),
-              isA<PropAssignment>().havingStringName('prefixedSetter2'),
-              isA<PropRead>().havingStringName('prefixedGetter2'),
-              isA<IndexPropAssignment>()
-                  .havingIndexValueSource('"indexAssignment2"'),
-              isA<BuilderMemberAccess>().havingSource('..["indexRead2"]'),
-              isA<BuilderMethodInvocation>()
-                  .havingStringName('methodInvocation2'),
-            ]);
-            expect(
-                usage.cascadedMembers, hasLength(usage.cascadeSections.length),
-                reason: 'all cascade sections should map to a cascaded member');
-          });
+            'cascadedMembers returns all values for different types of cascades,'
+            ' in the order they appeared in the original source',
+            () {
+              expect(usage.cascadedMembers, [
+                // "1"s
+                isA<PropAssignment>().havingStringName('setter1'),
+                isA<PropRead>().havingStringName('getter1'),
+                isA<PropAssignment>().havingStringName('prefixedSetter1'),
+                isA<PropRead>().havingStringName('prefixedGetter1'),
+                isA<IndexPropAssignment>().havingIndexValueSource(
+                  '"indexAssignment1"',
+                ),
+                isA<BuilderMemberAccess>().havingSource('..["indexRead1"]'),
+                isA<BuilderMethodInvocation>().havingStringName(
+                  'methodInvocation1',
+                ),
+                // "2"s
+                isA<PropAssignment>().havingStringName('setter2'),
+                isA<PropRead>().havingStringName('getter2'),
+                isA<PropAssignment>().havingStringName('prefixedSetter2'),
+                isA<PropRead>().havingStringName('prefixedGetter2'),
+                isA<IndexPropAssignment>().havingIndexValueSource(
+                  '"indexAssignment2"',
+                ),
+                isA<BuilderMemberAccess>().havingSource('..["indexRead2"]'),
+                isA<BuilderMethodInvocation>().havingStringName(
+                  'methodInvocation2',
+                ),
+              ]);
+              expect(
+                usage.cascadedMembers,
+                hasLength(usage.cascadeSections.length),
+                reason: 'all cascade sections should map to a cascaded member',
+              );
+            },
+          );
         });
 
         group('children', () {
           test('no arguments', () async {
-            final usage = getComponentUsage(await parseInvocation('''
+            final usage = getComponentUsage(
+              await parseInvocation('''
                 Foo()()
-            ''', isResolved: isResolved))!;
+            ''', isResolved: isResolved),
+            )!;
             expect(usage.children, isEmpty);
           });
 
           group('variadic children', () {
             test('single argument', () async {
-              final usage = getComponentUsage(await parseInvocation('''
+              final usage = getComponentUsage(
+                await parseInvocation('''
                   Foo()(Dom.h1()())
-              ''', isResolved: isResolved))!;
+              ''', isResolved: isResolved),
+              )!;
               expect(usage.children, [
                 isA<ExpressionComponentChild>()
                     .havingSource('Dom.h1()()')
@@ -558,9 +646,11 @@ void main() {
             });
 
             test('multiple arguments', () async {
-              final usage = getComponentUsage(await parseInvocation('''
+              final usage = getComponentUsage(
+                await parseInvocation('''
                   Foo()(Dom.h1()(), 2, "3")
-              ''', isResolved: isResolved))!;
+              ''', isResolved: isResolved),
+              )!;
               expect(usage.children, [
                 isA<ExpressionComponentChild>()
                     .havingSource('Dom.h1()()')
@@ -577,9 +667,11 @@ void main() {
 
           group('children within single list literal', () {
             test('containing only expressions', () async {
-              final usage = getComponentUsage(await parseInvocation('''
+              final usage = getComponentUsage(
+                await parseInvocation('''
                   Foo()([Dom.h1()(), 2, "3"])
-              ''', isResolved: isResolved))!;
+              ''', isResolved: isResolved),
+              )!;
               expect(usage.children, [
                 isA<ExpressionComponentChild>()
                     .havingSource('Dom.h1()()')
@@ -594,7 +686,8 @@ void main() {
             });
 
             test('containing expressions and collection elements', () async {
-              final usage = getComponentUsage(await parseInvocation('''
+              final usage = getComponentUsage(
+                await parseInvocation('''
                   Foo()([
                     "expression",
                     ...someChildren,
@@ -602,27 +695,34 @@ void main() {
                     if (condition) ...someChildren,
                     for (final item in items) renderChild(child),
                   ])
-              ''', isResolved: isResolved))!;
+              ''', isResolved: isResolved),
+              )!;
               expect(usage.children, [
                 isA<ExpressionComponentChild>()
                     .havingSource('"expression"')
                     .havingIsVariadic(isFalse),
-                isA<CollectionElementComponentChild>()
-                    .havingSource('...someChildren'),
-                isA<CollectionElementComponentChild>()
-                    .havingSource('if (condition) someChild'),
-                isA<CollectionElementComponentChild>()
-                    .havingSource('if (condition) ...someChildren'),
                 isA<CollectionElementComponentChild>().havingSource(
-                    'for (final item in items) renderChild(child)'),
+                  '...someChildren',
+                ),
+                isA<CollectionElementComponentChild>().havingSource(
+                  'if (condition) someChild',
+                ),
+                isA<CollectionElementComponentChild>().havingSource(
+                  'if (condition) ...someChildren',
+                ),
+                isA<CollectionElementComponentChild>().havingSource(
+                  'for (final item in items) renderChild(child)',
+                ),
               ]);
             });
           });
 
           test('children within multiple list literals', () async {
-            final usage = getComponentUsage(await parseInvocation('''
+            final usage = getComponentUsage(
+              await parseInvocation('''
                 Foo()([1, 2], [3, 4])
-            ''', isResolved: isResolved))!;
+            ''', isResolved: isResolved),
+            )!;
             expect(usage.children, [
               isA<ExpressionComponentChild>()
                   .havingSource('[1, 2]')
@@ -633,27 +733,33 @@ void main() {
             ]);
           });
 
-          test('children within multiple list literals within a list literal',
-              () async {
-            final usage = getComponentUsage(await parseInvocation('''
+          test(
+            'children within multiple list literals within a list literal',
+            () async {
+              final usage = getComponentUsage(
+                await parseInvocation('''
                 Foo()([[1, 2], [3, 4]])
-            ''', isResolved: isResolved))!;
-            expect(usage.children, [
-              isA<ExpressionComponentChild>()
-                  .havingSource('[1, 2]')
-                  .havingIsVariadic(isFalse),
-              isA<ExpressionComponentChild>()
-                  .havingSource('[3, 4]')
-                  .havingIsVariadic(isFalse),
-            ]);
-          });
+            ''', isResolved: isResolved),
+              )!;
+              expect(usage.children, [
+                isA<ExpressionComponentChild>()
+                    .havingSource('[1, 2]')
+                    .havingIsVariadic(isFalse),
+                isA<ExpressionComponentChild>()
+                    .havingSource('[3, 4]')
+                    .havingIsVariadic(isFalse),
+              ]);
+            },
+          );
         });
 
         group('PropAssignment getters return the correct values', () {
           test('for a simple prop', () async {
-            final assignment = getComponentUsage(await parseInvocation('''
+            final assignment = getComponentUsage(
+              await parseInvocation('''
                 (Foo()..cascadedProp = null)()
-            ''', isResolved: isResolved))!.cascadedProps.single;
+            ''', isResolved: isResolved),
+            )!.cascadedProps.single;
 
             expect(assignment.node, hasSource('..cascadedProp = null'));
             expect(assignment.name.name, 'cascadedProp');
@@ -666,9 +772,11 @@ void main() {
           });
 
           test('for a prefixed prop', () async {
-            final assignment = getComponentUsage(await parseInvocation('''
+            final assignment = getComponentUsage(
+              await parseInvocation('''
                 (Foo()..dom.role = null)()
-            ''', isResolved: isResolved))!.cascadedProps.single;
+            ''', isResolved: isResolved),
+            )!.cascadedProps.single;
 
             expect(assignment.node, hasSource('..dom.role = null'));
             expect(assignment.name.name, 'role');
@@ -683,18 +791,22 @@ void main() {
 
         group('PropAccess getters return the correct values', () {
           test('for a simple access', () async {
-            final getter = getComponentUsage(await parseInvocation('''
+            final getter = getComponentUsage(
+              await parseInvocation('''
                 (Foo()..bar)()
-            ''', isResolved: isResolved))!.cascadedGetters.single;
+            ''', isResolved: isResolved),
+            )!.cascadedGetters.single;
 
             expect(getter.node, hasSource('..bar'));
             expect(getter.name, hasSource('bar'));
           });
 
           test('for a prefixed access', () async {
-            final getter = getComponentUsage(await parseInvocation('''
+            final getter = getComponentUsage(
+              await parseInvocation('''
                 (Foo()..bar.baz)()
-            ''', isResolved: isResolved))!.cascadedGetters.single;
+            ''', isResolved: isResolved),
+            )!.cascadedGetters.single;
 
             expect(getter.node, hasSource('..bar.baz'));
             expect(getter.name, hasSource('baz'));
@@ -702,9 +814,11 @@ void main() {
         });
 
         test('IndexPropAssignment getters return the correct values', () async {
-          final indexAssignment = getComponentUsage(await parseInvocation('''
+          final indexAssignment = getComponentUsage(
+            await parseInvocation('''
               (Foo()..["bar"] = null)()
-          ''', isResolved: isResolved))!.cascadedIndexAssignments.single;
+          ''', isResolved: isResolved),
+          )!.cascadedIndexAssignments.single;
 
           expect(indexAssignment.node, hasSource('..["bar"] = null'));
           expect(indexAssignment.leftHandSide, hasSource('..["bar"]'));
@@ -712,15 +826,19 @@ void main() {
           expect(indexAssignment.rightHandSide, hasSource('null'));
         });
 
-        test('BuilderMethodInvocation getters return the correct values',
-            () async {
-          final invocation = getComponentUsage(await parseInvocation('''
+        test(
+          'BuilderMethodInvocation getters return the correct values',
+          () async {
+            final invocation = getComponentUsage(
+              await parseInvocation('''
               (Foo()..bar())()
-          ''', isResolved: isResolved))!.cascadedMethodInvocations.single;
+          ''', isResolved: isResolved),
+            )!.cascadedMethodInvocations.single;
 
-          expect(invocation.node, hasSource('..bar()'));
-          expect(invocation.methodName, hasSource('bar'));
-        });
+            expect(invocation.node, hasSource('..bar()'));
+            expect(invocation.methodName, hasSource('bar'));
+          },
+        );
       }
 
       group('when AST is not resolved', () => sharedTests(isResolved: false));
@@ -744,28 +862,42 @@ void main() {
 
         testCasesByName.forEach((name, source) {
           test(name, () async {
-            expect(typeCategoryForReactNode(await resolveExpression(source)),
-                ReactNodeTypeCategory.primitive);
+            expect(
+              typeCategoryForReactNode(await resolveExpression(source)),
+              ReactNodeTypeCategory.primitive,
+            );
           });
         });
       });
 
-      test('returns `.reactElement` for ReactElement-typed expressions:',
-          () async {
-        final expression = await sharedContext.parseExpression('Dom.div()()',
+      test(
+        'returns `.reactElement` for ReactElement-typed expressions:',
+        () async {
+          final expression = await sharedContext.parseExpression(
+            'Dom.div()()',
             isResolved: true,
-            imports: 'import "package:over_react/over_react.dart"');
-        expect(typeCategoryForReactNode(expression),
-            ReactNodeTypeCategory.reactElement);
-      });
+            imports: 'import "package:over_react/over_react.dart"',
+          );
+          expect(
+            typeCategoryForReactNode(expression),
+            ReactNodeTypeCategory.reactElement,
+          );
+        },
+      );
 
-      test('returns `.unknown` for expressions that could not be resolved:',
-          () async {
-        final expression = await sharedContext
-            .parseExpression('someUnresolvedIdentifier', isResolved: false);
-        expect(typeCategoryForReactNode(expression),
-            ReactNodeTypeCategory.unknown);
-      });
+      test(
+        'returns `.unknown` for expressions that could not be resolved:',
+        () async {
+          final expression = await sharedContext.parseExpression(
+            'someUnresolvedIdentifier',
+            isResolved: false,
+          );
+          expect(
+            typeCategoryForReactNode(expression),
+            ReactNodeTypeCategory.unknown,
+          );
+        },
+      );
 
       group('returns `.other` for other types:', () {
         const testCasesByName = {
@@ -776,8 +908,10 @@ void main() {
 
         testCasesByName.forEach((name, source) {
           test(name, () async {
-            expect(typeCategoryForReactNode(await resolveExpression(source)),
-                ReactNodeTypeCategory.other);
+            expect(
+              typeCategoryForReactNode(await resolveExpression(source)),
+              ReactNodeTypeCategory.other,
+            );
           });
         });
       });
@@ -827,30 +961,39 @@ extension<T extends ExpressionComponentChild> on TypeMatcher<T> {
       having((c) => c.isVariadic, 'isVariadic', matcher);
 }
 
-void checkComponentUsage(FluentComponentUsage? componentUsage,
-    BuilderTestCase builderSource, String source,
-    [String? cascadeSource]) {
+void checkComponentUsage(
+  FluentComponentUsage? componentUsage,
+  BuilderTestCase builderSource,
+  String source, [
+  String? cascadeSource,
+]) {
   expect(componentUsage, isNotNull);
   componentUsage!;
   expect(componentUsage.builder.toSource(), builderSource.source);
   expect(
     componentUsage.factory,
     isA<Identifier>().having(
-        (f) => f.name,
-        'name',
-        equals(componentUsage.isBuilderResolved
+      (f) => f.name,
+      'name',
+      equals(
+        componentUsage.isBuilderResolved
             ? builderSource.factoryName
             // Remove the import namespace for unresolved AST.
-            : builderSource.factoryName.split('.').last)),
+            : builderSource.factoryName.split('.').last,
+      ),
+    ),
   );
-  expect(componentUsage.propsName,
-      componentUsage.isBuilderResolved ? builderSource.propsName : isNull);
+  expect(
+    componentUsage.propsName,
+    componentUsage.isBuilderResolved ? builderSource.propsName : isNull,
+  );
   expect(componentUsage.node.toSource(), source);
   expect(
-      componentUsage.componentName,
-      componentUsage.isBuilderResolved
-          ? builderSource.componentName
-          : builderSource.unresolvedComponentName);
+    componentUsage.componentName,
+    componentUsage.isBuilderResolved
+        ? builderSource.componentName
+        : builderSource.unresolvedComponentName,
+  );
   if (componentUsage.isBuilderResolved) {
     expect(componentUsage.isDom, builderSource.isDom);
     expect(componentUsage.isSvg, builderSource.isSvg);
@@ -997,8 +1140,11 @@ Future<InvocationExpression> parseInvocation(
   if (parsedExpression is InvocationExpression) {
     return parsedExpression;
   }
-  throw ArgumentError.value(expression, 'expression',
-      'was not a InvocationExpression; was $parsedExpression');
+  throw ArgumentError.value(
+    expression,
+    'expression',
+    'was not a InvocationExpression; was $parsedExpression',
+  );
 }
 
 /// Parses [dartSource] and returns the unresolved AST, throwing if there are any syntax errors.

--- a/test/util/element_type_helpers_test.dart
+++ b/test/util/element_type_helpers_test.dart
@@ -75,9 +75,12 @@ void main() {
       /// with generic bounds.
       DartType parameterType(String name) =>
           allDescendantsOfType<SimpleFormalParameter>(unit)
-              .singleWhere((p) => p.name?.lexeme == name, orElse: () {
-                throw StateError("Could not find variable with name '$name'");
-              })
+              .singleWhere(
+                (p) => p.name?.lexeme == name,
+                orElse: () {
+                  throw StateError("Could not find variable with name '$name'");
+                },
+              )
               .declaredElement!
               .type;
 
@@ -154,86 +157,116 @@ void main() {
       group('isOrIsSubtypeOfTypeFromPackage', () {
         test('returns true when the type is an exact match', () {
           expect(
-              parameterType('uiProps')
-                  .isOrIsSubtypeOfClassFromPackage('UiProps', 'over_react'),
-              isTrue);
+            parameterType(
+              'uiProps',
+            ).isOrIsSubtypeOfClassFromPackage('UiProps', 'over_react'),
+            isTrue,
+          );
         });
 
         test('returns true when the type is a subtype', () {
           expect(
-              parameterType('customProps')
-                  .isOrIsSubtypeOfClassFromPackage('UiProps', 'over_react'),
-              isTrue);
+            parameterType(
+              'customProps',
+            ).isOrIsSubtypeOfClassFromPackage('UiProps', 'over_react'),
+            isTrue,
+          );
         });
 
         test('returns true when the type is bounded by that type', () {
           expect(
-              parameterType('uiPropsAsBound')
-                  .isOrIsSubtypeOfClassFromPackage('UiProps', 'over_react'),
-              isTrue);
+            parameterType(
+              'uiPropsAsBound',
+            ).isOrIsSubtypeOfClassFromPackage('UiProps', 'over_react'),
+            isTrue,
+          );
         });
 
         test('returns true when the type is bounded by a subtype', () {
           expect(
-              parameterType('customPropsAsBound')
-                  .isOrIsSubtypeOfClassFromPackage('UiProps', 'over_react'),
-              isTrue);
+            parameterType(
+              'customPropsAsBound',
+            ).isOrIsSubtypeOfClassFromPackage('UiProps', 'over_react'),
+            isTrue,
+          );
         });
 
         test('returns false when the type name does not match', () {
           expect(
-              parameterType('uiProps')
-                  .isOrIsSubtypeOfClassFromPackage('NotUiProps', 'over_react'),
-              isFalse);
+            parameterType(
+              'uiProps',
+            ).isOrIsSubtypeOfClassFromPackage('NotUiProps', 'over_react'),
+            isFalse,
+          );
         });
 
         test('returns false when the package name does not match', () {
           expect(
-              parameterType('uiProps')
-                  .isOrIsSubtypeOfClassFromPackage('UiProps', 'not_over_react'),
-              isFalse);
+            parameterType(
+              'uiProps',
+            ).isOrIsSubtypeOfClassFromPackage('UiProps', 'not_over_react'),
+            isFalse,
+          );
         });
       });
 
       group('isElementFromPackage', () {
         test(
-            'returns whether a type is declared in package with the given name',
-            () async {
-          final uiPropsElement = parameterTypeElement('uiProps');
-          final mapElement = parameterTypeElement('map');
-          final customClassElement = parameterTypeElement('customClass');
+          'returns whether a type is declared in package with the given name',
+          () async {
+            final uiPropsElement = parameterTypeElement('uiProps');
+            final mapElement = parameterTypeElement('map');
+            final customClassElement = parameterTypeElement('customClass');
 
-          expect(uiPropsElement.isElementFromPackage('UiProps', 'over_react'),
-              isTrue);
+            expect(
+              uiPropsElement.isElementFromPackage('UiProps', 'over_react'),
+              isTrue,
+            );
 
-          expect(
+            expect(
               uiPropsElement.isElementFromPackage('NotUiProps', 'over_react'),
-              isFalse);
-          expect(
+              isFalse,
+            );
+            expect(
               uiPropsElement.isElementFromPackage('UiProps', 'not_over_react'),
-              isFalse);
+              isFalse,
+            );
 
-          expect(mapElement.isElementFromPackage('Map', 'over_react'), isFalse);
-          expect(
+            expect(
+              mapElement.isElementFromPackage('Map', 'over_react'),
+              isFalse,
+            );
+            expect(
               customClassElement.isElementFromPackage(
-                  'CustomClass', 'over_react'),
-              isFalse);
-        });
+                'CustomClass',
+                'over_react',
+              ),
+              isFalse,
+            );
+          },
+        );
       });
 
       group('isDeclaredInPackage', () {
         test(
-            'returns whether an element is declared in package with the given name',
-            () async {
-          final uiPropsElement = parameterTypeElement('uiProps');
-          final mapElement = parameterTypeElement('map');
-          final customClassElement = parameterTypeElement('customClass');
+          'returns whether an element is declared in package with the given name',
+          () async {
+            final uiPropsElement = parameterTypeElement('uiProps');
+            final mapElement = parameterTypeElement('map');
+            final customClassElement = parameterTypeElement('customClass');
 
-          expect(uiPropsElement.isDeclaredInPackage('over_react'), isTrue);
-          expect(uiPropsElement.isDeclaredInPackage('not_over_react'), isFalse);
-          expect(mapElement.isDeclaredInPackage('over_react'), isFalse);
-          expect(customClassElement.isDeclaredInPackage('over_react'), isFalse);
-        });
+            expect(uiPropsElement.isDeclaredInPackage('over_react'), isTrue);
+            expect(
+              uiPropsElement.isDeclaredInPackage('not_over_react'),
+              isFalse,
+            );
+            expect(mapElement.isDeclaredInPackage('over_react'), isFalse);
+            expect(
+              customClassElement.isDeclaredInPackage('over_react'),
+              isFalse,
+            );
+          },
+        );
       });
     });
   });

--- a/test/util/importer_test.dart
+++ b/test/util/importer_test.dart
@@ -24,7 +24,9 @@ void main() {
   group('importerSuggestorBuilder', () {
     final resolvedContext = SharedAnalysisContext.overReact;
     final muiImporter = importerSuggestorBuilder(
-        importUri: rmuiImportUri, importNamespace: muiNs);
+      importUri: rmuiImportUri,
+      importNamespace: muiNs,
+    );
 
     // Warm up analysis in a setUpAll so that if getting the resolved AST times out
     // (which is more common for the WSD context), it fails here instead of failing the first test.
@@ -38,82 +40,84 @@ void main() {
     );
 
     group(
-        'adds a RMUI import when there is an undefined `mui` identifier in the file',
-        () {
-      bool isFakeUriError(AnalysisError error) =>
-          error.errorCode.name.toLowerCase() == 'uri_does_not_exist' &&
-          error.message.contains('fake');
+      'adds a RMUI import when there is an undefined `mui` identifier in the file',
+      () {
+        bool isFakeUriError(AnalysisError error) =>
+            error.errorCode.name.toLowerCase() == 'uri_does_not_exist' &&
+            error.message.contains('fake');
 
-      test('when there are no other imports', () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
-              content() => mui.Button();
-          ''',
-          isExpectedError: isUndefinedMuiError,
-          expectedOutput: /*language=dart*/ '''
-              import 'package:react_material_ui/react_material_ui.dart' as mui;
-              content() => mui.Button();
-          ''',
-        );
-      });
-
-      group('when there are other imports', () {
-        test('(alphabetized before RMUI)', () async {
+        test('when there are no other imports', () async {
           await testSuggestor(
             input: /*language=dart*/ '''
-                import 'package:over_react/over_react.dart';
-            
-                content() => mui.Button();
-            ''',
+              content() => mui.Button();
+          ''',
             isExpectedError: isUndefinedMuiError,
             expectedOutput: /*language=dart*/ '''
+              import 'package:react_material_ui/react_material_ui.dart' as mui;
+              content() => mui.Button();
+          ''',
+          );
+        });
+
+        group('when there are other imports', () {
+          test('(alphabetized before RMUI)', () async {
+            await testSuggestor(
+              input: /*language=dart*/ '''
+                import 'package:over_react/over_react.dart';
+            
+                content() => mui.Button();
+            ''',
+              isExpectedError: isUndefinedMuiError,
+              expectedOutput: /*language=dart*/ '''
                 import 'package:over_react/over_react.dart';
                 import 'package:react_material_ui/react_material_ui.dart' as mui;
                 
                 content() => mui.Button();
             ''',
-          );
-        });
+            );
+          });
 
-        test('(alphabetized after RMUI)', () async {
-          await testSuggestor(
-            input: /*language=dart*/ '''
+          test('(alphabetized after RMUI)', () async {
+            await testSuggestor(
+              input: /*language=dart*/ '''
                 import 'package:z_fake_package/z_fake_package.dart';
             
                 content() => mui.Button();
             ''',
-            isExpectedError: (e) => isUndefinedMuiError(e) || isFakeUriError(e),
-            expectedOutput: /*language=dart*/ '''
+              isExpectedError: (e) =>
+                  isUndefinedMuiError(e) || isFakeUriError(e),
+              expectedOutput: /*language=dart*/ '''
                 import 'package:react_material_ui/react_material_ui.dart' as mui;
                 import 'package:z_fake_package/z_fake_package.dart';
                 
                 content() => mui.Button();
             ''',
-          );
-        });
+            );
+          });
 
-        test('(one alphabetized before and after RMUI)', () async {
-          await testSuggestor(
-            input: /*language=dart*/ '''
+          test('(one alphabetized before and after RMUI)', () async {
+            await testSuggestor(
+              input: /*language=dart*/ '''
                 import 'package:over_react/over_react.dart';
                 import 'package:z_fake_package/z_fake_package.dart';
             
                 content() => mui.Button();
             ''',
-            isExpectedError: (e) => isUndefinedMuiError(e) || isFakeUriError(e),
-            expectedOutput: /*language=dart*/ '''
+              isExpectedError: (e) =>
+                  isUndefinedMuiError(e) || isFakeUriError(e),
+              expectedOutput: /*language=dart*/ '''
                 import 'package:over_react/over_react.dart';
                 import 'package:react_material_ui/react_material_ui.dart' as mui;
                 import 'package:z_fake_package/z_fake_package.dart';
                 
                 content() => mui.Button();
             ''',
-          );
-        });
+            );
+          });
 
-        test('(more than one alphabetized before and after RMUI)', () async {
-          await testSuggestor(
-            input: /*language=dart*/ '''
+          test('(more than one alphabetized before and after RMUI)', () async {
+            await testSuggestor(
+              input: /*language=dart*/ '''
                 import 'package:over_react/over_react.dart';
                 import 'package:over_react/components.dart';
                 import 'package:z_fake_package/z_fake_package_1.dart';
@@ -121,8 +125,9 @@ void main() {
             
                 content() => mui.Button();
             ''',
-            isExpectedError: (e) => isUndefinedMuiError(e) || isFakeUriError(e),
-            expectedOutput: /*language=dart*/ '''
+              isExpectedError: (e) =>
+                  isUndefinedMuiError(e) || isFakeUriError(e),
+              expectedOutput: /*language=dart*/ '''
                 import 'package:over_react/over_react.dart';
                 import 'package:over_react/components.dart';
                 import 'package:react_material_ui/react_material_ui.dart' as mui;
@@ -131,20 +136,21 @@ void main() {
                 
                 content() => mui.Button();
             ''',
-          );
-        });
+            );
+          });
 
-        test('(a relative import, alphabetized before RMUI)', () async {
-          await testSuggestor(
-            input: /*language=dart*/ '''
+          test('(a relative import, alphabetized before RMUI)', () async {
+            await testSuggestor(
+              input: /*language=dart*/ '''
                 import 'package:over_react/over_react.dart';
                 
                 import 'a/fake_relative_file.dart';
             
                 content() => mui.Button();
             ''',
-            isExpectedError: (e) => isUndefinedMuiError(e) || isFakeUriError(e),
-            expectedOutput: /*language=dart*/ '''
+              isExpectedError: (e) =>
+                  isUndefinedMuiError(e) || isFakeUriError(e),
+              expectedOutput: /*language=dart*/ '''
                 import 'package:over_react/over_react.dart';
                 import 'package:react_material_ui/react_material_ui.dart' as mui;
                 
@@ -152,93 +158,94 @@ void main() {
                 
                 content() => mui.Button();
             ''',
-          );
-        });
+            );
+          });
 
-        test('(a dart import)', () async {
-          await testSuggestor(
-            input: /*language=dart*/ '''
+          test('(a dart import)', () async {
+            await testSuggestor(
+              input: /*language=dart*/ '''
                 import 'dart:html';
             
                 content() => mui.Button();
             ''',
-            isExpectedError: (e) => isUndefinedMuiError(e) || isFakeUriError(e),
-            expectedOutput: /*language=dart*/ '''
+              isExpectedError: (e) =>
+                  isUndefinedMuiError(e) || isFakeUriError(e),
+              expectedOutput: /*language=dart*/ '''
                 import 'dart:html';
                 
                 import 'package:react_material_ui/react_material_ui.dart' as mui;
                 
                 content() => mui.Button();
             ''',
+            );
+          });
+        });
+
+        test('when there is just a library declaration', () async {
+          await testSuggestor(
+            input: /*language=dart*/ '''
+              library lib;
+          
+              content() => mui.Button();
+          ''',
+            isExpectedError: (e) => isUndefinedMuiError(e) || isFakeUriError(e),
+            expectedOutput: /*language=dart*/ '''
+              library lib;
+          
+              import 'package:react_material_ui/react_material_ui.dart' as mui;
+              
+              content() => mui.Button();
+          ''',
           );
         });
-      });
 
-      test('when there is just a library declaration', () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
-              library lib;
-          
-              content() => mui.Button();
-          ''',
-          isExpectedError: (e) => isUndefinedMuiError(e) || isFakeUriError(e),
-          expectedOutput: /*language=dart*/ '''
-              library lib;
-          
-              import 'package:react_material_ui/react_material_ui.dart' as mui;
-              
-              content() => mui.Button();
-          ''',
-        );
-      });
-
-      test('when there are only parts', () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
+        test('when there are only parts', () async {
+          await testSuggestor(
+            input: /*language=dart*/ '''
               part 'fake_part.dart';
           
               content() => mui.Button();
           ''',
-          isExpectedError: (e) => isUndefinedMuiError(e) || isFakeUriError(e),
-          expectedOutput: /*language=dart*/ '''
+            isExpectedError: (e) => isUndefinedMuiError(e) || isFakeUriError(e),
+            expectedOutput: /*language=dart*/ '''
               import 'package:react_material_ui/react_material_ui.dart' as mui;
               
               part 'fake_part.dart';
               
               content() => mui.Button();
           ''',
-        );
-      });
+          );
+        });
 
-      test('when there are only exports', () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
+        test('when there are only exports', () async {
+          await testSuggestor(
+            input: /*language=dart*/ '''
               export 'package:over_react/over_react.dart';
           
               content() => mui.Button();
           ''',
-          isExpectedError: isUndefinedMuiError,
-          expectedOutput: /*language=dart*/ '''
+            isExpectedError: isUndefinedMuiError,
+            expectedOutput: /*language=dart*/ '''
               import 'package:react_material_ui/react_material_ui.dart' as mui;
               
               export 'package:over_react/over_react.dart';
               
               content() => mui.Button();
           ''',
-        );
-      });
+          );
+        });
 
-      test('when there are imports and parts', () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
+        test('when there are imports and parts', () async {
+          await testSuggestor(
+            input: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
               
               part 'fake_part.dart';
           
               content() => mui.Button();
           ''',
-          isExpectedError: (e) => isUndefinedMuiError(e) || isFakeUriError(e),
-          expectedOutput: /*language=dart*/ '''
+            isExpectedError: (e) => isUndefinedMuiError(e) || isFakeUriError(e),
+            expectedOutput: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
               import 'package:react_material_ui/react_material_ui.dart' as mui;
               
@@ -246,20 +253,20 @@ void main() {
               
               content() => mui.Button();
           ''',
-        );
-      });
+          );
+        });
 
-      test('when there are exports and parts', () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
+        test('when there are exports and parts', () async {
+          await testSuggestor(
+            input: /*language=dart*/ '''
               export 'package:over_react/over_react.dart';
               
               part 'fake_part.dart';
           
               content() => mui.Button();
           ''',
-          isExpectedError: (e) => isUndefinedMuiError(e) || isFakeUriError(e),
-          expectedOutput: /*language=dart*/ '''
+            isExpectedError: (e) => isUndefinedMuiError(e) || isFakeUriError(e),
+            expectedOutput: /*language=dart*/ '''
               import 'package:react_material_ui/react_material_ui.dart' as mui;
               
               export 'package:over_react/over_react.dart';
@@ -268,12 +275,12 @@ void main() {
               
               content() => mui.Button();
           ''',
-        );
-      });
+          );
+        });
 
-      test('when there are imports, exports, and parts', () async {
-        await testSuggestor(
-          input: /*language=dart*/ '''
+        test('when there are imports, exports, and parts', () async {
+          await testSuggestor(
+            input: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
           
               export 'package:over_react/over_react.dart';
@@ -282,8 +289,8 @@ void main() {
           
               content() => mui.Button();
           ''',
-          isExpectedError: (e) => isUndefinedMuiError(e) || isFakeUriError(e),
-          expectedOutput: /*language=dart*/ '''
+            isExpectedError: (e) => isUndefinedMuiError(e) || isFakeUriError(e),
+            expectedOutput: /*language=dart*/ '''
               import 'package:over_react/over_react.dart';
               import 'package:react_material_ui/react_material_ui.dart' as mui;
           
@@ -293,21 +300,23 @@ void main() {
               
               content() => mui.Button();
           ''',
-        );
-      });
-    });
+          );
+        });
+      },
+    );
 
     test(
-        'adds a RMUI import when there is an undefined `mui` identifier in a part file',
-        () async {
-      // testSuggestor isn't really set up for multiple files,
-      // so the test setup here is a little more manual.
+      'adds a RMUI import when there is an undefined `mui` identifier in a part file',
+      () async {
+        // testSuggestor isn't really set up for multiple files,
+        // so the test setup here is a little more manual.
 
-      const partFilename = 'mui_importer_test_part.dart';
-      const mainLibraryFilename = 'mui_importer_test_main_library.dart';
+        const partFilename = 'mui_importer_test_part.dart';
+        const mainLibraryFilename = 'mui_importer_test_main_library.dart';
 
-      final partFileContext =
-          await resolvedContext.resolvedFileContextForTest('''
+        final partFileContext = await resolvedContext
+            .resolvedFileContextForTest(
+              '''
             part of '${mainLibraryFilename}';
   
             content() => mui.Button();
@@ -315,26 +324,31 @@ void main() {
               filename: partFilename,
               // Don't pre-resolve since this isn't a library.
               preResolveLibrary: false,
-              throwOnAnalysisErrors: false);
+              throwOnAnalysisErrors: false,
+            );
 
-      final mainLibraryFileContext =
-          await resolvedContext.resolvedFileContextForTest(
-        '''
+        final mainLibraryFileContext = await resolvedContext
+            .resolvedFileContextForTest(
+              '''
             part '${partFilename}';
         ''',
-        filename: mainLibraryFilename,
-        isExpectedError: isUndefinedMuiError,
-      );
+              filename: mainLibraryFilename,
+              isExpectedError: isUndefinedMuiError,
+            );
 
-      final mainPatches = await muiImporter(mainLibraryFileContext).toList();
-      expect(mainPatches, [
-        hasPatchText(contains(
-            "import 'package:react_material_ui/react_material_ui.dart' as mui;")),
-      ]);
+        final mainPatches = await muiImporter(mainLibraryFileContext).toList();
+        expect(mainPatches, [
+          hasPatchText(
+            contains(
+              "import 'package:react_material_ui/react_material_ui.dart' as mui;",
+            ),
+          ),
+        ]);
 
-      final partPatches = await muiImporter(partFileContext).toList();
-      expect(partPatches, isEmpty);
-    });
+        final partPatches = await muiImporter(partFileContext).toList();
+        expect(partPatches, isEmpty);
+      },
+    );
 
     group('does not add an RMUI import when', () {
       test('a `mui` identifier in the file is not undefined', () async {
@@ -357,8 +371,9 @@ void main() {
       test('for a different package name', () async {
         final testSuggestor = getSuggestorTester(
           importerSuggestorBuilder(
-              importUri: 'package:over_react/over_react.dart',
-              importNamespace: 'or'),
+            importUri: 'package:over_react/over_react.dart',
+            importNamespace: 'or',
+          ),
           resolvedContext: resolvedContext,
         );
         await testSuggestor(

--- a/test/util/package_util_test.dart
+++ b/test/util/package_util_test.dart
@@ -41,7 +41,8 @@ void main() {
       test('with a nested pubspec', () {
         expect(
           findPackageRootFor(
-              'test/test_fixtures/wsd_project/lib/analysis_warmup.dart'),
+            'test/test_fixtures/wsd_project/lib/analysis_warmup.dart',
+          ),
           equals('$currentPathFromRoot/test/test_fixtures/wsd_project'),
         );
       });
@@ -56,8 +57,11 @@ void main() {
       test('when a pubspec cannot be found', () {
         expect(
           () => findPackageRootFor('..'),
-          throwsA(isA<Exception>()
-              .havingToStringValue(contains('Could not find package root'))),
+          throwsA(
+            isA<Exception>().havingToStringValue(
+              contains('Could not find package root'),
+            ),
+          ),
         );
       });
     });
@@ -69,15 +73,17 @@ void main() {
         // Determine the expected ancestors of the current path from root.
         final segments = p.split(currentPathFromRoot);
         for (var i = 1; i < segments.length; i++) {
-          ancestorsOfPathFromRoot
-              .add(p.joinAll(segments.sublist(0, segments.length - i)));
+          ancestorsOfPathFromRoot.add(
+            p.joinAll(segments.sublist(0, segments.length - i)),
+          );
         }
       });
 
       test('for a nested file', () {
         expect(
           ancestorsOfPath(
-              'test/test_fixtures/wsd_project/lib/analysis_warmup.dart'),
+            'test/test_fixtures/wsd_project/lib/analysis_warmup.dart',
+          ),
           orderedEquals([
             '$currentPathFromRoot/test/test_fixtures/wsd_project/lib',
             '$currentPathFromRoot/test/test_fixtures/wsd_project',
@@ -102,10 +108,7 @@ void main() {
       });
 
       test('on the current directory', () {
-        expect(
-          ancestorsOfPath('.'),
-          orderedEquals(ancestorsOfPathFromRoot),
-        );
+        expect(ancestorsOfPath('.'), orderedEquals(ancestorsOfPathFromRoot));
       });
     });
 
@@ -118,15 +121,18 @@ void main() {
         filesInTopLevelDir = [
           File('$directory/some_place/some_file.dart'),
           File(
-              'test/test_fixtures/wsd_project/$directory/lib/analysis_warmup.dart'),
+            'test/test_fixtures/wsd_project/$directory/lib/analysis_warmup.dart',
+          ),
         ];
         filesNotInTopLevelBuildDir = [
           File('test/$directory/some_place/some_file.dart'),
           File('some_file.dart'),
           File(
-              'test/test_fixtures/$directory/wsd_project/lib/analysis_warmup.dart'),
+            'test/test_fixtures/$directory/wsd_project/lib/analysis_warmup.dart',
+          ),
           File(
-              'test/test_fixtures/wsd_project/lib/$directory/analysis_warmup.dart'),
+            'test/test_fixtures/wsd_project/lib/$directory/analysis_warmup.dart',
+          ),
         ];
       }
 

--- a/test/util/pubspec_upgrader_test.dart
+++ b/test/util/pubspec_upgrader_test.dart
@@ -35,11 +35,15 @@ void main() {
       void sharedTests(bool isDevDependency, {String? hostedUrl}) {
         final key = isDevDependency ? 'dev_dependencies' : 'dependencies';
 
-        String getExpectedOutput(
-            {bool useMidVersionMin = false, String? hostedUrl}) {
+        String getExpectedOutput({
+          bool useMidVersionMin = false,
+          String? hostedUrl,
+        }) {
           if (useMidVersionMin) {
-            final expected = VersionConstraint.parse('^5.0.0')
-                    .allows(Version.parse(midVersionMin))
+            final expected =
+                VersionConstraint.parse(
+                  '^5.0.0',
+                ).allows(Version.parse(midVersionMin))
                 ? '^$midVersionMin'
                 : '">=$midVersionMin <6.0.0"';
 
@@ -57,8 +61,10 @@ void main() {
               '';
         }
 
-        String getExpectedPreReleaseOutput(
-            {bool useMidVersionMin = false, String? hostedUrl}) {
+        String getExpectedPreReleaseOutput({
+          bool useMidVersionMin = false,
+          String? hostedUrl,
+        }) {
           return ''
               '$key:\n'
               '${getDependencyDeclaration('react', '^5.0.0-alpha', hostedUrl)}'
@@ -67,76 +73,85 @@ void main() {
         }
 
         /// Suggestor used to test the default configurations.
-        final testSuggestor = getSuggestorTester(PubspecUpgrader(
-          'react',
-          parseVersionRange(reactVersionRange),
-          isDevDependency: isDevDependency,
-          hostedUrl: hostedUrl,
-        ));
+        final testSuggestor = getSuggestorTester(
+          PubspecUpgrader(
+            'react',
+            parseVersionRange(reactVersionRange),
+            isDevDependency: isDevDependency,
+            hostedUrl: hostedUrl,
+          ),
+        );
 
         /// Suggestor to test when the codemod should not add the dependency if
         /// it does not encounter it.
-        final doNotAddDependencies = getSuggestorTester(PubspecUpgrader(
-          'react',
-          parseVersionRange(reactVersionRange),
-          shouldAddDependencies: false,
-          isDevDependency: isDevDependency,
-          hostedUrl: hostedUrl,
-        ));
+        final doNotAddDependencies = getSuggestorTester(
+          PubspecUpgrader(
+            'react',
+            parseVersionRange(reactVersionRange),
+            shouldAddDependencies: false,
+            isDevDependency: isDevDependency,
+            hostedUrl: hostedUrl,
+          ),
+        );
 
         group('when there are no special cases', () {
           sharedPubspecTest(
-              testSuggestor: testSuggestor,
-              getExpectedOutput: getExpectedOutput,
-              hostedUrl: hostedUrl,
-              startingRange: parseVersionRange('>=4.6.1 <4.9.0'),
-              isDevDependency: isDevDependency,
-              dependency: 'react',
-              midVersionRange: '^$midVersionMin');
+            testSuggestor: testSuggestor,
+            getExpectedOutput: getExpectedOutput,
+            hostedUrl: hostedUrl,
+            startingRange: parseVersionRange('>=4.6.1 <4.9.0'),
+            isDevDependency: isDevDependency,
+            dependency: 'react',
+            midVersionRange: '^$midVersionMin',
+          );
 
           group('and the new version is a pre-release version', () {
             sharedPubspecTest(
-                testSuggestor: getSuggestorTester(PubspecUpgrader(
+              testSuggestor: getSuggestorTester(
+                PubspecUpgrader(
                   'react',
                   parseVersionRange(reactVersionRangeForTesting),
                   isDevDependency: isDevDependency,
                   hostedUrl: hostedUrl,
-                )),
-                getExpectedOutput: getExpectedPreReleaseOutput,
-                hostedUrl: hostedUrl,
-                startingRange: parseVersionRange('>=4.6.1 <4.9.0'),
-                isDevDependency: isDevDependency,
-                midVersionRange: '^5.5.3',
-                shouldUpdateMidRange: false,
-                dependency: 'react');
+                ),
+              ),
+              getExpectedOutput: getExpectedPreReleaseOutput,
+              hostedUrl: hostedUrl,
+              startingRange: parseVersionRange('>=4.6.1 <4.9.0'),
+              isDevDependency: isDevDependency,
+              midVersionRange: '^5.5.3',
+              shouldUpdateMidRange: false,
+              dependency: 'react',
+            );
           });
         });
 
         group('when the codemod should not add dependencies', () {
           sharedPubspecTest(
-              testSuggestor: doNotAddDependencies,
-              getExpectedOutput: getExpectedOutput,
-              hostedUrl: hostedUrl,
-              startingRange: parseVersionRange('>=4.6.1 <4.9.0'),
-              isDevDependency: isDevDependency,
-              dependency: 'react',
-              midVersionRange: '^$midVersionMin',
-              shouldAddDependencies: false);
+            testSuggestor: doNotAddDependencies,
+            getExpectedOutput: getExpectedOutput,
+            hostedUrl: hostedUrl,
+            startingRange: parseVersionRange('>=4.6.1 <4.9.0'),
+            isDevDependency: isDevDependency,
+            dependency: 'react',
+            midVersionRange: '^$midVersionMin',
+            shouldAddDependencies: false,
+          );
         });
 
-        group(
-            'when the codemod should not update because the version range is '
+        group('when the codemod should not update because the version range is '
             'acceptable', () {
           sharedPubspecTest(
-              testSuggestor: testSuggestor,
-              getExpectedOutput: getExpectedOutput,
-              hostedUrl: hostedUrl,
-              startingRange: parseVersionRange('^5.0.0'),
-              isDevDependency: isDevDependency,
-              dependency: 'react',
-              shouldUpdate: false,
-              shouldUpdateMidRange: false,
-              midVersionRange: '^5.5.3');
+            testSuggestor: testSuggestor,
+            getExpectedOutput: getExpectedOutput,
+            hostedUrl: hostedUrl,
+            startingRange: parseVersionRange('^5.0.0'),
+            isDevDependency: isDevDependency,
+            dependency: 'react',
+            shouldUpdate: false,
+            shouldUpdateMidRange: false,
+            midVersionRange: '^5.5.3',
+          );
         });
 
         test('does not lower the lower bound', () async {
@@ -144,14 +159,16 @@ void main() {
             expectedPatchCount: 1,
             shouldDartfmtOutput: false,
             validateContents: validatePubspecYaml,
-            input: ''
+            input:
+                ''
                 'name: nothing\n'
                 'version: 0.0.0\n'
                 '$key:\n'
                 '${getDependencyDeclaration('react', '">=4.8.0 <5.0.0"', hostedUrl)}'
                 '  test: 1.5.1\n'
                 '',
-            expectedOutput: ''
+            expectedOutput:
+                ''
                 'name: nothing\n'
                 'version: 0.0.0\n'
                 '$key:\n'
@@ -167,7 +184,8 @@ void main() {
               expectedPatchCount: 0,
               shouldDartfmtOutput: false,
               validateContents: validatePubspecYaml,
-              input: ''
+              input:
+                  ''
                   'dependency_overrides:\n'
                   '  react:\n'
                   '    git:\n'
@@ -181,7 +199,8 @@ void main() {
               expectedPatchCount: 0,
               shouldDartfmtOutput: false,
               validateContents: validatePubspecYaml,
-              input: ''
+              input:
+                  ''
                   'dependency_overrides:\n'
                   '  react:\n'
                   '    path: ../\n',
@@ -193,14 +212,18 @@ void main() {
       group('true', () {
         sharedTests(true);
 
-        group('and the dependency is hosted',
-            () => sharedTests(true, hostedUrl: 'https://pub.whatever.org'));
+        group(
+          'and the dependency is hosted',
+          () => sharedTests(true, hostedUrl: 'https://pub.whatever.org'),
+        );
       });
       group('false', () {
         sharedTests(false);
 
-        group('and the dependency is hosted',
-            () => sharedTests(false, hostedUrl: 'https://pub.whatever.org'));
+        group(
+          'and the dependency is hosted',
+          () => sharedTests(false, hostedUrl: 'https://pub.whatever.org'),
+        );
       });
     });
   });

--- a/test/util/wsd_util_test.dart
+++ b/test/util/wsd_util_test.dart
@@ -46,13 +46,13 @@ void main() {
     }
 
     Future<FluentComponentUsage> parseAndGetSingleUsage(String source) async {
-      final context = await resolvedContext
-          .resolvedFileContextForTest(withOverReactAndWsdImports(source));
+      final context = await resolvedContext.resolvedFileContextForTest(
+        withOverReactAndWsdImports(source),
+      );
       final result = await context.getResolvedUnit();
-      return allDescendantsOfType<InvocationExpression>(result!.unit)
-          .map(getComponentUsage)
-          .whereNotNull()
-          .single;
+      return allDescendantsOfType<InvocationExpression>(
+        result!.unit,
+      ).map(getComponentUsage).whereNotNull().single;
     }
 
     group('isWsdStaticConstant', () {
@@ -63,8 +63,9 @@ void main() {
         });
 
         test('when namespaced', () async {
-          final expression =
-              await getResolvedExpression('wsd_v2.ButtonSize.DEFAULT');
+          final expression = await getResolvedExpression(
+            'wsd_v2.ButtonSize.DEFAULT',
+          );
           expect(isWsdStaticConstant(expression, 'ButtonSize.DEFAULT'), isTrue);
         });
       });
@@ -81,112 +82,153 @@ void main() {
         });
       });
 
-      group('returns false for expressions containing WSD static constants',
-          () {
-        const constant = 'ButtonSize.DEFAULT';
+      group(
+        'returns false for expressions containing WSD static constants',
+        () {
+          const constant = 'ButtonSize.DEFAULT';
 
-        test('property access on constant', () async {
-          final expression = await getResolvedExpression('$constant.className');
-          expect(isWsdStaticConstant(expression, constant), isFalse);
-        });
+          test('property access on constant', () async {
+            final expression = await getResolvedExpression(
+              '$constant.className',
+            );
+            expect(isWsdStaticConstant(expression, constant), isFalse);
+          });
 
-        test('method call on constant', () async {
-          final expression =
-              await getResolvedExpression('$constant.toString()');
-          expect(isWsdStaticConstant(expression, constant), isFalse);
-        });
+          test('method call on constant', () async {
+            final expression = await getResolvedExpression(
+              '$constant.toString()',
+            );
+            expect(isWsdStaticConstant(expression, constant), isFalse);
+          });
 
-        test('cascade on constant', () async {
-          final expression =
-              await getResolvedExpression('$constant..toString()');
-          expect(isWsdStaticConstant(expression, constant), isFalse);
-        });
+          test('cascade on constant', () async {
+            final expression = await getResolvedExpression(
+              '$constant..toString()',
+            );
+            expect(isWsdStaticConstant(expression, constant), isFalse);
+          });
 
-        test('other child expression', () async {
-          final expression = await getResolvedExpression(
+          test('other child expression', () async {
+            final expression = await getResolvedExpression(
               'doSomething($constant)',
-              otherSource: 'doSomething(dynamic value) {}');
-          expect(isWsdStaticConstant(expression, constant), isFalse);
-        });
-      });
+              otherSource: 'doSomething(dynamic value) {}',
+            );
+            expect(isWsdStaticConstant(expression, constant), isFalse);
+          });
+        },
+      );
 
       test('returns false for constants not declared in WSD', () async {
         const constantSource = 'MyClass.staticConstant';
-        final expression = await getResolvedExpression(constantSource,
-            otherSource: /*language=dart*/ '''
+        final expression = await getResolvedExpression(
+          constantSource,
+          otherSource: /*language=dart*/ '''
               abstract class MyClass {
                 static const staticConstant = null;
               }
-          ''');
+          ''',
+        );
         expect(isWsdStaticConstant(expression, constantSource), isFalse);
       });
 
-      group('returns false (and does not throw) for non-matching expressions:',
-          () {
-        test('simple identifier', () async {
-          final expression = await getResolvedExpression('identifier',
-              otherSource: 'dynamic identifier;');
-          expect(
-              isWsdStaticConstant(expression, 'ButtonSize.DEFAULT'), isFalse);
-        });
+      group(
+        'returns false (and does not throw) for non-matching expressions:',
+        () {
+          test('simple identifier', () async {
+            final expression = await getResolvedExpression(
+              'identifier',
+              otherSource: 'dynamic identifier;',
+            );
+            expect(
+              isWsdStaticConstant(expression, 'ButtonSize.DEFAULT'),
+              isFalse,
+            );
+          });
 
-        test('prefixed identifier', () async {
-          final expression = await getResolvedExpression('identifier.property',
-              otherSource: 'dynamic identifier;');
-          expect(expression, isA<PrefixedIdentifier>(),
-              reason: 'test setup check');
-          expect(
-              isWsdStaticConstant(expression, 'ButtonSize.DEFAULT'), isFalse);
-        });
+          test('prefixed identifier', () async {
+            final expression = await getResolvedExpression(
+              'identifier.property',
+              otherSource: 'dynamic identifier;',
+            );
+            expect(
+              expression,
+              isA<PrefixedIdentifier>(),
+              reason: 'test setup check',
+            );
+            expect(
+              isWsdStaticConstant(expression, 'ButtonSize.DEFAULT'),
+              isFalse,
+            );
+          });
 
-        test('other property access', () async {
-          final expression = await getResolvedExpression(
+          test('other property access', () async {
+            final expression = await getResolvedExpression(
               'identifier.property.property',
-              otherSource: 'dynamic identifier;');
-          expect(expression, isA<PropertyAccess>(), reason: 'test setup check');
-          expect(
-              isWsdStaticConstant(expression, 'ButtonSize.DEFAULT'), isFalse);
-        });
+              otherSource: 'dynamic identifier;',
+            );
+            expect(
+              expression,
+              isA<PropertyAccess>(),
+              reason: 'test setup check',
+            );
+            expect(
+              isWsdStaticConstant(expression, 'ButtonSize.DEFAULT'),
+              isFalse,
+            );
+          });
 
-        test('other expressions', () async {
-          final expression = await getResolvedExpression('1 + 1');
-          expect(
-              isWsdStaticConstant(expression, 'ButtonSize.DEFAULT'), isFalse);
-        });
-      });
+          test('other expressions', () async {
+            final expression = await getResolvedExpression('1 + 1');
+            expect(
+              isWsdStaticConstant(expression, 'ButtonSize.DEFAULT'),
+              isFalse,
+            );
+          });
+        },
+      );
 
-      test('throws when the provided string is not a prefixed identifier',
-          () async {
-        final expression = await getResolvedExpression('ButtonSize.DEFAULT');
-        final throwsExpectedError = throwsA(isArgumentError.havingToStringValue(
-            contains("Expected 'ClassName.constantName'")));
+      test(
+        'throws when the provided string is not a prefixed identifier',
+        () async {
+          final expression = await getResolvedExpression('ButtonSize.DEFAULT');
+          final throwsExpectedError = throwsA(
+            isArgumentError.havingToStringValue(
+              contains("Expected 'ClassName.constantName'"),
+            ),
+          );
 
-        expect(() {
-          isWsdStaticConstant(expression, 'notPrefixed');
-        }, throwsExpectedError);
-        expect(() {
-          isWsdStaticConstant(
-              expression, 'prefixed.but not a valid identifier');
-        }, throwsExpectedError);
-        expect(() {
-          isWsdStaticConstant(
-              expression, 'prefixed but not a valid.identifier');
-        }, throwsExpectedError);
-      });
+          expect(() {
+            isWsdStaticConstant(expression, 'notPrefixed');
+          }, throwsExpectedError);
+          expect(() {
+            isWsdStaticConstant(
+              expression,
+              'prefixed.but not a valid identifier',
+            );
+          }, throwsExpectedError);
+          expect(() {
+            isWsdStaticConstant(
+              expression,
+              'prefixed but not a valid.identifier',
+            );
+          }, throwsExpectedError);
+        },
+      );
     });
 
     group('mapWsdConstant', () {
       test(
-          'returns the correct value for the WSD constant key matching the given expression',
-          () async {
-        final expression = await getResolvedExpression('ButtonSize.DEFAULT');
-        final mapped = mapWsdConstant(expression, {
-          'ButtonSize.SMALL': 'small',
-          'ButtonSize.DEFAULT': 'default',
-          'ButtonSize.LARGE': 'large',
-        });
-        expect(mapped, 'default');
-      });
+        'returns the correct value for the WSD constant key matching the given expression',
+        () async {
+          final expression = await getResolvedExpression('ButtonSize.DEFAULT');
+          final mapped = mapWsdConstant(expression, {
+            'ButtonSize.SMALL': 'small',
+            'ButtonSize.DEFAULT': 'default',
+            'ButtonSize.LARGE': 'large',
+          });
+          expect(mapped, 'default');
+        },
+      );
 
       test('returns null if there is no matching value', () async {
         final expression = await getResolvedExpression('ButtonSize.DEFAULT');
@@ -198,66 +240,73 @@ void main() {
       });
 
       test(
-          'returns null if the matching value is not a constant declared in WSD',
-          () async {
-        const constantSource = 'MyClass.staticConstant';
-        final expression = await getResolvedExpression(constantSource,
+        'returns null if the matching value is not a constant declared in WSD',
+        () async {
+          const constantSource = 'MyClass.staticConstant';
+          final expression = await getResolvedExpression(
+            constantSource,
             otherSource: /*language=dart*/ '''
               abstract class MyClass {
                 static const staticConstant = null;
               }
-          ''');
-        final mapped = mapWsdConstant(expression, {
-          constantSource: 'mapped',
-        });
-        expect(mapped, isNull);
-      });
+          ''',
+          );
+          final mapped = mapWsdConstant(expression, {constantSource: 'mapped'});
+          expect(mapped, isNull);
+        },
+      );
 
       test(
-          'returns null if the value is another expression that is not a WSD constant',
-          () async {
-        final expression = await getResolvedExpression('identifier',
-            otherSource: 'dynamic identifier;');
-        final mapped = mapWsdConstant(expression, {
-          'ButtonSize.SMALL': 'small',
-          'ButtonSize.DEFAULT': 'default',
-          'ButtonSize.LARGE': 'large',
-        });
-        expect(mapped, isNull);
-      });
+        'returns null if the value is another expression that is not a WSD constant',
+        () async {
+          final expression = await getResolvedExpression(
+            'identifier',
+            otherSource: 'dynamic identifier;',
+          );
+          final mapped = mapWsdConstant(expression, {
+            'ButtonSize.SMALL': 'small',
+            'ButtonSize.DEFAULT': 'default',
+            'ButtonSize.LARGE': 'large',
+          });
+          expect(mapped, isNull);
+        },
+      );
     });
 
     group('usesWsdFactory', () {
       test(
-          'returns true for usages of WSD components with matching factory names',
-          () async {
-        final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
+        'returns true for usages of WSD components with matching factory names',
+        () async {
+          final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
           content() => Button()();
       ''');
-        expect(usesWsdFactory(usage, 'Button'), isTrue);
-      });
+          expect(usesWsdFactory(usage, 'Button'), isTrue);
+        },
+      );
 
       test(
-          'returns true for namespaced usages of WSD components with matching factory names',
-          () async {
-        final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
+        'returns true for namespaced usages of WSD components with matching factory names',
+        () async {
+          final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
           content() => wsd_v2.Button()();
       ''');
-        expect(usesWsdFactory(usage, 'Button'), isTrue);
-      });
+          expect(usesWsdFactory(usage, 'Button'), isTrue);
+        },
+      );
 
       test(
-          'returns true for both v1 and v2 WSD components with matching factory names',
-          () async {
-        final v1Usage = await parseAndGetSingleUsage(/*language=dart*/ '''
+        'returns true for both v1 and v2 WSD components with matching factory names',
+        () async {
+          final v1Usage = await parseAndGetSingleUsage(/*language=dart*/ '''
           content() => wsd_v1.Button()();
       ''');
-        final v2usage = await parseAndGetSingleUsage(/*language=dart*/ '''
+          final v2usage = await parseAndGetSingleUsage(/*language=dart*/ '''
           content() => wsd_v2.Button()();
       ''');
-        expect(usesWsdFactory(v1Usage, 'Button'), isTrue);
-        expect(usesWsdFactory(v2usage, 'Button'), isTrue);
-      });
+          expect(usesWsdFactory(v1Usage, 'Button'), isTrue);
+          expect(usesWsdFactory(v2usage, 'Button'), isTrue);
+        },
+      );
 
       group('returns false for builders not directly using the factory', () {
         test('and instead using a factory variable', () async {
@@ -282,64 +331,74 @@ void main() {
         expect(usesWsdFactory(usage, 'Tooltip'), isFalse);
       });
 
-      test('returns false for non-WSD components with matching factory names',
-          () async {
-        final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
+      test(
+        'returns false for non-WSD components with matching factory names',
+        () async {
+          final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
           // Shadows the WSD Button
           UiFactory Button;
           content() => Button()();
       ''');
-        expect(usesWsdFactory(usage, 'Button'), isFalse);
-      });
+          expect(usesWsdFactory(usage, 'Button'), isFalse);
+        },
+      );
 
-      test('throws when the provided string is not a simple identifier',
-          () async {
-        final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
+      test(
+        'throws when the provided string is not a simple identifier',
+        () async {
+          final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
             content() => Button()();
         ''');
-        final throwsExpectedError = throwsA(isArgumentError.havingToStringValue(
-            contains('must be a valid, non-namespaced identifier')));
+          final throwsExpectedError = throwsA(
+            isArgumentError.havingToStringValue(
+              contains('must be a valid, non-namespaced identifier'),
+            ),
+          );
 
-        expect(() {
-          usesWsdFactory(usage, 'prefixed.identifier');
-        }, throwsExpectedError);
-        expect(() {
-          usesWsdFactory(usage, 'not a valid identifier');
-        }, throwsExpectedError);
-      });
+          expect(() {
+            usesWsdFactory(usage, 'prefixed.identifier');
+          }, throwsExpectedError);
+          expect(() {
+            usesWsdFactory(usage, 'not a valid identifier');
+          }, throwsExpectedError);
+        },
+      );
     });
 
     group('usesWsdPropsClass', () {
       test(
-          'returns true for usages of WSD components with matching props names',
-          () async {
-        final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
+        'returns true for usages of WSD components with matching props names',
+        () async {
+          final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
           content() => Button()();
       ''');
-        expect(usesWsdPropsClass(usage, 'ButtonProps'), isTrue);
-      });
+          expect(usesWsdPropsClass(usage, 'ButtonProps'), isTrue);
+        },
+      );
 
       test(
-          'returns true for namespaced usages of WSD components with matching props names',
-          () async {
-        final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
+        'returns true for namespaced usages of WSD components with matching props names',
+        () async {
+          final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
           content() => wsd_v2.Button()();
       ''');
-        expect(usesWsdPropsClass(usage, 'ButtonProps'), isTrue);
-      });
+          expect(usesWsdPropsClass(usage, 'ButtonProps'), isTrue);
+        },
+      );
 
       test(
-          'returns true for both v1 and v2 WSD components with matching props names',
-          () async {
-        final v1Usage = await parseAndGetSingleUsage(/*language=dart*/ '''
+        'returns true for both v1 and v2 WSD components with matching props names',
+        () async {
+          final v1Usage = await parseAndGetSingleUsage(/*language=dart*/ '''
           content() => wsd_v1.Button()();
       ''');
-        final v2usage = await parseAndGetSingleUsage(/*language=dart*/ '''
+          final v2usage = await parseAndGetSingleUsage(/*language=dart*/ '''
           content() => wsd_v2.Button()();
       ''');
-        expect(usesWsdPropsClass(v1Usage, 'ButtonProps'), isTrue);
-        expect(usesWsdPropsClass(v2usage, 'ButtonProps'), isTrue);
-      });
+          expect(usesWsdPropsClass(v1Usage, 'ButtonProps'), isTrue);
+          expect(usesWsdPropsClass(v2usage, 'ButtonProps'), isTrue);
+        },
+      );
 
       group('returns true for indirect usages of WSD props classes', () {
         test('via factory variables', () async {
@@ -357,61 +416,69 @@ void main() {
         });
       });
 
-      test('returns false for WSD components with different props names',
-          () async {
-        final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
+      test(
+        'returns false for WSD components with different props names',
+        () async {
+          final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
             content() => Button()();
         ''');
-        expect(usesWsdPropsClass(usage, 'TooltipProps'), isFalse);
-      });
+          expect(usesWsdPropsClass(usage, 'TooltipProps'), isFalse);
+        },
+      );
 
       group(
-          'returns false for usages of non-WSD components with matching props names',
-          () {
-        test('via top-level factories', () async {
-          final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
+        'returns false for usages of non-WSD components with matching props names',
+        () {
+          test('via top-level factories', () async {
+            final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
             // Shadows the WSD Button/ButtonProps
             UiFactory<ButtonProps> Button;
             mixin ButtonProps on UiProps {}
             content() => Button()();
         ''');
-          expect(usesWsdPropsClass(usage, 'ButtonProps'), isFalse);
-        });
+            expect(usesWsdPropsClass(usage, 'ButtonProps'), isFalse);
+          });
 
-        test('via factory variables', () async {
-          final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
+          test('via factory variables', () async {
+            final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
             // Shadows the WSD ButtonProps
             mixin ButtonProps on UiProps {}
             content(UiFactory<ButtonProps> buttonFactory) => buttonFactory()();
         ''');
-          expect(usesWsdPropsClass(usage, 'ButtonProps'), isFalse);
-        });
+            expect(usesWsdPropsClass(usage, 'ButtonProps'), isFalse);
+          });
 
-        test('via builders', () async {
-          final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
+          test('via builders', () async {
+            final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
             // Shadows the WSD ButtonProps
             mixin ButtonProps on UiProps {}
             content(ButtonProps buttonBuilder) => buttonBuilder();
         ''');
-          expect(usesWsdPropsClass(usage, 'ButtonProps'), isFalse);
-        });
-      });
+            expect(usesWsdPropsClass(usage, 'ButtonProps'), isFalse);
+          });
+        },
+      );
 
-      test('throws when the provided string is not a simple identifier',
-          () async {
-        final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
+      test(
+        'throws when the provided string is not a simple identifier',
+        () async {
+          final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
             content() => Button()();
         ''');
-        final throwsExpectedError = throwsA(isArgumentError.havingToStringValue(
-            contains('must be a valid, non-namespaced identifier')));
+          final throwsExpectedError = throwsA(
+            isArgumentError.havingToStringValue(
+              contains('must be a valid, non-namespaced identifier'),
+            ),
+          );
 
-        expect(() {
-          usesWsdPropsClass(usage, 'prefixed.identifier');
-        }, throwsExpectedError);
-        expect(() {
-          usesWsdPropsClass(usage, 'not a valid identifier');
-        }, throwsExpectedError);
-      });
+          expect(() {
+            usesWsdPropsClass(usage, 'prefixed.identifier');
+          }, throwsExpectedError);
+          expect(() {
+            usesWsdPropsClass(usage, 'not a valid identifier');
+          }, throwsExpectedError);
+        },
+      );
     });
 
     group('usesWsdToolbarFactory', () {
@@ -453,41 +520,49 @@ void main() {
     });
 
     group('wsdComponentVersionForFactory', () {
-      test('returns the correct version for non-toolbar WSD v1 components',
-          () async {
-        final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
+      test(
+        'returns the correct version for non-toolbar WSD v1 components',
+        () async {
+          final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
             content() => wsd_v1.Button()();
         ''');
-        expect(wsdComponentVersionForFactory(usage), WsdComponentVersion.v1);
-      });
+          expect(wsdComponentVersionForFactory(usage), WsdComponentVersion.v1);
+        },
+      );
 
-      test('returns the correct version for non-toolbar WSD v2 components',
-          () async {
-        final usage1 = await parseAndGetSingleUsage(/*language=dart*/ '''
+      test(
+        'returns the correct version for non-toolbar WSD v2 components',
+        () async {
+          final usage1 = await parseAndGetSingleUsage(/*language=dart*/ '''
             content() => wsd_v2.Button()();
         ''');
-        final usage2 = await parseAndGetSingleUsage(/*language=dart*/ '''
+          final usage2 = await parseAndGetSingleUsage(/*language=dart*/ '''
             content() => Button()();
         ''');
-        expect(wsdComponentVersionForFactory(usage1), WsdComponentVersion.v2);
-        expect(wsdComponentVersionForFactory(usage2), WsdComponentVersion.v2);
-      });
+          expect(wsdComponentVersionForFactory(usage1), WsdComponentVersion.v2);
+          expect(wsdComponentVersionForFactory(usage2), WsdComponentVersion.v2);
+        },
+      );
 
-      test('returns the correct version for toolbar WSD v1 components',
-          () async {
-        final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
+      test(
+        'returns the correct version for toolbar WSD v1 components',
+        () async {
+          final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
             content() => toolbars_v1.Button()();
         ''');
-        expect(wsdComponentVersionForFactory(usage), WsdComponentVersion.v1);
-      });
+          expect(wsdComponentVersionForFactory(usage), WsdComponentVersion.v1);
+        },
+      );
 
-      test('returns the correct version for toolbar WSD v2 components',
-          () async {
-        final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
+      test(
+        'returns the correct version for toolbar WSD v2 components',
+        () async {
+          final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
             content() => toolbars_v2.Button()();
         ''');
-        expect(wsdComponentVersionForFactory(usage), WsdComponentVersion.v2);
-      });
+          expect(wsdComponentVersionForFactory(usage), WsdComponentVersion.v2);
+        },
+      );
 
       test('returns `notWsd` for non-WSD components', () async {
         final usage = await parseAndGetSingleUsage(/*language=dart*/ '''
@@ -495,7 +570,9 @@ void main() {
             content() => Foo()();
         ''');
         expect(
-            wsdComponentVersionForFactory(usage), WsdComponentVersion.notWsd);
+          wsdComponentVersionForFactory(usage),
+          WsdComponentVersion.notWsd,
+        );
       });
 
       group('returns null for usages that', () {

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -32,33 +32,45 @@ void main() {
   group('Utils', () {
     group('buildIgnoreComment()', () {
       test('constInitializedWithNonConstantValue', () {
-        expect(buildIgnoreComment(constInitializedWithNonConstantValue: true),
-            '// ignore: const_initialized_with_non_constant_value');
+        expect(
+          buildIgnoreComment(constInitializedWithNonConstantValue: true),
+          '// ignore: const_initialized_with_non_constant_value',
+        );
       });
 
       test('mixinOfNonClass', () {
-        expect(buildIgnoreComment(mixinOfNonClass: true),
-            '// ignore: mixin_of_non_class');
+        expect(
+          buildIgnoreComment(mixinOfNonClass: true),
+          '// ignore: mixin_of_non_class',
+        );
       });
 
       test('undefinedClass', () {
-        expect(buildIgnoreComment(undefinedClass: true),
-            '// ignore: undefined_class');
+        expect(
+          buildIgnoreComment(undefinedClass: true),
+          '// ignore: undefined_class',
+        );
       });
 
       test('undefinedIdentifier', () {
-        expect(buildIgnoreComment(undefinedIdentifier: true),
-            '// ignore: undefined_identifier');
+        expect(
+          buildIgnoreComment(undefinedIdentifier: true),
+          '// ignore: undefined_identifier',
+        );
       });
 
       test('uriHasNotBeenGenerated', () {
-        expect(buildIgnoreComment(uriHasNotBeenGenerated: true),
-            '// ignore: uri_has_not_been_generated');
+        expect(
+          buildIgnoreComment(uriHasNotBeenGenerated: true),
+          '// ignore: uri_has_not_been_generated',
+        );
       });
 
       test('multiple', () {
-        expect(buildIgnoreComment(mixinOfNonClass: true, undefinedClass: true),
-            '// ignore: mixin_of_non_class, undefined_class');
+        expect(
+          buildIgnoreComment(mixinOfNonClass: true, undefinedClass: true),
+          '// ignore: mixin_of_non_class, undefined_class',
+        );
       });
     });
 
@@ -155,7 +167,8 @@ void overReactExample() {}''';
     });
 
     group('getNonHostedDependencyVersion', () {
-      final pubspecContent = ''
+      final pubspecContent =
+          ''
           'name: nothing\n'
           'version: 0.0.0\n'
           'dependencies:\n'
@@ -170,48 +183,66 @@ void overReactExample() {}''';
           '';
 
       test('returns null if the dependency is not found', () {
-        expect(getNonHostedDependencyVersion(pubspecContent, 'a_dependency'),
-            isNull);
+        expect(
+          getNonHostedDependencyVersion(pubspecContent, 'a_dependency'),
+          isNull,
+        );
       });
 
       group('identifies the expected version for a dependency that is', () {
         test('"any"', () {
           expect(
-              getNonHostedDependencyVersion(pubspecContent, 'any_dependency'),
-              VersionConstraint.parse('any'));
+            getNonHostedDependencyVersion(pubspecContent, 'any_dependency'),
+            VersionConstraint.parse('any'),
+          );
         });
         test('fixed', () {
-          expect(getNonHostedDependencyVersion(pubspecContent, 'fixed'),
-              VersionConstraint.parse('10.2.3'));
+          expect(
+            getNonHostedDependencyVersion(pubspecContent, 'fixed'),
+            VersionConstraint.parse('10.2.3'),
+          );
         });
         test('using the caret syntax', () {
-          expect(getNonHostedDependencyVersion(pubspecContent, 'caret_syntax'),
-              VersionConstraint.parse('^2.3.4'));
+          expect(
+            getNonHostedDependencyVersion(pubspecContent, 'caret_syntax'),
+            VersionConstraint.parse('^2.3.4'),
+          );
         });
         test('a greater than range', () {
           expect(
-              getNonHostedDependencyVersion(
-                  pubspecContent, 'greater_than_ranged'),
-              VersionConstraint.parse('>=5.7.8'));
+            getNonHostedDependencyVersion(
+              pubspecContent,
+              'greater_than_ranged',
+            ),
+            VersionConstraint.parse('>=5.7.8'),
+          );
         });
         test('a less than range', () {
           expect(
-              getNonHostedDependencyVersion(pubspecContent, 'less_than_ranged'),
-              VersionConstraint.parse('<=5.7.8'));
+            getNonHostedDependencyVersion(pubspecContent, 'less_than_ranged'),
+            VersionConstraint.parse('<=5.7.8'),
+          );
         });
         test('an intersection', () {
-          expect(getNonHostedDependencyVersion(pubspecContent, 'intersection'),
-              VersionConstraint.parse('>=2.3.0 <2.8.0'));
+          expect(
+            getNonHostedDependencyVersion(pubspecContent, 'intersection'),
+            VersionConstraint.parse('>=2.3.0 <2.8.0'),
+          );
         });
         test('with double quotes', () {
-          expect(getNonHostedDependencyVersion(pubspecContent, 'intersection'),
-              VersionConstraint.parse('>=2.3.0 <2.8.0'));
+          expect(
+            getNonHostedDependencyVersion(pubspecContent, 'intersection'),
+            VersionConstraint.parse('>=2.3.0 <2.8.0'),
+          );
         });
         test('with single quotes', () {
           expect(
-              getNonHostedDependencyVersion(
-                  pubspecContent, 'intersection_single_quoted'),
-              VersionConstraint.parse('>=2.3.0 <2.8.0'));
+            getNonHostedDependencyVersion(
+              pubspecContent,
+              'intersection_single_quoted',
+            ),
+            VersionConstraint.parse('>=2.3.0 <2.8.0'),
+          );
         });
       });
     });
@@ -228,16 +259,19 @@ void overReactExample() {}''';
       });
 
       test(
-          'returns the version constraint\'s toString if caret syntax cannot be used',
-          () {
-        expect(friendlyFromString('>1.0.0 <2.0.0'), '>1.0.0 <2.0.0');
-        expect(friendlyFromString('>=1.0.0 <3.0.0'), '>=1.0.0 <3.0.0');
-        expect(friendlyFromString('>=1.0.0 <1.5.0'), '>=1.0.0 <1.5.0');
-        // Edge cases
-        expect(friendlyFromString('any'), 'any');
-        expect(friendlyVersionConstraint(VersionConstraint.empty),
-            VersionConstraint.empty.toString());
-      });
+        'returns the version constraint\'s toString if caret syntax cannot be used',
+        () {
+          expect(friendlyFromString('>1.0.0 <2.0.0'), '>1.0.0 <2.0.0');
+          expect(friendlyFromString('>=1.0.0 <3.0.0'), '>=1.0.0 <3.0.0');
+          expect(friendlyFromString('>=1.0.0 <1.5.0'), '>=1.0.0 <1.5.0');
+          // Edge cases
+          expect(friendlyFromString('any'), 'any');
+          expect(
+            friendlyVersionConstraint(VersionConstraint.empty),
+            VersionConstraint.empty.toString(),
+          );
+        },
+      );
     });
 
     group('mightNeedYamlEscaping()', () {
@@ -294,91 +328,111 @@ void overReactExample() {}''';
       group('when the current dependency uses the caret syntax ', () {
         test('and the target uses caret syntax', () {
           expect(
-              shouldUpdateVersionRange(
-                  constraint: VersionConstraint.parse('^4.0.0'),
-                  targetConstraint: parseVersionRange('^5.0.0')),
-              isTrue);
+            shouldUpdateVersionRange(
+              constraint: VersionConstraint.parse('^4.0.0'),
+              targetConstraint: parseVersionRange('^5.0.0'),
+            ),
+            isTrue,
+          );
         });
 
         test('and the target uses a range', () {
           expect(
-              shouldUpdateVersionRange(
-                  constraint: VersionConstraint.parse('^4.0.0'),
-                  targetConstraint: parseVersionRange('>=5.0.0 <6.0.0')),
-              isTrue);
+            shouldUpdateVersionRange(
+              constraint: VersionConstraint.parse('^4.0.0'),
+              targetConstraint: parseVersionRange('>=5.0.0 <6.0.0'),
+            ),
+            isTrue,
+          );
         });
       });
 
       group('when the current dependency uses a range ', () {
         test('and the range has no specified max', () {
           expect(
-              shouldUpdateVersionRange(
-                  constraint: VersionConstraint.parse('>=4.0.0'),
-                  targetConstraint: parseVersionRange('^5.0.0')),
-              isTrue);
+            shouldUpdateVersionRange(
+              constraint: VersionConstraint.parse('>=4.0.0'),
+              targetConstraint: parseVersionRange('^5.0.0'),
+            ),
+            isTrue,
+          );
         });
 
         test('and the target uses caret syntax', () {
           expect(
-              shouldUpdateVersionRange(
-                  constraint: VersionConstraint.parse('>=4.0.0 <5.0.0'),
-                  targetConstraint: parseVersionRange('^5.0.0')),
-              isTrue);
+            shouldUpdateVersionRange(
+              constraint: VersionConstraint.parse('>=4.0.0 <5.0.0'),
+              targetConstraint: parseVersionRange('^5.0.0'),
+            ),
+            isTrue,
+          );
         });
 
         test('and the target uses a range', () {
           expect(
-              shouldUpdateVersionRange(
-                  constraint: VersionConstraint.parse('>=4.0.0 <5.0.0'),
-                  targetConstraint: parseVersionRange('>=5.0.0 <6.0.0')),
-              isTrue);
+            shouldUpdateVersionRange(
+              constraint: VersionConstraint.parse('>=4.0.0 <5.0.0'),
+              targetConstraint: parseVersionRange('>=5.0.0 <6.0.0'),
+            ),
+            isTrue,
+          );
         });
       });
 
       group('when shouldIgnoreMin is true ', () {
         test('and the current min is higher than the target min', () {
           expect(
-              shouldUpdateVersionRange(
-                  constraint: VersionConstraint.parse('>=5.5.0 <6.0.0'),
-                  targetConstraint: parseVersionRange('>=5.0.0 <6.0.0'),
-                  shouldIgnoreMin: true),
-              isTrue);
+            shouldUpdateVersionRange(
+              constraint: VersionConstraint.parse('>=5.5.0 <6.0.0'),
+              targetConstraint: parseVersionRange('>=5.0.0 <6.0.0'),
+              shouldIgnoreMin: true,
+            ),
+            isTrue,
+          );
         });
 
         test('and the target max is higher than the current max', () {
           expect(
-              shouldUpdateVersionRange(
-                  constraint: VersionConstraint.parse('>=5.5.0 <6.0.0'),
-                  targetConstraint: parseVersionRange('>=5.0.0 <7.0.0'),
-                  shouldIgnoreMin: true),
-              isTrue);
+            shouldUpdateVersionRange(
+              constraint: VersionConstraint.parse('>=5.5.0 <6.0.0'),
+              targetConstraint: parseVersionRange('>=5.0.0 <7.0.0'),
+              shouldIgnoreMin: true,
+            ),
+            isTrue,
+          );
         });
       });
 
       group('when shouldIgnoreMin is false ', () {
         test('and the current min is higher than the target min', () {
           expect(
-              shouldUpdateVersionRange(
-                  constraint: VersionConstraint.parse('>=5.5.0 <6.0.0'),
-                  targetConstraint: parseVersionRange('>=5.0.0 <6.0.0')),
-              isFalse);
+            shouldUpdateVersionRange(
+              constraint: VersionConstraint.parse('>=5.5.0 <6.0.0'),
+              targetConstraint: parseVersionRange('>=5.0.0 <6.0.0'),
+            ),
+            isFalse,
+          );
         });
 
         test('and the target max is higher than the current max', () {
           expect(
-              shouldUpdateVersionRange(
-                  constraint: VersionConstraint.parse('>=5.5.0 <6.0.0'),
-                  targetConstraint: parseVersionRange('>=5.0.0 <7.0.0')),
-              isTrue);
+            shouldUpdateVersionRange(
+              constraint: VersionConstraint.parse('>=5.5.0 <6.0.0'),
+              targetConstraint: parseVersionRange('>=5.0.0 <7.0.0'),
+            ),
+            isTrue,
+          );
         });
       });
 
       test('and the current max is higher than the target max', () {
         expect(
-            shouldUpdateVersionRange(
-                constraint: VersionConstraint.parse('>=5.0.0 <7.0.0'),
-                targetConstraint: parseVersionRange('>=5.0.0 <6.0.0')),
-            isFalse);
+          shouldUpdateVersionRange(
+            constraint: VersionConstraint.parse('>=5.0.0 <7.0.0'),
+            targetConstraint: parseVersionRange('>=5.0.0 <6.0.0'),
+          ),
+          isFalse,
+        );
       });
     });
 
@@ -469,81 +523,84 @@ void overReactExample() {}''';
           parseString(content: source).unit.declarations.single;
 
       test('returns all comments for a node', () {
-        expect(allCommentsForNode(parseAndGetSingle('''
+        expect(
+          allCommentsForNode(
+            parseAndGetSingle('''
           // Some comment
           int node;
-        ''')).map((comment) => comment.toString()).toList(), [
-          '// Some comment',
-        ]);
+        '''),
+          ).map((comment) => comment.toString()).toList(),
+          ['// Some comment'],
+        );
       });
 
       test('handles nodes with doc comments properly', () {
         // It's important to test both orders due to the way
         // doc comments are included in the node.
 
-        expect(allCommentsForNode(parseAndGetSingle('''
+        expect(
+          allCommentsForNode(
+            parseAndGetSingle('''
           /// Doc comment
           // other comment
           int node;
-        ''')).map((comment) => comment.toString()).toList(), [
-          '/// Doc comment',
-          '// other comment',
-        ]);
+        '''),
+          ).map((comment) => comment.toString()).toList(),
+          ['/// Doc comment', '// other comment'],
+        );
 
-        expect(allCommentsForNode(parseAndGetSingle('''
+        expect(
+          allCommentsForNode(
+            parseAndGetSingle('''
           // other comment
           /// Doc comment
           int node;
-        ''')).map((comment) => comment.toString()).toList(), [
-          '// other comment',
-          '/// Doc comment',
-        ]);
+        '''),
+          ).map((comment) => comment.toString()).toList(),
+          ['// other comment', '/// Doc comment'],
+        );
       });
 
       test('handles mixed comment types properly', () {
-        expect(allCommentsForNode(parseAndGetSingle('''
+        expect(
+          allCommentsForNode(
+            parseAndGetSingle('''
           // single line comment
           /* multiline comment */
           int node;
-        ''')).map((comment) => comment.toString()).toList(), [
-          '// single line comment',
-          '/* multiline comment */',
-        ]);
+        '''),
+          ).map((comment) => comment.toString()).toList(),
+          ['// single line comment', '/* multiline comment */'],
+        );
 
-        expect(allCommentsForNode(parseAndGetSingle('''
+        expect(
+          allCommentsForNode(
+            parseAndGetSingle('''
           /* multiline comment */
           // single line comment
           int node;
-        ''')).map((comment) => comment.toString()).toList(), [
-          '/* multiline comment */',
-          '// single line comment',
-        ]);
+        '''),
+          ).map((comment) => comment.toString()).toList(),
+          ['/* multiline comment */', '// single line comment'],
+        );
       });
     });
 
     group('hasParseErrors()', () {
       test('when sourceText contains invalid code', () {
-        expect(
-          hasParseErrors('a = 1;'),
-          isTrue,
-        );
+        expect(hasParseErrors('a = 1;'), isTrue);
       });
 
       test('when sourceText contains valid code', () {
-        expect(
-          hasParseErrors('final a = 1;'),
-          isFalse,
-        );
+        expect(hasParseErrors('final a = 1;'), isFalse);
       });
     });
 
     group('allDescendants()', () {
       TopLevelVariableDeclaration parseAndGetSingle(String source) =>
-          parseString(content: source)
-              .unit
-              .declarations
-              .whereType<TopLevelVariableDeclaration>()
-              .single;
+          parseString(
+            content: source,
+          ).unit.declarations.whereType<TopLevelVariableDeclaration>().single;
 
       test('returns all descendants for a node', () {
         final node = parseAndGetSingle('''
@@ -551,45 +608,79 @@ void overReactExample() {}''';
         ''');
 
         expect(
-            allDescendants(node).toList(),
-            unorderedEquals([
-              isA<VariableDeclarationList>().having(
-                (node) => node.toSource(),
-                'string value',
-                'UiFactory<FooProps> Foo = castUiFactory(_\$Foo)',
+          allDescendants(node).toList(),
+          unorderedEquals([
+            isA<VariableDeclarationList>().having(
+              (node) => node.toSource(),
+              'string value',
+              'UiFactory<FooProps> Foo = castUiFactory(_\$Foo)',
+            ),
+            isA<VariableDeclaration>().having(
+              (node) => node.toSource(),
+              'string value',
+              'Foo = castUiFactory(_\$Foo)',
+            ),
+            isA<NamedType>().having(
+              (node) => node.name.name,
+              'name',
+              'UiFactory',
+            ),
+            isA<NamedType>().having(
+              (node) => node.name.name,
+              'name',
+              'FooProps',
+            ),
+            isA<MethodInvocation>().having(
+              (node) => node.methodName.name,
+              'methodName',
+              'castUiFactory',
+            ),
+            isA<TypeArgumentList>().having(
+              (node) => node.arguments.toList(),
+              'arguments',
+              [
+                isA<NamedType>().having(
+                  (node) => node.name.name,
+                  'name',
+                  'FooProps',
+                ),
+              ],
+            ),
+            isA<ArgumentList>().having(
+              (node) => node.arguments.toList(),
+              'arguments',
+              [
+                isA<SimpleIdentifier>().having(
+                  (node) => node.name,
+                  'name',
+                  '_\$Foo',
+                ),
+              ],
+            ),
+            if (currentAnalyzerHasChildrenIdentifiersInNamedTypes())
+              isA<SimpleIdentifier>().having(
+                (node) => node.name,
+                'name',
+                'UiFactory',
               ),
-              isA<VariableDeclaration>().having(
-                (node) => node.toSource(),
-                'string value',
-                'Foo = castUiFactory(_\$Foo)',
+            if (currentAnalyzerHasChildrenIdentifiersInNamedTypes())
+              isA<SimpleIdentifier>().having(
+                (node) => node.name,
+                'name',
+                'FooProps',
               ),
-              isA<NamedType>()
-                  .having((node) => node.name.name, 'name', 'UiFactory'),
-              isA<NamedType>()
-                  .having((node) => node.name.name, 'name', 'FooProps'),
-              isA<MethodInvocation>().having((node) => node.methodName.name,
-                  'methodName', 'castUiFactory'),
-              isA<TypeArgumentList>().having(
-                  (node) => node.arguments.toList(), 'arguments', [
-                isA<NamedType>()
-                    .having((node) => node.name.name, 'name', 'FooProps')
-              ]),
-              isA<ArgumentList>().having(
-                  (node) => node.arguments.toList(), 'arguments', [
-                isA<SimpleIdentifier>()
-                    .having((node) => node.name, 'name', '_\$Foo')
-              ]),
-              if (currentAnalyzerHasChildrenIdentifiersInNamedTypes())
-                isA<SimpleIdentifier>()
-                    .having((node) => node.name, 'name', 'UiFactory'),
-              if (currentAnalyzerHasChildrenIdentifiersInNamedTypes())
-                isA<SimpleIdentifier>()
-                    .having((node) => node.name, 'name', 'FooProps'),
-              isA<SimpleIdentifier>()
-                  .having((node) => node.name, 'name', '_\$Foo'),
-              isA<SimpleIdentifier>()
-                  .having((node) => node.name, 'name', 'castUiFactory'),
-            ]));
+            isA<SimpleIdentifier>().having(
+              (node) => node.name,
+              'name',
+              '_\$Foo',
+            ),
+            isA<SimpleIdentifier>().having(
+              (node) => node.name,
+              'name',
+              'castUiFactory',
+            ),
+          ]),
+        );
       });
 
       test('returns empty list when input has no descendants', () {
@@ -602,11 +693,9 @@ void overReactExample() {}''';
 
     group('allDescendantsOfType()', () {
       TopLevelVariableDeclaration parseAndGetSingle(String source) =>
-          parseString(content: source)
-              .unit
-              .declarations
-              .whereType<TopLevelVariableDeclaration>()
-              .single;
+          parseString(
+            content: source,
+          ).unit.declarations.whereType<TopLevelVariableDeclaration>().single;
 
       group('returns all descendants of the specified type for a node', () {
         final node = parseAndGetSingle('''
@@ -615,33 +704,52 @@ void overReactExample() {}''';
 
         test('when there are many descendants of a type', () {
           expect(
-              allDescendantsOfType<SimpleIdentifier>(node).toList(),
-              unorderedEquals([
-                if (currentAnalyzerHasChildrenIdentifiersInNamedTypes())
-                  isA<SimpleIdentifier>()
-                      .having((node) => node.name, 'name', 'UiFactory'),
-                if (currentAnalyzerHasChildrenIdentifiersInNamedTypes())
-                  isA<SimpleIdentifier>()
-                      .having((node) => node.name, 'name', 'FooProps'),
-                isA<SimpleIdentifier>()
-                    .having((node) => node.name, 'name', '_\$Foo'),
-                isA<SimpleIdentifier>()
-                    .having((node) => node.name, 'name', 'castUiFactory'),
-              ]));
+            allDescendantsOfType<SimpleIdentifier>(node).toList(),
+            unorderedEquals([
+              if (currentAnalyzerHasChildrenIdentifiersInNamedTypes())
+                isA<SimpleIdentifier>().having(
+                  (node) => node.name,
+                  'name',
+                  'UiFactory',
+                ),
+              if (currentAnalyzerHasChildrenIdentifiersInNamedTypes())
+                isA<SimpleIdentifier>().having(
+                  (node) => node.name,
+                  'name',
+                  'FooProps',
+                ),
+              isA<SimpleIdentifier>().having(
+                (node) => node.name,
+                'name',
+                '_\$Foo',
+              ),
+              isA<SimpleIdentifier>().having(
+                (node) => node.name,
+                'name',
+                'castUiFactory',
+              ),
+            ]),
+          );
         });
 
         test('when there is one descendant of a type', () {
           expect(
-              allDescendantsOfType<MethodInvocation>(node).toList(),
-              unorderedEquals([
-                isA<MethodInvocation>().having((node) => node.methodName.name,
-                    'methodName', 'castUiFactory'),
-              ]));
+            allDescendantsOfType<MethodInvocation>(node).toList(),
+            unorderedEquals([
+              isA<MethodInvocation>().having(
+                (node) => node.methodName.name,
+                'methodName',
+                'castUiFactory',
+              ),
+            ]),
+          );
         });
 
         test('when there are no descendants of a type', () {
           expect(
-              allDescendantsOfType<MethodDeclaration>(node).toList(), isEmpty);
+            allDescendantsOfType<MethodDeclaration>(node).toList(),
+            isEmpty,
+          );
         });
       });
 
@@ -666,9 +774,11 @@ void overReactExample() {}''';
 /// author tests that pass regardless of analyzer behavior.
 bool currentAnalyzerHasChildrenIdentifiersInNamedTypes() {
   final namedTypes = <NamedType>[];
-  parseString(content: '''
+  parseString(
+    content: '''
     NamedType variable;
-  ''').unit.accept(_NamedTypeVisitor(namedTypes.add));
+  ''',
+  ).unit.accept(_NamedTypeVisitor(namedTypes.add));
   return namedTypes.single.childEntities
       .whereType<SimpleIdentifier>()
       .isNotEmpty;
@@ -794,22 +904,23 @@ class Foo extends _\$Foo
   });
 }
 
-void sharedGenerateNewVersionRangeTests(
-    {required VersionRange currentRange,
-    required VersionRange currentRangeWithHigherMinBound,
-    required VersionRange targetRange,
-    required VersionRange expectedMixedRange}) {
+void sharedGenerateNewVersionRangeTests({
+  required VersionRange currentRange,
+  required VersionRange currentRangeWithHigherMinBound,
+  required VersionRange targetRange,
+  required VersionRange expectedMixedRange,
+}) {
   group('', () {
     test('', () {
       expect(generateNewVersionRange(currentRange, targetRange), targetRange);
     });
 
-    test(
-        'when the current range lower bound is higher than the target '
+    test('when the current range lower bound is higher than the target '
         'range lower bound', () {
       expect(
-          generateNewVersionRange(currentRangeWithHigherMinBound, targetRange),
-          expectedMixedRange);
+        generateNewVersionRange(currentRangeWithHigherMinBound, targetRange),
+        expectedMixedRange,
+      );
     });
   });
 }

--- a/tool/dart_dev/config.dart
+++ b/tool/dart_dev/config.dart
@@ -2,9 +2,6 @@ import 'package:dart_dev/dart_dev.dart';
 import 'package:glob/glob.dart';
 
 final config = {
-  'format': FormatTool()
-    ..exclude = [
-      Glob('test/test_fixtures/**'),
-    ],
+  'format': FormatTool()..exclude = [Glob('test/test_fixtures/**')],
   'analyze': AnalyzeTool(),
 };


### PR DESCRIPTION
## Motivation
Follow-up to #332 (Dart 3 upgrade). The format check was disabled during the upgrade to keep the changes minimal. Now that the upgrade is merged, running `dart run dart_dev format` and re-enabling the format check.

## Changes
- Run `dart run dart_dev format` across the codebase (111 files changed)
- Remove `format-check: false` from CI workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)